### PR TITLE
Improved documentation of batch simulator and shapes for SRE

### DIFF
--- a/sbi/inference/snl/snl.py
+++ b/sbi/inference/snl/snl.py
@@ -150,7 +150,6 @@ class SNL:
                     ),
                     num_samples=num_simulations_per_round,
                     simulation_batch_size=self._simulation_batch_size,
-                    x_dim=self._true_observation.shape[1:],  # do not pass batch_dim
                 )
             else:
                 parameters, observations = simulators.simulate_in_batches(
@@ -160,7 +159,6 @@ class SNL:
                     ),
                     num_samples=num_simulations_per_round,
                     simulation_batch_size=self._simulation_batch_size,
-                    x_dim=self._true_observation.shape[1:],  # do not pass batch_dim
                 )
 
             # Store (parameter, observation) pairs.

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -95,7 +95,6 @@ class SnpeBase:
             parameter_sample_fn=lambda num_samples: self._prior.sample((num_samples,)),
             num_samples=num_pilot_samples,
             simulation_batch_size=self._simulation_batch_size,
-            x_dim=self._true_observation.shape[1:],  # do not pass batch_dim
         )
 
         # create the deep neural density estimator
@@ -263,7 +262,6 @@ class SnpeBase:
                     0, num_simulations_per_round - self.num_pilot_samples
                 ),
                 simulation_batch_size=self._simulation_batch_size,
-                x_dim=self._true_observation.shape[1:],  # do not pass batch_dim
             )
             parameters = torch.cat(
                 (parameters, self.pilot_parameters[:num_simulations_per_round]), dim=0
@@ -280,7 +278,6 @@ class SnpeBase:
                 ),
                 num_samples=num_simulations_per_round,
                 simulation_batch_size=self._simulation_batch_size,
-                x_dim=self._true_observation.shape[1:],  # do not pass batch_dim
             )
 
         # Store (parameter, observation) pairs.

--- a/sbi/inference/sre/sre.py
+++ b/sbi/inference/sre/sre.py
@@ -190,7 +190,6 @@ class SRE:
                     ),
                     num_samples=num_simulations_per_round,
                     simulation_batch_size=self._simulation_batch_size,
-                    x_dim=self._true_observation.shape[1:],  # do not pass batch_dim
                 )
             else:
                 parameters, observations = simulators.simulate_in_batches(
@@ -200,7 +199,6 @@ class SRE:
                     ),
                     num_samples=num_simulations_per_round,
                     simulation_batch_size=self._simulation_batch_size,
-                    x_dim=self._true_observation.shape[1:],  # do not pass batch_dim
                 )
 
             # Store (parameter, observation) pairs.

