### PR TITLE
Fix pilot samples recycling round 1. 

### DIFF
--- a/sbi/inference/snl/snl.py
+++ b/sbi/inference/snl/snl.py
@@ -113,7 +113,6 @@ class SNL(NeuralInference):
                     ),
                     num_samples=num_simulations_per_round,
                     simulation_batch_size=self._simulation_batch_size,
-                    x_dim=self._true_observation.shape[1:],  # do not pass batch_dim
                 )
             else:
                 parameters, observations = simulators.simulate_in_batches(
@@ -123,7 +122,6 @@ class SNL(NeuralInference):
                     ),
                     num_samples=num_simulations_per_round,
                     simulation_batch_size=self._simulation_batch_size,
-                    x_dim=self._true_observation.shape[1:],  # do not pass batch_dim
                 )
 
             # Store (parameter, observation) pairs.

--- a/sbi/inference/sre/sre.py
+++ b/sbi/inference/sre/sre.py
@@ -146,7 +146,6 @@ class SRE(NeuralInference):
                     ),
                     num_samples=num_simulations_per_round,
                     simulation_batch_size=self._simulation_batch_size,
-                    x_dim=self._true_observation.shape[1:],  # do not pass batch_dim
                 )
             else:
                 parameters, observations = simulators.simulate_in_batches(
@@ -156,7 +155,6 @@ class SRE(NeuralInference):
                     ),
                     num_samples=num_simulations_per_round,
                     simulation_batch_size=self._simulation_batch_size,
-                    x_dim=self._true_observation.shape[1:],  # do not pass batch_dim
                 )
 
             # Store (parameter, observation) pairs.

--- a/sbi/simulators/simutils.py
+++ b/sbi/simulators/simutils.py
@@ -547,8 +547,7 @@ def simulate_in_batches(
     parameter_sample_fn: Callable,
     num_samples: int,
     simulation_batch_size: int,
-    x_dim: torch.Size,
-) -> Tuple[Tensor, Tensor]:
+) -> (Tensor, Tensor):
     """
     Return parameters and simulated data for `num_samples` parameter sets. 
     
@@ -563,14 +562,14 @@ def simulate_in_batches(
         parameter_sample_fn: Function to call for generating theta, e.g. prior sampling
         num_samples: Number of simulations to run
         simulation_batch_size: Number of simulations that are run within a single batch
-            If `simulation_batch_size == -1`, we run a batch with all simulations required, i.e. `simulation_batch_size = num_samples`
-        x_dim: dimensionality of a single simulator output
+            If `simulation_batch_size == -1`, we run a batch with all simulations required,
+            i.e. `simulation_batch_size = num_samples`
 
     Returns: Tensor simulation input parameters of shape (num_samples, num_dim_parameters),
              Tensor simulator outputs x of shape (num_samples, num_dim_x)
     """
 
-    assert num_samples > 0, "number of samples must be larger than zero."
+    assert num_samples > 0, "Number of samples to simulate must be larger than zero."
 
     # Generate parameters (simulation inputs) by sampling from prior (round 1) or
     # proposal (round > 1).

--- a/tests/simulator_utils_test.py
+++ b/tests/simulator_utils_test.py
@@ -267,19 +267,15 @@ def test_simulate_in_batches(
     """Test combinations of num_samples and simulation_batch_size. """
 
     simulate_in_batches(
-        simulator,
-        lambda n: prior.sample((n,)),
-        num_samples,
-        batch_size,
-        torch.Size([5]),
+        simulator, lambda n: prior.sample((n,)), num_samples, batch_size,
     )
 
 
-def test_inference_with_pilot_samples_samples():
+def test_inference_with_pilot_samples_many_samples():
     """Test whether num_pilot_samples can be same as num_simulations_per_round."""
 
     num_dim = 3
-    true_observation = torch.zeros((1, num_dim))
+    true_observation = torch.zeros(num_dim)
 
     prior = MultivariateNormal(
         loc=torch.zeros(num_dim), covariance_matrix=torch.eye(num_dim)


### PR DESCRIPTION
If there are more pilot samples than simulations needed in first round 0 will be passed to `simulate_in_batches`. this is avoided here. 