### PR TITLE
Install deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   #- python setup.py install
   #- eval $(ssh-agent -s)
 script:
-  - PYTHONPATH=$PWD:$PYTHONPATH travis_wait 30 pytest --cov=lfi
+  - PYTHONPATH=$PWD:$PYTHONPATH travis_wait 30 pytest --cov=sbi
 after_success:
   - coveralls
   #- git config user.name "jan-matthis"

--- a/environment.yml
+++ b/environment.yml
@@ -10,22 +10,24 @@ channels:
 
 dependencies:
   - autopep8
+  - autoflake
   - black
-  - cudatoolkit=10.*
+  - cudatoolkit
   - flake8
+  - isort
   - jupyter
   - matplotlib
   - numpy
   - pillow
   - pip
   - pip:
-    - pyro-ppl>=1.2.0
+    - pyro-ppl
     - torchtestcase
     - -e .  # install package in development mode
   - pytest
   - pytest-pep8
-  - python=3.7
-  - pytorch=1.4.*
+  - python
+  - pytorch
   - pyyaml
   - rope
   - scikit-learn

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@
 # conda env create --file environment.yml
 # update:
 # conda env update --file environment.yml --prune
-name: lfi
+name: sbi
 
 channels:
   - conda-forge

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 description-file = README.md
 
 [tool:pytest]
-pep8maxlinelength = 80
+pep8maxlinelength = 88

--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,25 @@
 from setuptools import find_packages, setup
 
-exec(open("lfi/version.py").read())
+exec(open("sbi/version.py").read())
 
 setup(
-    name="lfi",
+    name="sbi",
     version=__version__,
-    description="LFI + CDE.",
-    url="https://github.com/mackelab/lfi",
+    description="Simulation-based inference",
+    url="https://github.com/mackelab/sbi",
     author="Conor Durkan",
     packages=find_packages(exclude=["tests"]),
     license="GPLv3",
+    test_requires=["pytest", "deepdiff", "torchtestcase"],
     install_requires=[
         "matplotlib",
         "numpy",
-        "pillow",
         "pyro-ppl",
         "scipy",
         "tensorboard",
         "torch",
         "tqdm",
     ],
-    extras_requires={
-        "dev": ["autoflake", "black", "flake8", "isort", "pyyaml"],
-        "testing": ["pytest", "deepdiff", "torchtestcase"],
-    },
+    extras_requires={"dev": ["autoflake", "black", "flake8", "isort", "pytest"]},
     dependency_links=[],
 )

--- a/setup.py
+++ b/setup.py
@@ -10,16 +10,19 @@ setup(
     author="Conor Durkan",
     packages=find_packages(exclude=["tests"]),
     license="GPLv3",
-    test_requires=["pytest", "deepdiff", "torchtestcase"],
     install_requires=[
         "matplotlib",
         "numpy",
+        "pillow",
         "pyro-ppl",
         "scipy",
         "tensorboard",
         "torch",
         "tqdm",
     ],
-    extras_requires={"dev": ["autoflake", "black", "flake8", "isort", "pytest"]},
+    extras_requires={
+        "dev": ["autoflake", "black", "flake8", "isort", "pyyaml"],
+        "testing": ["pytest", "deepdiff", "torchtestcase"],
+    },
     dependency_links=[],
 )


### PR DESCRIPTION
* Rename `lfi` conda env to `sbi`
* No version pining in `environment.yml`
        - install possible for people on OSX which does not have `cudatoolkit>=10`
        - easier to transfer to travis
* Moved test_requires (should be anyways tests_require) into an extras_requires as per https://stackoverflow.com/a/27271396 and to match `dev` entry by @jan-matthis (may make easier for pip users)

* Future work: consider splitting `environment.yml` into release, development and test environments.

Closes #9.