### PR TITLE
WIP Refactor simulators to function

### DIFF
--- a/sbi/simulators/simutils.py
+++ b/sbi/simulators/simutils.py
@@ -8,6 +8,48 @@ from pyknos.nflows import distributions as distributions_
 from torch import distributions
 
 
+def get_simulator_dimensions(simulator_fun, parameter_sample_fun):
+    """Infer simulator input output dimension from prior and simulating once. 
+    
+    Arguments:
+        simulator_fun {function} -- simulator function taking parameter batch as only argument, return data. 
+        parameter_sample_fun {function} -- prior function with kwarg 'num_samples'.
+    
+    Returns:
+        dim_input [int] -- input dimension of simulator, i.e., parameter vector dimension.
+        dim_output [int] -- output dimension of simualtor, i.e., dimension of data or summary stats.
+    """
+    # sample from prior to get parameter dimension
+    param = parameter_sample_fun(num_samples=1)
+    dim_input = param.squeeze().shape[0]
+
+    # simulate once to get simulator output dimension
+    data = simulator_fun(param)
+    dim_output = data.squeeze().shape[0]
+
+    return dim_input, dim_output
+
+
+def get_simulator_name(simulator_fun, name=None):
+    """Get or set name of the simulator. 
+    
+    Returns function name if no name is given. 
+    
+    Arguments:
+        simulator_fun {function} -- simulator function taking parameter batch as only argument, return data. 
+    
+    Keyword Arguments:
+        name {string} -- name of the simualtor, e.g., 'linearGaussian' (default: {None})
+    
+    Returns:
+        string -- Name of the simulator. 
+    """
+    if name is None:
+        return simulator_fun.__name__
+    else:
+        return name
+
+
 # TODO: we do not want this function
 def simulation_wrapper(simulator, parameter_sample_fn, num_samples):
 

--- a/tests/test_simutils.py
+++ b/tests/test_simutils.py
@@ -1,0 +1,40 @@
+import pytest
+import torch
+import torch.distributions as dist
+from sbi.simulators.linear_gaussian import LinearGaussianSimulator
+from sbi.simulators.nonlinear_gaussian import NonlinearGaussianSimulator
+from sbi.simulators.simutils import get_simulator_dimensions, get_simulator_name
+
+
+@pytest.mark.parametrize("name", [None, "mysimulator"])
+def test_get_simualtor_name(name):
+
+    # get simualtor
+    def mysimulator(params):
+        return params
+
+    assert get_simulator_name(mysimulator, name) == "mysimulator"
+
+
+def test_get_simualtor_dimensions():
+
+    # test linear gaussian
+    dim = 3
+    dim_in, dim_out = get_simulator_dimensions(
+        LinearGaussianSimulator(dim=dim),
+        lambda num_samples: dist.Uniform(
+            low=torch.tensor(dim * [-2.0]), high=torch.tensor(dim * [2.0])
+        ).sample((num_samples,)),
+    )
+    assert dim_in == dim, "input dim inferred incorrectly"
+    assert dim_out == dim, "output dim inferred incorrectly"
+
+    # test non linear gaussian
+    dim_in, dim_out = get_simulator_dimensions(
+        NonlinearGaussianSimulator(),
+        lambda num_samples: dist.Uniform(
+            low=torch.tensor(5 * [-2.0]), high=torch.tensor(5 * [2.0])
+        ).sample((num_samples,)),
+    )
+    assert dim_in == 5, "input dim inferred incorrectly"
+    assert dim_out == 8, "output dim inferred incorrectly"


### PR DESCRIPTION
At the moment simulators are still classes and inference methods use their properties like `name`, `parameter_dim` and methods for obtaining the ground truth posterior. We want to change this (#32 ). 

Todos: 
- [ ] add methods for inferring name and dimensions from `prior` and `simulate` function (#48 )
- [ ] replace usage of properties by those functions 
- [ ] move ground truth posterior methods for linear gaussian to utils (#47 )
- [ ] rewrite currently used simulators as functions 
- [ ] adapt all usages of that in inference method, tests and examples (#52 ). 
- [ ] write new tests for simulators 