### PR TITLE
Example marking of slow tests

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -45,4 +45,4 @@ jobs:
       run: |
         pip install torchtestcase
         pip install pytest
-        pytest
+        pytest -m "not slow"

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,5 @@ description-file = README.md
 
 [tool:pytest]
 pep8maxlinelength = 88
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')

--- a/tests/test_linearGaussian_snl.py
+++ b/tests/test_linearGaussian_snl.py
@@ -14,7 +14,7 @@ torch.manual_seed(0)
 
 # will be called by pytest. Then runs test_*(num_dim) for 1D and 3D
 
-
+@pytest.mark.slow
 @pytest.mark.parametrize("num_dim", [1, 3])
 def test_snl_on_linearGaussian_based_on_mmd(num_dim):
 

--- a/tests/test_linearGaussian_snl.py
+++ b/tests/test_linearGaussian_snl.py
@@ -1,10 +1,11 @@
 import pytest
+import torch
+from torch import distributions
+
 import sbi.simulators as simulators
 import sbi.utils as utils
-import torch
 from sbi import inference
 from sbi.inference.snl.snl import SNL
-from torch import distributions
 
 # use cpu by default
 torch.set_default_tensor_type("torch.FloatTensor")
@@ -14,7 +15,7 @@ torch.manual_seed(0)
 
 
 @pytest.mark.parametrize("num_dim", [1, 3])
-def test_snl_on_linearGaussian_api(num_dim: int = 3):
+def test_snl_on_linearGaussian_api(num_dim: int):
     """Test api for inference on linear Gaussian model using SNL.
     
     Avoids expensive computations for fast testing by using few training simulations and generating few posterior samples.
@@ -57,7 +58,7 @@ def test_snl_on_linearGaussian_api(num_dim: int = 3):
 # will be called by pytest. Then runs test_*(num_dim) for 1D and 3D
 @pytest.mark.slow
 @pytest.mark.parametrize("num_dim", [1, 3])
-def test_snl_on_linearGaussian_based_on_mmd(num_dim: int = 3):
+def test_snl_on_linearGaussian_based_on_mmd(num_dim: int):
     """Test snl inference on linear Gaussian via mmd to ground truth posterior. 
 
     NOTE: The mmd threshold is calculated based on a number of test runs and taking the mean plus 2 stds. 

--- a/tests/test_linearGaussian_snl.py
+++ b/tests/test_linearGaussian_snl.py
@@ -3,8 +3,8 @@ import sbi.simulators as simulators
 import sbi.utils as utils
 import torch
 from sbi import inference
-from torch import distributions
 from sbi.inference.snl.snl import SNL
+from torch import distributions
 
 # use cpu by default
 torch.set_default_tensor_type("torch.FloatTensor")
@@ -12,11 +12,16 @@ torch.set_default_tensor_type("torch.FloatTensor")
 # seed the simulations
 torch.manual_seed(0)
 
-@pytest.mark.parametrize("num_dim", [1, 3])
-def test_snl_on_linearGaussian_api(num_dim):
-    # test api for inference on linear Gaussian model using SNL
-    # avoids expensive computations for fast testing
 