--- a/sbi/simulators/simutils.py
+++ b/sbi/simulators/simutils.py
@@ -129,16 +129,16 @@ def simulate_in_batches(
     Args:
         simulator: simulator function that takes in parameters of shape
          (simulation_batch_size, num_dim_parameters) and
-         outputs xs of shape (simulation_batch_size, num_dim_x)
+         outputs xs of shape (simulation_batch_size, x.shape)
         parameter_sample_fn: Function to call for generating theta, e.g. prior sampling
         num_samples: Number of simulations to run
         simulation_batch_size: Number of simulations that are run within a single batch
-            If `simulation_batch_size == -1`, we run a batch with all simulations
-             required, i.e. `simulation_batch_size = num_samples`
+            If `simulation_batch_size == -1`, we run all required simulations
+             simultaneously , i.e. `simulation_batch_size = num_samples`
 
     Returns: torch.Tensor simulation input parameters of shape
-                (num_samples, num_dim_parameters)
-             torch.Tensor simulator outputs x of shape (num_samples, num_dim_x)
+                (num_samples, parameters.shape)
+             torch.Tensor simulator outputs xs of shape (num_samples, x.shape)
     """
 
     # generate parameters (simulation inputs) by sampling from prior (round 1)
@@ -160,8 +160,7 @@ def simulate_in_batches(
             # XXX: if we assert the that simulator returns a torch.Tensor with batch dim
             # we can avoid the following 2 checks
             x = simulator(batch)
-            if not isinstance(x, torch.Tensor):
-                x = torch.from_numpy(x)
+            x = torch.as_tensor(x)
             if simulation_batch_size == 1:
                 # In case simulator outputs data of shape (dim_observation), we prepend
                 # a dimension to make it (1, dim_observation)

--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -193,7 +193,7 @@ class BoxUniform(Independent):
     ):
         """Multidimensional uniform distribution defined on a box.
         
-        A `Uniform` distribution initialized with e.g. a parameter vector low or high of length 3 will result in a /batch/ dimension of length 3. A log_prob evaluation will then output three numbers, one for each of the independent Uniforms in the batch. Instead, a `BoxUniform` initialized in the same way has three /event/ dimensions, and returns a scalar log_prob corresponding to whether the evaluated point is in the box defined by low and high or outside. 
+        A `Uniform` distribution initialized with e.g. a parameter vector low or high of length 3 will result in a /batch/ dimension of length 3. A log_prob evaluation will then output three numbers, one for each of the independent Uniforms in the batch. Instead, a `BoxUniform` initialized in the same way has three /event/ dimensions, and returns a scalar log_prob corresponding to whether the evaluated point is in the box defined by low and high or outside.
     
         Refer to torch.distributions.Uniform and torch.distributions.Independent for further documentation.
     
@@ -207,12 +207,16 @@ class BoxUniform(Independent):
         super().__init__(Uniform(low=low, high=high), reinterpreted_batch_ndims)
 
 
-# XXX does an in-place version (e.g. make_conform_) make sense?
+# XXX does an in-place version (e.g. ensure_parameter_batched_) make sense?
 def ensure_parameter_batched(parameter: torch.Tensor) -> torch.Tensor:
     """
-    Return tensors that both have the same tensor.ndim
-    Function also covers cases where parameters is ndim=1 and observation ndim=2
-    Also, we have specialized check for multi-dimensional data x, e.g. images.
+    Return parameter tensor that has a batch dimension, i.e. has shape
+    (1, dim_parameters)
+
+    Args:
+        parameter: A single parameter set, potentially without batch dimension
+    Returns:
+        Batched parameter set
     """
 
     # => ensure parameters have shape (1, dim_parameter)
@@ -222,16 +226,22 @@ def ensure_parameter_batched(parameter: torch.Tensor) -> torch.Tensor:
     return parameter
 
 
-# XXX does an in-place version (e.g. make_conform_) make sense?
+# XXX does an in-place version (e.g. ensure_observation_batched_) make sense?
 def ensure_observation_batched(observation: torch.Tensor) -> torch.Tensor:
     """
-    Return tensors that both have the same tensor.ndim
-    Function also covers cases where parameters is ndim=1 and observation ndim=2
-    Also, we have specialized check for multi-dimensional data x, e.g. images.
+    Return observation tensor that has a batch dimension, i.e. has shape
+    (1, dim_observation)
+
+    Function also covers cases where observation has observation.ndim>1, e.g. images
+
+    Args:
+        observation: A single observation, potentially without batch dimension
+    Returns:
+        Batched observation
     """
 
-    # => ensure observation has shape (1, dim_observation). If shape[0] > 1, we assume that the batch-dimension
-    # is missing, even though ndim might be >1 (e.g. for images)
+    # => ensure observation has shape (1, dim_observation). If shape[0] > 1, we assume
+    # that the batch-dimension is missing, even though ndim might be >1 (e.g. images)
     if observation.shape[0] > 1 or observation.ndim == 1:
         observation = observation.unsqueeze(0)
 

--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -214,7 +214,7 @@ def ensure_parameter_batched(parameter: torch.Tensor) -> torch.Tensor:
     (1, dim_parameters)
 
     Args:
-        parameter: A single parameter set, potentially without batch dimension
+        parameter: A tensor (parameter set) of n parameters of shape (n) or (1,n)
     Returns:
         Batched parameter set
     """
@@ -235,7 +235,7 @@ def ensure_observation_batched(observation: torch.Tensor) -> torch.Tensor:
     Function also covers cases where observation has observation.ndim>1, e.g. images
 
     Args:
-        observation: A single observation, potentially without batch dimension
+        observation: A tensor (observation) of n values of shape (n) or (1,n)
     Returns:
         Batched observation
     """


### PR DESCRIPTION
**Contributions:**
- Removed dimension x_dim as input from simulate_in_batches(), as it is not used in newest implementation
- updated docstrings
- updated comments

**Limitations:**
- does not yet contain the naming conventions discussed in issue #100 