### PR TITLE
Rewired nflows imports to pyknos.nflows

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -22,6 +22,19 @@ jobs:
       with:
         python-version: '3.7.6'
         architecture: 'x64'
+    
+    - name: Checkout private dep pyknos
+      uses: actions/checkout@v2
+      with:
+        repository: mackelab/pyknos
+        token: ${{ secrets.access_pyknos_nflows_private }}
+        path: pyknos
+        
+    - name: Install private deps
+      run: |
+        python -m pip install --upgrade pip
+        cd pyknos
+        pip install -e .
 
     - name: Install dependencies
       run: |

--- a/environment.yml
+++ b/environment.yml
@@ -21,8 +21,8 @@ dependencies:
   - pillow
   - pip
   - pip:
+    - "pyknos@git+ssh://git@github.com/mackelab/pyknos.git"
     - pyro-ppl
-    - "nflows@git+https://github.com/mackelab/nflows-pr"
     - torchtestcase
     - -e .  # install package in development mode
   - pytest

--- a/sbi/inference/snpe/sbi_MDN_posterior.py
+++ b/sbi/inference/snpe/sbi_MDN_posterior.py
@@ -8,7 +8,7 @@ from sbi.mcmc import Slice
 from torch import multiprocessing as mp
 
 from sbi.mcmc import SliceSampler
-from nflows.nn.nde import MultivariateGaussianMDN
+from pyknos.mdn.mdn import MultivariateGaussianMDN
 
 
 class MDNPosterior(MultivariateGaussianMDN):
@@ -303,7 +303,6 @@ class MDNPosterior(MultivariateGaussianMDN):
         self.train()
 
         return samples
-
 
 
 class NeuralPotentialFunction:

--- a/sbi/inference/snpe/sbi_flow_posterior.py
+++ b/sbi/inference/snpe/sbi_flow_posterior.py
@@ -7,7 +7,7 @@ from pyro.infer.mcmc.api import MCMC
 from sbi.mcmc import Slice
 from torch import multiprocessing as mp
 
-from nflows import flows
+from pyknos.nflows import flows
 from sbi.mcmc import SliceSampler
 
 
@@ -325,10 +325,12 @@ class FlowPosterior(flows.Flow):
             embedding_net: nn.Module
                 neural net to encode the context
         """
-        assert isinstance(embedding_net, torch.nn.Module), 'embedding_net is not a nn.Module. ' \
-                                                           'If you want to use hard-coded summary features, ' \
-                                                           'please simply pass the encoded features and pass ' \
-                                                           'embedding_net=None'
+        assert isinstance(embedding_net, torch.nn.Module), (
+            "embedding_net is not a nn.Module. "
+            "If you want to use hard-coded summary features, "
+            "please simply pass the encoded features and pass "
+            "embedding_net=None"
+        )
         self.embedding_net = embedding_net
 
 

--- a/sbi/mcmc/slice.py
+++ b/sbi/mcmc/slice.py
@@ -156,7 +156,7 @@ def test_():
     #     parameters = next(iter(inputs_dict.values()))
     #     return -(likelihood.log_prob(parameters) + prior.log_prob(parameters).sum())
     prior = distributions.Uniform(low=-5 * torch.ones(4), high=2 * torch.ones(4))
-    from nflows import distributions as distributions_
+    from pyknos.nflows import distributions as distributions_
 
     likelihood = distributions_.LotkaVolterraOscillating()
     potential_function = PotentialFunction(likelihood, prior)

--- a/sbi/simulators/simutils.py
+++ b/sbi/simulators/simutils.py
@@ -4,7 +4,7 @@ import pickle
 import sbi.simulators as simulators
 import sbi.utils as utils
 import torch
-from nflows import distributions as distributions_
+from pyknos.nflows import distributions as distributions_
 from torch import distributions
 
 

--- a/sbi/utils/get_models.py
+++ b/sbi/utils/get_models.py
@@ -6,7 +6,8 @@ from pyknos.nflows import distributions as distributions_
 from pyknos.nflows import flows
 from pyknos.nflows import transforms
 from pyknos.nflows.nn import nets
-from pyknos.nflows.nn.nde import MixtureOfGaussiansMADE, MultivariateGaussianMDN
+from pyknos.nflows.nn.nde import MixtureOfGaussiansMADE
+from pyknos.mdn.mdn import MultivariateGaussianMDN
 
 
 def get_neural_posterior(model, embedding, parameter_dim, observation_dim, prior):

--- a/sbi/utils/get_models.py
+++ b/sbi/utils/get_models.py
@@ -2,10 +2,11 @@ from sbi.utils.torchutils import create_alternating_binary_mask
 from torch import nn
 from torch.nn import functional as F
 
-from nflows import distributions as distributions_
-from nflows import flows, transforms
-from nflows.nn import nets
-from nflows.nn.nde import MixtureOfGaussiansMADE, MultivariateGaussianMDN
+from pyknos.nflows import distributions as distributions_
+from pyknos.nflows import flows
+from pyknos.nflows import transforms
+from pyknos.nflows.nn import nets
+from pyknos.nflows.nn.nde import MixtureOfGaussiansMADE, MultivariateGaussianMDN
 
 
 def get_neural_posterior(model, embedding, parameter_dim, observation_dim, prior):

--- a/sbi/utils/get_sbi_models.py
+++ b/sbi/utils/get_sbi_models.py
@@ -2,12 +2,13 @@ from sbi.utils.torchutils import create_alternating_binary_mask
 from torch import nn
 from torch.nn import functional as F
 
-from nflows import distributions as distributions_
-from nflows import transforms
-from nflows.nn import nets
+from pyknos.nflows import distributions as distributions_
+from pyknos.nflows import transforms
+from pyknos.nflows.nn import nets
 from sbi.inference.snpe.sbi_MDN_posterior import MDNPosterior
 from sbi.inference.snpe.sbi_flow_posterior import FlowPosterior
 import torch
+
 
 def get_sbi_posterior(
     model,

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         "matplotlib",
         "numpy",
         "pyro-ppl",
-        "nflows@git+https://github.com/mackelab/nflows-pr",
+        "pyknos@git+ssh://git@github.com/mackelab/pyknos.git",
         "scipy",
         "tensorboard",
         "torch",


### PR DESCRIPTION
This establishes sbi's dependency on nflows indirectly through pyknos.nflows rather directly to nflows.

The idea is that we will have access to a variety of density estimators via pyknos, one class of which is provided by nflows.

We currently use nflows as provided by our local fork, mackelab/nflows

@janfb @michaeldeistler could you :eyes: this? Ideally install sbi from scratch with conda and / or pip and check that tests pass.