### PR TITLE
Linear Gaussian 3D example APT

### DIFF
--- a/examples/snpec_linear_Gaussian.ipynb
+++ b/examples/snpec_linear_Gaussian.ipynb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c44f2ee779ab7fb5fbe3d3baf6b8ce1c6b4f180e3b60d65849b68e86c93a223d
-size 30951
+oid sha256:8145bca85dccb4267b0ca98e2fa8bff5a1b579390c554927ddcc5ea1d504560d
+size 32182

--- a/examples/snpec_linear_Gaussian.ipynb
+++ b/examples/snpec_linear_Gaussian.ipynb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c44f2ee779ab7fb5fbe3d3baf6b8ce1c6b4f180e3b60d65849b68e86c93a223d
+size 30951

--- a/lfi/inference/apt.py
+++ b/lfi/inference/apt.py
@@ -582,7 +582,7 @@ class APT:
         self._summary["epochs"].append(epochs)
         self._summary["best-validation-log-probs"].append(best_validation_log_prob)
 
-    def _estimate_acceptance_rate(self, num_samples=int(1e7), true_observation=None):
+    def _estimate_acceptance_rate(self, num_samples=int(1e5), true_observation=None):
         """
         Estimates rejection sampling acceptance rates.
 

--- a/lfi/simulators/linear_gaussian.py
+++ b/lfi/simulators/linear_gaussian.py
@@ -112,3 +112,9 @@ class LinearGaussianSimulator(Simulator):
     @property
     def parameter_plotting_limits(self):
         return [-4, 4]
+
+    @property
+    def normalization_parameters(self):
+        mean = torch.zeros(self._dim)
+        std = torch.ones(self._dim)
+        return mean, std


### PR DESCRIPTION
- added notebook in examples/
- reduced number of samples to estimate acceptance ratio from 1e7 to 1e5
- added normalization_parameters() function to linear_gaussian.py