### PR TITLE
APT observation z-scoring and embedding_net

### DIFF
--- a/examples/snpec_linear_Gaussian.ipynb
+++ b/examples/snpec_linear_Gaussian.ipynb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c84a1c2c585a9a9a0a2073a218c21ec99046c4d847d446ca1517d98c9749e04a
-size 29668
+oid sha256:4b88308edc4ca1fbb52ba775f9fb2f73aef97c5ded990a34b292f79c3b63643d
+size 28143

--- a/examples/snpec_twoMoons.ipynb
+++ b/examples/snpec_twoMoons.ipynb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:076561dc2f0d10afd4cf63b8669d95c0ce77e0813c07660f14d2a555325ad885
-size 25071
+oid sha256:201e5879e108b1493db4c9e4e99500768db6a2467e8aee1d6e1a3e3f0cda18d0
+size 22699

--- a/sbi/utils/__init__.py
+++ b/sbi/utils/__init__.py
@@ -5,6 +5,7 @@ from sbi.utils.get_models import (
 )
 from sbi.utils.io import get_data_root, get_log_root, get_project_root, get_timestamp
 from sbi.utils.logging import summarize
+from sbi.utils.sbi import Normalize
 from sbi.utils.mmd import biased_mmd, unbiased_mmd_squared
 from sbi.utils.plot import plot_hist_marginals, plot_hist_marginals_pair
 from sbi.utils.torchutils import (

--- a/sbi/utils/sbi.py
+++ b/sbi/utils/sbi.py
@@ -1,0 +1,11 @@
+import torch.nn as nn
+
+
+class Normalize(nn.Module):
+    def __init__(self, mean, std):
+        super(Normalize, self).__init__()
+        self.mean = mean
+        self.std = std
+
+    def forward(self, tensor):
+        return (tensor - self.mean) / self.std

--- a/tests/test_linearGaussian_apt.py
+++ b/tests/test_linearGaussian_apt.py
@@ -29,16 +29,13 @@ def test_apt_on_linearGaussian_based_on_mmd(num_dim):
     )
     true_observation = simulator.get_ground_truth_observation()
 
-    # define nn for inference
-    neural_posterior = utils.get_neural_posterior(
-        "maf", parameter_dim, observation_dim, simulator
-    )
     apt = APT(
         simulator=simulator,
         true_observation=true_observation,
         prior=prior,
-        neural_posterior=neural_posterior,
         num_atoms=-1,
+        density_estimator='maf',
+        z_score_obs=True,
         use_combined_loss=False,
         train_with_mcmc=False,
         mcmc_method="slice-np",

--- a/tests/test_twoMoons.py
+++ b/tests/test_twoMoons.py
@@ -22,15 +22,15 @@ prior = distributions.Uniform(low=-a * torch.ones(simulator.parameter_dim), high
 parameter_dim, observation_dim = (simulator.parameter_dim, simulator.observation_dim)
 
 true_observation = simulator.get_ground_truth_observation()
-neural_posterior = utils.get_neural_posterior("maf", parameter_dim, observation_dim, simulator)
 
 apt = APT(
     simulator=simulator,
     true_observation=true_observation,
     prior=prior,
-    neural_posterior=neural_posterior,
     num_atoms=10,
     use_combined_loss=False,
+    density_estimator='maf',
+    z_score_obs=True,
     train_with_mcmc=False,
     mcmc_method="slice-np",
     summary_net=None,


### PR DESCRIPTION
- z-scoring of observations/contexts
- embedding net is now part of pyknos
- pilot samples
- simulation_per_round can be a list for each round
- in validation set, the remaining samples are dropped if they do not fill a full batch
- normalization of parameters theta relies on prior, not on samples
- updated notebook examples and tests