+@pytest.mark.parametrize("num_dim", [1, 3])
+def test_snl_on_linearGaussian_api(num_dim: int = 3):
+    """Test api for inference on linear Gaussian model using SNL.
+    
+    Avoids expensive computations for fast testing by using few training simulations and generating few posterior samples.
+
+    Keyword Arguments:
+        num_dimint {int} -- Parameter dimension of the gaussian model (default: {3})
+    """
     dim, std = num_dim, 1.0
     simulator = simulators.LinearGaussianSimulator(dim=dim, std=std)
     prior = distributions.MultivariateNormal(
@@ -52,7 +57,14 @@ def test_snl_on_linearGaussian_api(num_dim):
 # will be called by pytest. Then runs test_*(num_dim) for 1D and 3D
 @pytest.mark.slow
 @pytest.mark.parametrize("num_dim", [1, 3])
-def test_snl_on_linearGaussian_based_on_mmd(num_dim):
+def test_snl_on_linearGaussian_based_on_mmd(num_dim: int = 3):
+    """Test snl inference on linear Gaussian via mmd to ground truth posterior. 
+
+    NOTE: The mmd threshold is calculated based on a number of test runs and taking the mean plus 2 stds. 
+    
+    Keyword Arguments:
+        num_dim {int} -- Parameter dimension of the gaussian model. (default: {3})
+    """
 
     dim, std = num_dim, 1.0
     simulator = simulators.LinearGaussianSimulator(dim=dim, std=std)
@@ -92,6 +104,7 @@ def test_snl_on_linearGaussian_based_on_mmd(num_dim):
     mmd = utils.unbiased_mmd_squared(target_samples, samples)
 
     # check if mmd is larger than expected
+    # NOTE: the mmd is calculated based on a number of test runs
     max_mmd = 0.02
 
     assert (

--- a/tests/test_linearGaussian_sre.py
+++ b/tests/test_linearGaussian_sre.py
@@ -14,7 +14,7 @@ torch.manual_seed(0)
 
 # will be called by pytest. Then runs test_*(num_dim) for 1D and 3D
 
-
+@pytest.mark.slow
 @pytest.mark.parametrize("num_dim", [1, 3])
 def test_sre_on_linearGaussian_based_on_mmd(num_dim):
 

--- a/tests/test_linearGaussian_sre.py
+++ b/tests/test_linearGaussian_sre.py
@@ -1,10 +1,11 @@
 import pytest
+import torch
+from torch import distributions
+
 import sbi.simulators as simulators
 import sbi.utils as utils
-import torch
 from sbi import inference
 from sbi.inference.sre.sre import SRE
-from torch import distributions
 
 # use cpu by default
 torch.set_default_tensor_type("torch.FloatTensor")
@@ -14,7 +15,7 @@ torch.manual_seed(0)
 
 # will be called by pytest. Then runs test_*(num_dim) for 1D and 3D
 @pytest.mark.parametrize("num_dim", [1, 3])
-def test_sre_on_linearGaussian_api(num_dim: int = 3):
+def test_sre_on_linearGaussian_api(num_dim: int):
     """Test inference api of SRE with linear gaussian model. 
 
     Avoids intense computation for fast testing of API etc. 
@@ -51,15 +52,15 @@ def test_sre_on_linearGaussian_api(num_dim: int = 3):
     )
 
     # run inference
-    inference_method.run_inference(num_rounds=1, num_simulations_per_round=100)
+    inference_method.run_inference(num_rounds=1, num_simulations_per_round=1000)
 
     # draw samples from posterior
-    samples = inference_method.sample_posterior(num_samples=10)
+    samples = inference_method.sample_posterior(num_samples=100)
 
 
 @pytest.mark.slow
 @pytest.mark.parametrize("num_dim", [1, 3])
-def test_sre_on_linearGaussian_based_on_mmd(num_dim: int = 3):
+def test_sre_on_linearGaussian_based_on_mmd(num_dim: int):
     """Test mmd accuracy of inference with SRE on linear gaussian model. 
 
     NOTE: The mmd threshold is calculated based on a number of test runs and taking the mean plus 2 stds. 

--- a/tests/test_linearGaussian_sre.py
+++ b/tests/test_linearGaussian_sre.py
@@ -3,8 +3,8 @@ import sbi.simulators as simulators
 import sbi.utils as utils
 import torch
 from sbi import inference
-from torch import distributions
 from sbi.inference.sre.sre import SRE
+from torch import distributions
 
 # use cpu by default
 torch.set_default_tensor_type("torch.FloatTensor")
@@ -14,7 +14,14 @@ torch.manual_seed(0)
 
 # will be called by pytest. Then runs test_*(num_dim) for 1D and 3D
 @pytest.mark.parametrize("num_dim", [1, 3])
-def test_sre_on_linearGaussian_based_on_mmd(num_dim):
+def test_sre_on_linearGaussian_api(num_dim: int = 3):
+    """Test inference api of SRE with linear gaussian model. 
+
+    Avoids intense computation for fast testing of API etc. 
+    
+    Keyword Arguments:
+        num_dim {int} -- Parameter dimension of the gaussian model (default: {3})
+    """
     # test api for inference on linear Gaussian model using SNL
     # avoids expensive computations for fast testing
 
@@ -52,7 +59,14 @@ def test_sre_on_linearGaussian_based_on_mmd(num_dim):
 
 @pytest.mark.slow
 @pytest.mark.parametrize("num_dim", [1, 3])
-def test_sre_on_linearGaussian_based_on_mmd(num_dim):
+def test_sre_on_linearGaussian_based_on_mmd(num_dim: int = 3):
+    """Test mmd accuracy of inference with SRE on linear gaussian model. 
+
+    NOTE: The mmd threshold is calculated based on a number of test runs and taking the mean plus 2 stds. 
+    
+    Keyword Arguments:
+        num_dim {int} -- Parameter dimension of the gaussian model (default: {3})
+    """
 
     dim, std = num_dim, 1.0
     simulator = simulators.LinearGaussianSimulator(dim=dim, std=std)

--- a/tests/test_linearGaussian_sre.py
+++ b/tests/test_linearGaussian_sre.py
@@ -13,6 +13,42 @@ torch.set_default_tensor_type("torch.FloatTensor")
 torch.manual_seed(0)
 
 # will be called by pytest. Then runs test_*(num_dim) for 1D and 3D
+@pytest.mark.parametrize("num_dim", [1, 3])
+def test_sre_on_linearGaussian_based_on_mmd(num_dim):
+    # test api for inference on linear Gaussian model using SNL
+    # avoids expensive computations for fast testing
+
+    dim, std = num_dim, 1.0
+    simulator = simulators.LinearGaussianSimulator(dim=dim, std=std)
+    prior = distributions.MultivariateNormal(
+        loc=torch.zeros(dim), covariance_matrix=torch.eye(dim)
+    )
+
+    parameter_dim, observation_dim = dim, dim
+    true_observation = torch.zeros(dim)
+
+    # get classifier
+    classifier = utils.get_classifier(
+        "resnet",
+        parameter_dim=simulator.parameter_dim,
+        observation_dim=simulator.observation_dim,
+    )
+
+    # create inference method
+    inference_method = SRE(
+        simulator=simulator,
+        prior=prior,
+        true_observation=true_observation,
+        classifier=classifier,
+        mcmc_method="slice-np",
+    )
+
+    # run inference
+    inference_method.run_inference(num_rounds=1, num_simulations_per_round=100)
+
+    # draw samples from posterior
+    samples = inference_method.sample_posterior(num_samples=10)
+
 
 @pytest.mark.slow
 @pytest.mark.parametrize("num_dim", [1, 3])

--- a/tests/test_nonlinearGaussian_apt.py
+++ b/tests/test_nonlinearGaussian_apt.py
@@ -2,11 +2,13 @@ import os
 import sys
 
 import numpy as np
+import pytest
+import torch
+from torch import distributions
+
 import sbi.simulators as simulators
 import sbi.utils as utils
-import torch
 from sbi.inference.snpe.snpe_c import APT
-from torch import distributions
 
 # use cpu by default
 torch.set_default_tensor_type("torch.FloatTensor")
@@ -15,6 +17,7 @@ torch.set_default_tensor_type("torch.FloatTensor")
 torch.manual_seed(0)
 
 
+@pytest.mark.slow
 def test_nonlinearGaussian_based_on_mmd():
     task = "nonlinear-gaussian"
     (
@@ -28,11 +31,11 @@ def test_nonlinearGaussian_based_on_mmd():
     parameter_dim = ground_truth_parameters.shape[0]
     observation_dim = ground_truth_observation.shape[0]
 
-    print('here', ground_truth_observation)
+    print("here", ground_truth_observation)
 
     apt = APT(
         simulator=simulator,
-        true_observation=ground_truth_observation[None, ],
+        true_observation=ground_truth_observation[None,],
         prior=prior,
         num_atoms=-1,
         z_score_obs=True,

--- a/tests/test_twoMoons_apt.py
+++ b/tests/test_twoMoons_apt.py
@@ -6,6 +6,7 @@ import sbi.utils as utils
 import torch
 from sbi.inference.snpe.snpe_c import APT
 from torch import distributions
+import pytest
 
 # use cpu by default
 torch.set_default_tensor_type("torch.FloatTensor")
@@ -13,7 +14,7 @@ torch.set_default_tensor_type("torch.FloatTensor")
 # seed the simulations
 torch.manual_seed(0)
 
-
+@pytest.mark.slow
 def test_apt_on_twoMoons_based_on_mmd():
     simulator = simulators.TwoMoonsSimulator()
     a = 1


### PR DESCRIPTION
Added facility to mark tests as slow. 
* in setup.cfg, introduce a marker
* decorate affected functions as @pytest.mark.slow
* call whenever testing should be faster, pytest -m "not slow" instead of just pytest.

The current selection of functions is just a proposal. Also, we should build this into the automated CI. I would like to kindly ask @janfb, @jan-matthis to review these changes and ggf. commit a) a better selection of slow functions b) a new policy for the CI.