### PR TITLE
[WIP] Renaming variables to theta, x, x_o

### DIFF
--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -1,4 +1,3 @@
-
 from abc import ABC
 import os.path
 from typing import Callable, Optional
@@ -21,23 +20,27 @@ class NeuralInference(ABC):
         self,
         simulator: Callable,
         prior,
-        true_observation: Tensor,
+        x_o: Tensor,
         simulation_batch_size: int = 1,
         device: Optional[torch.device] = None,
-        summary_writer: Optional[SummaryWriter] = None, 
+        summary_writer: Optional[SummaryWriter] = None,
         simulator_name: Optional[str] = "simulator",
     ):
 
-        """
+        r"""
         Args:
 
             simulator: a regular function parameter->result
                 Both parameters and result can be multi-dimensional.         
             prior: distribution-like object with `log_prob`and `sample` methods.
-            true_observation: tensor containing the observation x_o.
-                If it has more than one dimension, the leading dimension will be interpreted as a batch dimension but *currently* only the first batch element will be used to condition on.
-            simulation_batch_size: number of parameter sets that the 
-                simulator accepts and converts to data x at once. If -1, we simulate all parameter sets at the same time. If >= 1, the simulator has to process data of shape (simulation_batch_size, parameter_dimension).
+            x_o: tensor containing the observation $x_o$.
+                If it has more than one dimension, the leading dimension will be
+                 interpreted as a batch dimension but *currently* only the first batch
+                 element will be used to condition on.
+            simulation_batch_size: number of parameter sets that the
+                simulator accepts and converts to data x at once. If -1, we simulate all
+                 parameter sets at the same time. If >= 1, the simulator has to process
+                 data of shape (simulation_batch_size, parameter_dimension).
             summary_writer: an optional SummaryWriter to control, among others, log     
                 file location (default is <current working directory>/logs.)
             device: torch.device on which to compute (optional).
@@ -45,18 +48,16 @@ class NeuralInference(ABC):
                 ['slice', 'hmc', 'nuts'].
         """
 
-        self._simulator, self._prior, self._true_observation = prepare_sbi_problem(
-            simulator, 
-            prior, 
-            true_observation
+        self._simulator, self._prior, self._x_o = prepare_sbi_problem(
+            simulator, prior, x_o
         )
 
         self._simulation_batch_size = simulation_batch_size
 
         self._device = get_default_device() if device is None else device
 
-        # Initialize roundwise (parameter, observation) storage.
-        self._parameter_bank, self._observation_bank = [], []
+        # Initialize roundwise (theta, x) for (parameters, simulation outputs) storage.
+        self._theta_bank, self._x_bank = [], []
 
         # XXX We could instantiate here the Posterior for all children. Two problems:
         # XXX 1. We must dispatch to right PotentialProvider for mcmc based on name
@@ -79,7 +80,7 @@ class NeuralInference(ABC):
             mmds=[],
             median_observation_distances=[],
             negative_log_probs_true_parameters=[],
-            neural_net_fit_times= [], #XXX unused elsewhere
+            neural_net_fit_times=[],  # XXX unused elsewhere
             epochs=[],
             best_validation_log_probs=[],
         )

--- a/sbi/inference/snpe/snpe_c.py
+++ b/sbi/inference/snpe/snpe_c.py
@@ -15,13 +15,13 @@ class SnpeC(SnpeBase):
         self,
         simulator,
         prior,
-        true_observation,
+        x_o,
         num_atoms=-1,
         num_pilot_samples=100,
         density_estimator=None,
         calibration_kernel=None,
         use_combined_loss=False,
-        z_score_obs=True,
+        z_score_x=True,
         simulation_batch_size: int = 1,
         retrain_from_scratch_each_round=False,
         discard_prior_samples=False,
@@ -30,7 +30,7 @@ class SnpeC(SnpeBase):
         sample_with_mcmc=False,
         mcmc_method="slice-np",
     ):
-        """SNPE-C / APT
+        r"""SNPE-C / APT
 
         Implementation of _Automatic Posterior Transformation for Likelihood-free
         Inference_ by Greenberg et al., ICML 2019, https://arxiv.org/abs/1905.07488
@@ -39,28 +39,29 @@ class SnpeC(SnpeBase):
             num_pilot_samples: number of simulations that are run when
                 instantiating an object. Used to z-score the observations.   
             density_estimator: neural density estimator
-            calibration_kernel: a function to calibrate the context
-            z_score_obs: whether to z-score the data features x
+            calibration_kernel: a function to calibrate the data $x$
+            z_score_x: whether to z-score the data features $x$
             use_combined_loss: whether to jointly neural_net prior samples 
-                using maximum likelihood. Useful to prevent density leaking when using box uniform priors.
+                using maximum likelihood. Useful to prevent density leaking when using
+                 box uniform priors.
             retrain_from_scratch_each_round: whether to retrain the conditional
                 density estimator for the posterior from scratch each round.
             discard_prior_samples: whether to discard prior samples from round
                 two onwards.
             num_atoms: int
                 Number of atoms to use for classification.
-                If -1, use all other parameters in minibatch.
+                If -1, use all other thetas in minibatch.
         """
 
         super(SnpeC, self).__init__(
             simulator=simulator,
             prior=prior,
-            true_observation=true_observation,
+            x_o=x_o,
             num_pilot_samples=num_pilot_samples,
             density_estimator=density_estimator,
             calibration_kernel=calibration_kernel,
             use_combined_loss=use_combined_loss,
-            z_score_obs=z_score_obs,
+            z_score_x=z_score_x,
             simulation_batch_size=simulation_batch_size,
             retrain_from_scratch_each_round=retrain_from_scratch_each_round,
             discard_prior_samples=discard_prior_samples,
@@ -72,8 +73,10 @@ class SnpeC(SnpeBase):
         assert isinstance(num_atoms, int), "Number of atoms must be an integer."
         self._num_atoms = num_atoms
 
-    def _get_log_prob_proposal_posterior(self, inputs, context, masks):
-        """
+    def _get_log_prob_proposal_posterior(
+        self, theta: torch.Tensor, x: torch.Tensor, masks: torch.Tensor
+    ) -> torch.Tensor:
+        r"""
         We have two main options when evaluating the proposal posterior.
         (1) Generate atoms from the proposal prior.
         (2) Generate atoms from a more targeted distribution,
@@ -83,27 +86,27 @@ class SnpeC(SnpeBase):
         estimator.
 
         Args:
-            inputs: torch.Tensor Batch of parameters.
-            context: torch.Tensor Batch of observations.
-            masks: torch.Tensor
-                binary, whether or not to retrain with prior loss on specific prior sample
+            theta: batch of parameters $\theta$.
+            x: batch of data $x$.
+            masks: binary, whether or not to retrain with prior loss on specific prior
+             sample
 
-        Returns: torch.Tensor [1] log_prob_proposal_posterior
+        Returns: log_prob_proposal_posterior
 
         """
 
-        batch_size = inputs.shape[0]
+        batch_size = theta.shape[0]
 
         num_atoms = self._num_atoms if self._num_atoms > 0 else batch_size
 
-        # Each set of parameter atoms is evaluated using the same observation,
-        # so we repeat rows of the context.
+        # Each set of parameter atoms is evaluated using the same x,
+        # so we repeat rows of the data x.
         # e.g. [1, 2] -> [1, 1, 2, 2]
-        repeated_context = utils.repeat_rows(context, num_atoms)
+        repeated_x = utils.repeat_rows(x, num_atoms)
 
         # To generate the full set of atoms for a given item in the batch,
         # we sample without replacement num_atoms - 1 times from the rest
-        # of the parameters in the batch.
+        # of the theta in the batch.
         assert 0 < num_atoms - 1 < batch_size
         probs = (
             (1 / (batch_size - 1))
@@ -111,17 +114,17 @@ class SnpeC(SnpeBase):
             * (1 - torch.eye(batch_size))
         )
         choices = torch.multinomial(probs, num_samples=num_atoms - 1, replacement=False)
-        contrasting_inputs = inputs[choices]
+        contrasting_theta = theta[choices]
 
         # We can now create our sets of atoms from the contrasting parameter sets
         # we have generated.
-        atomic_inputs = torch.cat(
-            (inputs[:, None, :], contrasting_inputs), dim=1
-        ).reshape(batch_size * num_atoms, -1)
+        atomic_theta = torch.cat((theta[:, None, :], contrasting_theta), dim=1).reshape(
+            batch_size * num_atoms, -1
+        )
 
         # Evaluate large batch giving (batch_size * num_atoms) log prob posterior evals.
         log_prob_posterior = self._neural_posterior.log_prob(
-            atomic_inputs, repeated_context, normalize_snpe_density=False
+            atomic_theta, repeated_x, normalize_snpe_density=False
         )
         assert torch.isfinite(
             log_prob_posterior
@@ -129,7 +132,7 @@ class SnpeC(SnpeBase):
         log_prob_posterior = log_prob_posterior.reshape(batch_size, num_atoms)
 
         # Get (batch_size * num_atoms) log prob prior evals.
-        log_prob_prior = self._prior.log_prob(atomic_inputs)
+        log_prob_prior = self._prior.log_prob(atomic_theta)
         log_prob_prior = log_prob_prior.reshape(batch_size, num_atoms)
         assert torch.isfinite(log_prob_prior).all(), "NaN/inf detected in prior eval."
 
@@ -138,7 +141,7 @@ class SnpeC(SnpeBase):
 
         # Normalize proposal posterior across discrete set of atoms.
         log_prob_proposal_posterior = self.calibration_kernel(
-            context
+            x
         ) * unnormalized_log_prob_proposal_posterior[:, 0] - torch.logsumexp(
             unnormalized_log_prob_proposal_posterior, dim=-1
         )
@@ -150,7 +153,7 @@ class SnpeC(SnpeBase):
         # todo: at all prior samples
         if self._use_combined_loss:
             log_prob_posterior_non_atomic = self._neural_posterior.log_prob(
-                inputs, context, normalize_snpe_density=False
+                theta, x, normalize_snpe_density=False
             )
             masks = masks.reshape(-1)
             log_prob_proposal_posterior = (
@@ -159,6 +162,6 @@ class SnpeC(SnpeBase):
 
         return log_prob_proposal_posterior
 
-    def _get_log_prob_proposal_MoG(self, inputs, context, masks):
+    def _get_log_prob_proposal_MoG(self, theta, x, masks):
 
         raise NotImplementedError

--- a/sbi/simulators/nonlinear_gaussian.py
+++ b/sbi/simulators/nonlinear_gaussian.py
@@ -9,90 +9,93 @@ from matplotlib import pyplot as plt
 import sbi.utils as utils
 from sbi.mcmc import SliceSampler
 from sbi.simulators.simulator import Simulator
+from torch import Tensor
 
 # fixed parameters for this simulator
-num_observations_per_parameter = 4
-parameter_dim = 5
+num_xs_per_parameter = 4
+theta_dim = 5
 observation_dim = 8
 
-
-def non_linear_gaussian(parameters: torch.Tensor) -> torch.Tensor:
-    """Generate observations from non-linear Gaussian model for the given batch of parameters.
+# XXX: rewrite in PyTorch, maybe take from sbibm.
+def non_linear_gaussian(theta: Tensor) -> Tensor:
+    """Generate simulation outputs x from non-linear Gaussian model for the given batch
+     of parameters theta.
         
     Arguments:
-        parameters {torch.Tensor} -- Batch of parameters.
+        theta: batch of parameters.
     
     Returns:
-        torch.Tensor [batch size, 2 * num_observations_per_parameter] -- Batch of observations.
+         batch of simulated data xs of shape
+          (batch_size, 2 * num_xs_per_parameter)
     """
     # Run simulator in NumPy.
-    if isinstance(parameters, torch.Tensor):
-        parameters = utils.tensor2numpy(parameters)
+    if isinstance(theta, Tensor):
+        theta = utils.tensor2numpy(theta)
 
     # If we have a single parameter then view it as a batch of one.
-    if parameters.ndim == 1:
-        parameters = parameters[np.newaxis, :]
+    if theta.ndim == 1:
+        theta = theta[np.newaxis, :]
 
-    num_simulations = parameters.shape[0]
+    num_simulations = theta.shape[0]
 
-    # Run simulator to generate self._num_observations_per_parameter
-    # observations from a 2D Gaussian parameterized by the 5 given parameters.
-    m0, m1, s0, s1, r = _unpack_params(parameters)
+    # Run simulator to generate self._num_xs_per_parameter
+    # observations from a 2D Gaussian parameterized by the 5 values in each theta.
+    m0, m1, s0, s1, r = _unpack_params(theta)
 
-    us = np.random.randn(num_simulations, num_observations_per_parameter, 2)
-    observations = np.zeros_like(us)
+    us = np.random.randn(num_simulations, num_xs_per_parameter, 2)
+    xs = np.zeros_like(us)
 
-    observations[:, :, 0] = s0 * us[:, :, 0] + m0
-    observations[:, :, 1] = (
-        s1 * (r * us[:, :, 0] + np.sqrt(1.0 - r ** 2) * us[:, :, 1]) + m1
-    )
+    xs[:, :, 0] = s0 * us[:, :, 0] + m0
+    xs[:, :, 1] = s1 * (r * us[:, :, 0] + np.sqrt(1.0 - r ** 2) * us[:, :, 1]) + m1
 
+    # XXX: this doesnt have any effect remove?
     mean = torch.zeros(observation_dim)
     std = torch.ones(observation_dim)
     return (
-        torch.Tensor(
-            observations.reshape([num_simulations, 2 * num_observations_per_parameter])
+        torch.tensor(
+            xs.reshape([num_simulations, 2 * num_xs_per_parameter]), dtype=torch.float32
         )
         - mean.reshape(1, -1)
     ) / std.reshape(1, -1)
 
 
-def _unpack_params(parameters):
-    """Unpack parameters parameters to m0, m1, s0, s1, r.
+def _unpack_params(theta):
+    """Unpack theta to m0, m1, s0, s1, r.
     
     Arguments:
-        parameters {np.array [batch_size, parameter_dim]} -- Batch of parameters.
+        theta: batch of parameters of shape (batch_size, theta_dim)
     
     Returns:
-        tuple(np.array) -- Tuple of parameters where each np.array holds a single parameter for the batch.
+        tuple(np.array) -- Tuple of parameters where each np.array holds a single
+         theta for the batch.
     """
-    assert parameters.shape[1] == 5, "parameter dimension must be 5"
+    assert theta.shape[1] == 5, "parameter dimension must be 5"
 
-    m0 = parameters[:, [0]]
-    m1 = parameters[:, [1]]
-    s0 = parameters[:, [2]] ** 2
-    s1 = parameters[:, [3]] ** 2
-    r = np.tanh(parameters[:, [4]])
+    m0 = theta[:, [0]]
+    m1 = theta[:, [1]]
+    s0 = theta[:, [2]] ** 2
+    s1 = theta[:, [3]] ** 2
+    r = np.tanh(theta[:, [4]])
 
     return m0, m1, s0, s1, r
 
 
 def get_ground_truth_posterior_samples_nonlinear_gaussian(
     num_samples: Optional[int] = None,
-) -> torch.Tensor:
+) -> Tensor:
     """Get pseudo ground truth posterior samples from mcmc.
         
     We have pre-generated posterior samples using MCMC on the product of the analytic
     likelihood and a uniform prior on [-3, 3]^5.
     Thus they are ground truth as long as MCMC has behaved well.
-    We load these once if samples have not been loaded before, store them for future use,
-    and return as many as are requested.
+    We load these once if samples have not been loaded before, store them for future
+    use, and return as many as are requested.
 
     Keyword Arguments:
-        num_samples {int} -- Number of sample to return. (default: {None})
+        num_samples: number of sample to return.
     
     Returns:
-        torch.Tensor [num_samples, parameter_dim] -- Batch of posterior samples.
+        posterior_samples: batch of posterior samples shaped [num_samples, theta_dim]
     """
 
     posterior_samples = torch.tensor(
@@ -110,106 +113,104 @@ def get_ground_truth_posterior_samples_nonlinear_gaussian(
         return posterior_samples
 
 
+# XXX This is a replication of the above function, no? needs refactoring.
 class NonlinearGaussianSimulator(Simulator):
     """
-    Implemenation of nonlinear Gaussian simulator as described in section 5.2 and appendix
-    A.1 of 'Sequential Neural Likelihood', Papamakarios et al. 
+    Implemenation of nonlinear Gaussian simulator as described in section 5.2 and
+     appendix A.1 of 'Sequential Neural Likelihood', Papamakarios et al.
     """
 
     def __init__(self):
-        """Set up simulator. 
+        """Set up simulator.
         """
         super().__init__()
-        self._num_observations_per_parameter = 4
+        self._num_xs_per_parameter = 4
         self._posterior_samples = None
 
-    def __call__(self, parameters):
-        """Generate observations from non-linear Gaussian model for the given batch of parameters.
+    def __call__(self, theta: Tensor) -> Tensor:
+        """Generate observations from non-linear Gaussian model for the given batch of
+         parameters theta.
         
-        Arguments:
-            parameters {torch.Tensor} -- Batch of parameters.
+        Args:
+            theta: Batch of parameters.
         
         Returns:
-            torch.Tensor [batch size, 2 * num_observations_per_parameter] -- Batch of observations.
+            Batch of observations of shape
+             (batch size, 2 * num_xs_per_parameter)
         """
         # Run simulator in NumPy.
-        if isinstance(parameters, torch.Tensor):
-            parameters = utils.tensor2numpy(parameters)
+        if isinstance(theta, Tensor):
+            theta = utils.tensor2numpy(theta)
 
-        # If we have a single parameter then view it as a batch of one.
-        if parameters.ndim == 1:
-            return self.simulate(parameters[np.newaxis, :])[0]
+        # If we have a single theta then view it as a batch of one.
+        if theta.ndim == 1:
+            return self.simulate(theta[np.newaxis, :])[0]
 
-        num_simulations = parameters.shape[0]
+        num_simulations = theta.shape[0]
 
         # Keep track of total simulations.
         self.num_total_simulations += num_simulations
 
-        # Run simulator to generate self._num_observations_per_parameter
-        # observations from a 2D Gaussian parameterized by the 5 given parameters.
-        m0, m1, s0, s1, r = self._unpack_params(parameters)
+        # Run simulator to generate self._num_xs_per_parameter
+        # observations from a 2D Gaussian parameterized by the 5 values in theta.
+        m0, m1, s0, s1, r = self._unpack_params(theta)
 
-        us = np.random.randn(num_simulations, self._num_observations_per_parameter, 2)
-        observations = np.empty_like(us)
+        us = np.random.randn(num_simulations, self._num_xs_per_parameter, 2)
+        xs = np.empty_like(us)
 
-        observations[:, :, 0] = s0 * us[:, :, 0] + m0
-        observations[:, :, 1] = (
-            s1 * (r * us[:, :, 0] + np.sqrt(1.0 - r ** 2) * us[:, :, 1]) + m1
-        )
+        xs[:, :, 0] = s0 * us[:, :, 0] + m0
+        xs[:, :, 1] = s1 * (r * us[:, :, 0] + np.sqrt(1.0 - r ** 2) * us[:, :, 1]) + m1
 
         mean, std = self._get_observation_normalization_parameters()
         return (
-            torch.Tensor(
-                observations.reshape(
-                    [num_simulations, 2 * self._num_observations_per_parameter]
-                )
+            torch.tensor(
+                xs.reshape([num_simulations, 2 * self._num_xs_per_parameter]),
+                dtype=torch.float32,
             )
             - mean.reshape(1, -1)
         ) / std.reshape(1, -1)
 
-    def log_prob(self, observations, parameters):
-        """Log likelihood of observations given parameters. 
+    def log_prob(self, x: Tensor, theta: Tensor):
+        """Log likelihood of observations given parameter sets theta.
         
-        Likelihood is proportional to a product of self._num_observations_per_parameter 2D
-        Gaussians and so log likelihood can be computed analytically.
+        Likelihood is proportional to a product of self._num_xs_per_parameter
+         2D Gaussians and so log likelihood can be computed analytically.
         
-        Arguments:
-            observations {torch.Tensor} [batch_size, observation_dim] -- Batch of observations.
-            parameters {torch.Tensor} [batch_size, parameter_dim] -- Batch of parameters.
+        Args:
+            x: Batch of observations of shape (batch_size, observation_dim).
+            theta: Batch of parameters (batch_size, parameter_dim).
         
         Returns:
-            torch.Tensor [batch_size] -- [Log likelihood log p(x | theta) for each item in the batch.
+            L: Log likelihood log p(x | theta) for each item in the batch.
         """
 
-        if isinstance(parameters, torch.Tensor):
-            parameters = utils.tensor2numpy(parameters)
+        if isinstance(theta, Tensor):
+            theta = utils.tensor2numpy(theta)
 
-        if isinstance(observations, torch.Tensor):
-            observations = utils.tensor2numpy(observations)
+        if isinstance(x, Tensor):
+            x = utils.tensor2numpy(x)
 
-        if observations.ndim == 1 and parameters.ndim == 1:
-            observations, parameters = (
-                observations.reshape(1, -1),
-                parameters.reshape(1, -1),
+        if x.ndim == 1 and theta.ndim == 1:
+            x, theta = (
+                x.reshape(1, -1),
+                theta.reshape(1, -1),
             )
 
-        m0, m1, s0, s1, r = self._unpack_params(parameters)
+        m0, m1, s0, s1, r = self._unpack_params(theta)
         logdet = np.log(s0) + np.log(s1) + 0.5 * np.log(1.0 - r ** 2)
 
-        observations = observations.reshape(
-            [observations.shape[0], self._num_observations_per_parameter, 2]
-        )
-        us = np.empty_like(observations)
+        x = x.reshape([x.shape[0], self._num_xs_per_parameter, 2])
+        us = np.empty_like(x)
 
-        us[:, :, 0] = (observations[:, :, 0] - m0) / s0
-        us[:, :, 1] = (observations[:, :, 1] - m1 - s1 * r * us[:, :, 0]) / (
+        us[:, :, 0] = (x[:, :, 0] - m0) / s0
+        us[:, :, 1] = (x[:, :, 1] - m1 - s1 * r * us[:, :, 0]) / (
             s1 * np.sqrt(1.0 - r ** 2)
         )
-        us = us.reshape([us.shape[0], 2 * self._num_observations_per_parameter])
+        us = us.reshape([us.shape[0], 2 * self._num_xs_per_parameter])
 
         L = (
             np.sum(scipy.stats.norm.logpdf(us), axis=1)
-            - self._num_observations_per_parameter * logdet[:, 0]
+            - self._num_xs_per_parameter * logdet[:, 0]
         )
 
         return L

--- a/sbi/simulators/simulator.py
+++ b/sbi/simulators/simulator.py
@@ -1,3 +1,6 @@
+# XXX: this class is deprecated and used only by NonLinearGaussian class
+# XXX: we should rewrite nonlinear Gaussian and remove this class because
+# XXX: we wanted to treat simulators as functions alltogether.
 class Simulator:
     """
     Base class for all simulator models.
@@ -6,16 +9,17 @@ class Simulator:
     def __init__(self):
         self.num_total_simulations = 0
 
-    def __call__(self, parameters):
-        """Simualte a batch of parameters. 
+    def __call__(self, theta):
+        """Simulate a batch of parameters theta.
         
-        Core method which returns a torch.Tensor batch of observations given a
-        torch.Tensor batch of parameters. 
+        Core method which returns a Tensor batch of observations given a
+        torch.Tensor batch of parameters theta.
 
-        Set up to be called as function because we want the simulator to be function at some point.  
+        Set up to be called as function because we want the simulator to be function at
+         some point.
 
-        Arguments:
-            parameters {torch.Tensor} -- batch of parameters.
+        Args:
+            theta: batch of parameters.
         
         Raises:
             NotImplementedError: [description]
@@ -25,19 +29,19 @@ class Simulator:
     @property
     def parameter_dim(self):
         """
-        Dimension of parameters for simulator.
+        Dimension of a single parameter set theta for simulator.
 
-        :return: int parameter_dim
+        :return: int theta_dim
         """
         raise NotImplementedError
 
     @property
     def observation_dim(self):
         """
-        Dimension of observations for simulator.
+        Dimension of a single simulation output x.
         TODO: decide whether observation_dim always corresponds to dimension of summary.
 
-        :return: int observation_dim
+        :return: int x_dim
         """
         raise NotImplementedError
 

--- a/sbi/utils/__init__.py
+++ b/sbi/utils/__init__.py
@@ -4,8 +4,8 @@ from sbi.utils.logging import summarize
 from sbi.utils.mmd import biased_mmd, unbiased_mmd_squared
 from sbi.utils.plot import plot_hist_marginals, plot_hist_marginals_pair
 from sbi.utils.sbiutils import (
-    Normalize,
-    match_shapes_of_inputs_and_contexts,
+    Standardize,
+    match_shapes_of_theta_and_x,
     sample_posterior_within_prior,
 )
 from sbi.utils.torchutils import (

--- a/sbi/utils/get_nn_models.py
+++ b/sbi/utils/get_nn_models.py
@@ -17,7 +17,7 @@ from sbi.utils.torchutils import create_alternating_binary_mask
 def posterior_nn(
     model: str,
     prior: torch.distributions.Distribution,
-    context: torch.Tensor,
+    x_o: torch.Tensor,
     embedding: Optional[torch.nn.Module] = None,
     hidden_features: int = 50,
     mdn_num_components: int = 20,
@@ -30,7 +30,7 @@ def posterior_nn(
     Args:
         model: Model, one of maf / mdn / made / nsf
         prior: Prior distribution
-        context: Observation
+        x_o: Observation
         embedding: Embedding network
         hidden_features: For all, number of hidden features
         mdn_num_components: For MDNs only, number of components
@@ -46,18 +46,18 @@ def posterior_nn(
         shift=-mean / std, scale=1 / std
     )
 
-    parameter_dim = prior.sample([1]).shape[1]
+    theta_dim = prior.sample([1]).shape[1]
 
-    context = utils.torchutils.atleast_2d(context)
-    observation_dim = torch.tensor([context.shape[1:]])
+    x_o = utils.torchutils.atleast_2d(x_o)
+    x_o_dim = torch.tensor([x_o.shape[1:]])
 
     if model == "mdn":
         neural_net = MultivariateGaussianMDN(
-            features=parameter_dim,
-            context_features=observation_dim,
+            features=theta_dim,
+            context_features=x_o_dim,
             hidden_features=hidden_features,
             hidden_net=nn.Sequential(
-                nn.Linear(observation_dim, hidden_features),
+                nn.Linear(x_o_dim, hidden_features),
                 nn.ReLU(),
                 nn.Dropout(p=0.0),
                 nn.Linear(hidden_features, hidden_features),
@@ -72,9 +72,9 @@ def posterior_nn(
     elif model == "made":
         transform = standardizing_transform
         distribution = distributions_.MADEMoG(
-            features=parameter_dim,
+            features=theta_dim,
             hidden_features=hidden_features,
-            context_features=observation_dim,
+            context_features=x_o_dim,
             num_blocks=made_num_blocks,
             num_mixture_components=made_num_mixture_components,
             use_residual_blocks=True,
@@ -92,9 +92,9 @@ def posterior_nn(
                 transforms.CompositeTransform(
                     [
                         transforms.MaskedAffineAutoregressiveTransform(
-                            features=parameter_dim,
+                            features=theta_dim,
                             hidden_features=hidden_features,
-                            context_features=observation_dim,
+                            context_features=x_o_dim,
                             num_blocks=2,
                             use_residual_blocks=False,
                             random_mask=False,
@@ -102,7 +102,7 @@ def posterior_nn(
                             dropout_probability=0.0,
                             use_batch_norm=True,
                         ),
-                        transforms.RandomPermutation(features=parameter_dim),
+                        transforms.RandomPermutation(features=theta_dim),
                     ]
                 )
                 for _ in range(flow_num_transforms)
@@ -111,7 +111,7 @@ def posterior_nn(
 
         transform = transforms.CompositeTransform([standardizing_transform, transform,])
 
-        distribution = distributions_.StandardNormal((parameter_dim,))
+        distribution = distributions_.StandardNormal((theta_dim,))
         neural_net = flows.Flow(transform, distribution, embedding)
 
     elif model == "nsf":
@@ -121,13 +121,13 @@ def posterior_nn(
                     [
                         transforms.PiecewiseRationalQuadraticCouplingTransform(
                             mask=create_alternating_binary_mask(
-                                features=parameter_dim, even=(i % 2 == 0)
+                                features=theta_dim, even=(i % 2 == 0)
                             ),
                             transform_net_create_fn=lambda in_features, out_features: nets.ResidualNet(
                                 in_features=in_features,
                                 out_features=out_features,
                                 hidden_features=hidden_features,
-                                context_features=observation_dim,
+                                context_features=x_o_dim,
                                 num_blocks=2,
                                 activation=torch.relu,
                                 dropout_probability=0.0,
@@ -138,7 +138,7 @@ def posterior_nn(
                             tail_bound=3.0,
                             apply_unconditional_transform=False,
                         ),
-                        transforms.LULinear(parameter_dim, identity_init=True),
+                        transforms.LULinear(theta_dim, identity_init=True),
                     ]
                 )
                 for i in range(flow_num_transforms)
@@ -147,7 +147,7 @@ def posterior_nn(
 
         transform = transforms.CompositeTransform([standardizing_transform, transform,])
 
-        distribution = distributions_.StandardNormal((parameter_dim,))
+        distribution = distributions_.StandardNormal((theta_dim,))
         neural_net = flows.Flow(transform, distribution, embedding)
 
     else:
@@ -159,7 +159,7 @@ def posterior_nn(
 def likelihood_nn(
     model: str,
     prior: torch.distributions.Distribution,
-    context: torch.Tensor,
+    x_o: torch.Tensor,
     embedding: Optional[torch.nn.Module] = None,
     hidden_features: int = 50,
     mdn_num_components: int = 20,
@@ -172,7 +172,7 @@ def likelihood_nn(
     Args:
         model: Model, one of maf / mdn / made / nsf
         prior: Prior distribution
-        context: Observation
+        x_o: Observation
         embedding: Embedding network
         hidden_features: For all, number of hidden features
         mdn_num_components: For MDNs only, number of components
@@ -183,19 +183,19 @@ def likelihood_nn(
     Returns:
         Neural network
     """
-    parameter_dim = prior.sample([1]).shape[1]
-    if context.dim() == 1:
-        observation_dim = torch.tensor([context.shape]).item()
+    theta_dim = prior.sample([1]).shape[1]
+    if x_o.dim() == 1:
+        x_o_dim = torch.tensor([x_o.shape]).item()
     else:
-        observation_dim = torch.tensor([context.shape[1]]).item()
+        x_o_dim = torch.tensor([x_o.shape[1]]).item()
 
     if model == "mdn":
         neural_net = MultivariateGaussianMDN(
-            features=observation_dim,
-            context_features=parameter_dim,
+            features=x_o_dim,
+            context_features=theta_dim,
             hidden_features=hidden_features,
             hidden_net=nn.Sequential(
-                nn.Linear(parameter_dim, hidden_features),
+                nn.Linear(theta_dim, hidden_features),
                 nn.BatchNorm1d(hidden_features),
                 nn.ReLU(),
                 nn.Dropout(p=0.0),
@@ -212,9 +212,9 @@ def likelihood_nn(
 
     elif model == "made":
         neural_net = MixtureOfGaussiansMADE(
-            features=observation_dim,
+            features=x_o_dim,
             hidden_features=hidden_features,
-            context_features=parameter_dim,
+            context_features=theta_dim,
             num_blocks=made_num_blocks,
             num_mixture_components=made_num_mixture_components,
             use_residual_blocks=True,
@@ -231,9 +231,9 @@ def likelihood_nn(
                 transforms.CompositeTransform(
                     [
                         transforms.MaskedAffineAutoregressiveTransform(
-                            features=observation_dim,
+                            features=x_o_dim,
                             hidden_features=hidden_features,
-                            context_features=parameter_dim,
+                            context_features=theta_dim,
                             num_blocks=2,
                             use_residual_blocks=False,
                             random_mask=False,
@@ -241,13 +241,13 @@ def likelihood_nn(
                             dropout_probability=0.0,
                             use_batch_norm=True,
                         ),
-                        transforms.RandomPermutation(features=observation_dim),
+                        transforms.RandomPermutation(features=x_o_dim),
                     ]
                 )
                 for _ in range(flow_num_transforms)
             ]
         )
-        distribution = distributions_.StandardNormal((observation_dim,))
+        distribution = distributions_.StandardNormal((x_o_dim,))
         neural_net = flows.Flow(transform, distribution, embedding)
 
     elif model == "nsf":
@@ -257,13 +257,13 @@ def likelihood_nn(
                     [
                         transforms.PiecewiseRationalQuadraticCouplingTransform(
                             mask=create_alternating_binary_mask(
-                                features=observation_dim, even=(i % 2 == 0)
+                                features=x_o_dim, even=(i % 2 == 0)
                             ),
                             transform_net_create_fn=lambda in_features, out_features: nets.ResidualNet(
                                 in_features=in_features,
                                 out_features=out_features,
                                 hidden_features=hidden_features,
-                                context_features=parameter_dim,
+                                context_features=theta_dim,
                                 num_blocks=2,
                                 activation=torch.relu,
                                 dropout_probability=0.0,
@@ -274,13 +274,13 @@ def likelihood_nn(
                             tail_bound=3.0,
                             apply_unconditional_transform=False,
                         ),
-                        transforms.LULinear(observation_dim, identity_init=True),
+                        transforms.LULinear(x_o_dim, identity_init=True),
                     ]
                 )
                 for i in range(flow_num_transforms)
             ]
         )
-        distribution = distributions_.StandardNormal((observation_dim,))
+        distribution = distributions_.StandardNormal((x_o_dim,))
         neural_net = flows.Flow(transform, distribution)
 
     else:
@@ -292,7 +292,7 @@ def likelihood_nn(
 def classifier_nn(
     model,
     prior: torch.distributions.Distribution,
-    context: torch.Tensor,
+    x_o: torch.Tensor,
     hidden_features: int = 50,
 ) -> torch.nn.Module:
     """Neural classifier
@@ -300,22 +300,22 @@ def classifier_nn(
     Args:
         model: Model, one of linear / mlp / resnet
         prior: Prior distribution
-        context: Observation
+        x_o: Observation
         hidden_features: For all, number of hidden features
 
     Returns:
         Neural network
     """
-    parameter_dim = prior.sample([1]).shape[1]
-    context = utils.torchutils.atleast_2d(context)
-    observation_dim = torch.tensor([context.shape[1:]])
+    theta_dim = prior.sample([1]).shape[1]
+    x_o = utils.torchutils.atleast_2d(x_o)
+    x_o_dim = torch.tensor([x_o.shape[1:]])
 
     if model == "linear":
-        neural_net = nn.Linear(parameter_dim + observation_dim, 1)
+        neural_net = nn.Linear(theta_dim + x_o_dim, 1)
 
     elif model == "mlp":
         neural_net = nn.Sequential(
-            nn.Linear(parameter_dim + observation_dim, hidden_features),
+            nn.Linear(theta_dim + x_o_dim, hidden_features),
             nn.BatchNorm1d(hidden_features),
             nn.ReLU(),
             nn.Linear(hidden_features, hidden_features),
@@ -326,7 +326,7 @@ def classifier_nn(
 
     elif model == "resnet":
         neural_net = nets.ResidualNet(
-            in_features=parameter_dim + observation_dim,
+            in_features=theta_dim + x_o_dim,
             out_features=1,
             hidden_features=hidden_features,
             context_features=None,

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -1,9 +1,10 @@
 import time
 import warnings
-from typing import Tuple, Sequence, Union
+from typing import Sequence, Tuple, Union
 
 import torch
 import torch.nn as nn
+
 import sbi.utils as utils
 
 
@@ -110,15 +111,15 @@ def sample_posterior_within_prior(
 ) -> Tuple[torch.Tensor, float]:
     r"""Return samples from a posterior $p(\theta|x)$ within the support of the prior
      via rejection sampling.
-    
+
     This is relevant for snpe methods and flows for which the posterior tends to have
      mass outside the prior boundaries.
-    
-    This function uses rejection sampling with samples from posterior, to do two things: 
-        1) obtain posterior samples within the prior support. 
+
+    This function uses rejection sampling with samples from posterior, to do two things:
+        1) obtain posterior samples within the prior support.
         2) calculate the fraction of accepted samples as a proxy for correcting the
          density during evaluation of the posterior.
-    
+
     Args:
         posterior_nn: neural net representing the posterior
         prior: torch distribution prior
@@ -126,7 +127,7 @@ def sample_posterior_within_prior(
         num_samples: number of sample to generate
         patience: upper time bound in minutes, in case sampling takes too long
          due to strong leakage
-    
+
     Returns:
         Accepted samples, and estimated acceptance
          probability
@@ -165,7 +166,9 @@ def sample_posterior_within_prior(
 
     if num_remaining > 0:
         warnings.warn(
-            f"Beware: Rejection sampling resulted in only {samples.shape[0]} samples within patience of {patience} min. Consider having more patience, leakage is {1-acceptance_prob}"
+            f"""Beware: Rejection sampling resulted in only {samples.shape[0]} samples
+            within patience of {patience} min. Consider having more patience, leakage
+            is {1-acceptance_prob}."""
         )
 
     return samples, acceptance_prob

--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -190,9 +190,15 @@ class BoxUniform(Independent):
     ):
         """Multidimensional uniform distribution defined on a box.
         
-        A `Uniform` distribution initialized with e.g. a parameter vector low or high of length 3 will result in a /batch/ dimension of length 3. A log_prob evaluation will then output three numbers, one for each of the independent Uniforms in the batch. Instead, a `BoxUniform` initialized in the same way has three /event/ dimensions, and returns a scalar log_prob corresponding to whether the evaluated point is in the box defined by low and high or outside. 
+        A `Uniform` distribution initialized with e.g. a parameter vector low or high of
+         length 3 will result in a /batch/ dimension of length 3. A log_prob evaluation
+         will then output three numbers, one for each of the independent Uniforms in
+         the batch. Instead, a `BoxUniform` initialized in the same way has three
+         /event/ dimensions, and returns a scalar log_prob corresponding to whether
+         the evaluated point is in the box defined by low and high or outside.
     
-        Refer to torch.distributions.Uniform and torch.distributions.Independent for further documentation.
+        Refer to torch.distributions.Uniform and torch.distributions.Independent for
+         further documentation.
     
         Args:
             low: lower range (inclusive).
@@ -204,33 +210,39 @@ class BoxUniform(Independent):
         super().__init__(Uniform(low=low, high=high), reinterpreted_batch_ndims)
 
 
-def ensure_parameter_batched(parameter: Tensor) -> Tensor:
+def ensure_theta_batched(theta: Tensor) -> Tensor:
     """
-    Return tensors that both have the same tensor.ndim
-    Function also covers cases where parameters is ndim=1 and observation ndim=2
-    Also, we have specialized check for multi-dimensional data x, e.g. images.
-    """
+    Return theta that has a batch dimension, i.e. has shape (1, shape_of_single_theta)
 
-    # => ensure parameters have shape (1, dim_parameter)
-    if parameter.ndim == 1:
-        parameter = parameter.unsqueeze(0)
-
-    return parameter
-
-
-def ensure_observation_batched(observation: Tensor) -> Tensor:
-    """
-    Return tensors that both have the same tensor.ndim
-    Function also covers cases where parameters is ndim=1 and observation ndim=2
-    Also, we have specialized check for multi-dimensional data x, e.g. images.
+     Args:
+         theta: parameter set of n parameters of shape (n) or (1,n)
+     Returns:
+         Batched parameter set theta
     """
 
-    # => ensure observation has shape (1, dim_observation). If shape[0] > 1, we assume that the batch-dimension
-    # is missing, even though ndim might be >1 (e.g. for images)
-    if observation.shape[0] > 1 or observation.ndim == 1:
-        observation = observation.unsqueeze(0)
+    # => ensure theta has shape (1, dim_parameter)
+    if theta.ndim == 1:
+        theta = theta.unsqueeze(0)
 
-    return observation
+    return theta
+
+
+def ensure_x_batched(x: Tensor) -> Tensor:
+    """
+    Return x that has a batch dimension, i.e. has shape (1, shape_of_single_x)
+
+    Args:
+         x: simulation output of shape (n) or (1,n)
+     Returns:
+         Batched simulation output x
+    """
+
+    # ensure x has shape (1, shape_of_single_x). If shape[0] > 1, we assume that
+    # the batch-dimension is missing, even though ndim might be >1 (e.g. for images)
+    if x.shape[0] > 1 or x.ndim == 1:
+        x = x.unsqueeze(0)
+
+    return x
 
 
 def atleast_2d(*arys: Union[np.array, Tensor]) -> Union[Tensor, List[Tensor]]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+from torch import manual_seed
+
+# Seed for fixture. Change to change random state of all seeded tests.
+seed = 0
+
+
+# Fixture will be visible in all test files.
+@pytest.fixture(scope="module")
+def set_seed():
+    manual_seed(seed)

--- a/tests/linearGaussian_simulator_test.py
+++ b/tests/linearGaussian_simulator_test.py
@@ -6,8 +6,8 @@ from sbi.simulators.linear_gaussian import linear_gaussian
 
 @pytest.mark.parametrize("D, N", ((1, 10000), (5, 100000)))
 def test_linearGaussian_simulator(D: int, N: int):
-    """Test linear Gaussian simulator. 
-    
+    """Test linear Gaussian simulator.
+
     Args:
         D: parameter dimension
         N: number of samples

--- a/tests/linearGaussian_simulator_test.py
+++ b/tests/linearGaussian_simulator_test.py
@@ -16,18 +16,18 @@ def test_linearGaussian_simulator(D: int, N: int):
     true_parameters = torch.zeros(D)
     num_simulations = N
     parameters = true_parameters.repeat(num_simulations).reshape(-1, D)
-    observations = linear_gaussian(parameters)
+    xs = linear_gaussian(parameters)
 
     # Check shapes.
     assert parameters.shape == torch.Size(
         (N, D)
     ), f"wrong shape of parameters: {parameters.shape} != {torch.Size((N, D))}"
-    assert observations.shape == torch.Size([N, D])
+    assert xs.shape == torch.Size([N, D])
 
     # Chec mean and std.
     assert torch.allclose(
-        observations.mean(axis=0), true_parameters, atol=5e-2
-    ), f"Expected mean of zero, obtained {observations.mean(axis=0)}"
+        xs.mean(axis=0), true_parameters, atol=5e-2
+    ), f"Expected mean of zero, obtained {xs.mean(axis=0)}"
     assert torch.allclose(
-        observations.std(axis=0), torch.ones(D), atol=5e-2
-    ), f"Expected std of one, obtained {observations.std(axis=0)}"
+        xs.std(axis=0), torch.ones(D), atol=5e-2
+    ), f"Expected std of one, obtained {xs.std(axis=0)}"

--- a/tests/linearGaussian_snl_test.py
+++ b/tests/linearGaussian_snl_test.py
@@ -51,15 +51,18 @@ def test_snl_on_linearGaussian_api(num_dim: int):
 @pytest.mark.slow
 @pytest.mark.parametrize("num_dim", (1, 3))
 @pytest.mark.parametrize("prior_str", ("uniform", "gaussian"))
-def test_snl_on_linearGaussian_based_on_mmd(num_dim: int, prior_str: str):
+def test_snl_on_linearGaussian_based_on_mmd(num_dim: int, prior_str: str, set_seed):
     """Test SNL on linear Gaussian, comparing to ground truth posterior via MMD.
 
     NOTE: The MMD threshold is calculated based on a number of test runs and taking the
     mean plus 2 stds.
 
+    This test is seeded using the set_seed fixture defined in tests/conftest.py.
+
     Args:
         num_dim: parameter dimension of the gaussian model
         prior_str: one of "gaussian" or "uniform"
+        set_seed: fixture for manual seeding, see tests/conftest.py
     """
 
     x_o = torch.zeros((1, num_dim))
@@ -107,12 +110,16 @@ def test_snl_on_linearGaussian_based_on_mmd(num_dim: int, prior_str: str):
 
 
 @pytest.mark.slow
-def test_multi_round_snl_on_linearGaussian_based_on_mmd():
+def test_multi_round_snl_on_linearGaussian_based_on_mmd(set_seed):
     """Test SNL on linear Gaussian, comparing to ground truth posterior via MMD.
 
     NOTE: The MMD threshold is calculated based on a number of test runs and taking the
     mean plus 2 stds.
+    
+    This test is seeded using the set_seed fixture defined in tests/conftest.py.
 
+    Args:
+        set_seed: fixture for manual seeding, see tests/conftest.py
     """
 
     num_dim = 3
@@ -164,15 +171,18 @@ def test_multi_round_snl_on_linearGaussian_based_on_mmd():
         ("slice", "uniform"),
     ),
 )
-def test_snl_posterior_correction(mcmc_method: str, prior_str: str):
+def test_snl_posterior_correction(mcmc_method: str, prior_str: str, set_seed):
     """Test SNL on linear Gaussian, comparing to ground truth posterior via MMD.
 
     NOTE: The mmd threshold is calculated based on a number of test runs and taking the
     mean plus 2 stds.
 
+    This test is seeded using the set_seed fixture defined in tests/conftest.py.
+
     Args:
         mcmc_method: which mcmc method to use for sampling
         prior_str: use gaussian or uniform prior
+        set_seed: fixture for manual seeding, see tests/conftest.py
     """
 
     num_dim = 2

--- a/tests/linearGaussian_snl_test.py
+++ b/tests/linearGaussian_snl_test.py
@@ -2,23 +2,22 @@ import pytest
 import torch
 from torch import distributions
 
+import sbi.utils as utils
 from sbi.inference.snl.snl import SNL
 from sbi.simulators.linear_gaussian import (
     get_true_posterior_samples_linear_gaussian_mvn_prior,
     get_true_posterior_samples_linear_gaussian_uniform_prior,
     linear_gaussian,
 )
-import sbi.utils as utils
 from sbi.simulators.simutils import prepare_sbi_problem
-
-torch.manual_seed(0)
 
 
 @pytest.mark.parametrize("num_dim", (1, 3))
 def test_snl_on_linearGaussian_api(num_dim: int):
     """Test API for inference on linear Gaussian model using SNL.
-    
-    Avoids expensive computations by training on few simulations and generating few posterior samples.
+
+    Avoids expensive computations by training on few simulations and generating few
+    posterior samples.
 
     Args:
         num_dim: parameter dimension of the gaussian model
@@ -55,8 +54,9 @@ def test_snl_on_linearGaussian_api(num_dim: int):
 def test_snl_on_linearGaussian_based_on_mmd(num_dim: int, prior_str: str):
     """Test SNL on linear Gaussian, comparing to ground truth posterior via MMD.
 
-    NOTE: The MMD threshold is calculated based on a number of test runs and taking the mean plus 2 stds. 
-    
+    NOTE: The MMD threshold is calculated based on a number of test runs and taking the
+    mean plus 2 stds.
+
     Args:
         num_dim: parameter dimension of the gaussian model
         prior_str: one of "gaussian" or "uniform"
@@ -110,7 +110,8 @@ def test_snl_on_linearGaussian_based_on_mmd(num_dim: int, prior_str: str):
 def test_multi_round_snl_on_linearGaussian_based_on_mmd():
     """Test SNL on linear Gaussian, comparing to ground truth posterior via MMD.
 
-    NOTE: The MMD threshold is calculated based on a number of test runs and taking the mean plus 2 stds. 
+    NOTE: The MMD threshold is calculated based on a number of test runs and taking the
+    mean plus 2 stds.
 
     """
 
@@ -166,7 +167,8 @@ def test_multi_round_snl_on_linearGaussian_based_on_mmd():
 def test_snl_posterior_correction(mcmc_method: str, prior_str: str):
     """Test SNL on linear Gaussian, comparing to ground truth posterior via MMD.
 
-    NOTE: The mmd threshold is calculated based on a number of test runs and taking the mean plus 2 stds.
+    NOTE: The mmd threshold is calculated based on a number of test runs and taking the
+    mean plus 2 stds.
 
     Args:
         mcmc_method: which mcmc method to use for sampling

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -2,6 +2,8 @@ import pytest
 import torch
 from torch import distributions
 
+import sbi.utils as utils
+import tests.utils_for_testing.linearGaussian_logprob as test_utils
 from sbi.inference.snpe.snpe_b import SnpeB
 from sbi.inference.snpe.snpe_c import SnpeC
 from sbi.simulators.linear_gaussian import (
@@ -9,11 +11,8 @@ from sbi.simulators.linear_gaussian import (
     get_true_posterior_samples_linear_gaussian_uniform_prior,
     linear_gaussian,
 )
-import sbi.utils as utils
-import tests.utils_for_testing.linearGaussian_logprob as test_utils
 from sbi.simulators.simutils import prepare_sbi_problem
 
-torch.manual_seed(0)
 
 # Running all combinations is excessive. The standard test is (3, "gaussian", "snpe_c"),
 # and we then vary only one parameter at a time to test single-D, uniform, and snpe-b.
@@ -203,7 +202,7 @@ def test_multi_round_snpe_on_linearGaussian_based_on_mmd(algorithm_str: str):
     ),
 )
 def test_apt_posterior_correction(sample_with_mcmc, mcmc_method, prior):
-    """Test that leakage correction applied to sampling works, with both MCMC and 
+    """Test that leakage correction applied to sampling works, with both MCMC and
     rejection."""
 
     num_dim = 2

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -27,9 +27,19 @@ from sbi.simulators.simutils import prepare_sbi_problem
     ),
 )
 def test_apt_on_linearGaussian_based_on_mmd(
-    num_dim: int, prior_str: str, algorithm_str: str, simulation_batch_size: int
+    num_dim: int,
+    prior_str: str,
+    algorithm_str: str,
+    simulation_batch_size: int,
+    set_seed,
 ):
-    """Test whether APT infers well a simple example where ground truth is available."""
+    """Test whether APT infers well a simple example where ground truth is available.
+
+    This test is seeded using the set_seed fixture defined in tests/conftest.py.
+
+    Args:
+        set_seed: fixture for manual seeding, see tests/conftest.py
+    """
 
     x_o = torch.zeros(1, num_dim)
     num_samples = 100
@@ -126,8 +136,14 @@ def test_apt_on_linearGaussian_based_on_mmd(
 
 # Test multi-round SNPE.
 @pytest.mark.parametrize("algorithm_str", ("snpe_b", "snpe_c"))
-def test_multi_round_snpe_on_linearGaussian_based_on_mmd(algorithm_str: str):
-    """Test whether APT infers well a simple example where ground truth is available."""
+def test_multi_round_snpe_on_linearGaussian_based_on_mmd(algorithm_str: str, set_seed):
+    """Test whether APT infers well a simple example where ground truth is available.
+
+    This test is seeded using the set_seed fixture defined in tests/conftest.py.
+
+    Args:
+        set_seed: fixture for manual seeding, see tests/conftest.py.
+    """
 
     num_dim = 3
     true_observation = torch.zeros((1, num_dim))
@@ -201,9 +217,15 @@ def test_multi_round_snpe_on_linearGaussian_based_on_mmd(algorithm_str: str):
         (False, "rejection", "uniform"),
     ),
 )
-def test_apt_posterior_correction(sample_with_mcmc, mcmc_method, prior):
+def test_apt_posterior_correction(sample_with_mcmc, mcmc_method, prior, set_seed):
     """Test that leakage correction applied to sampling works, with both MCMC and
-    rejection."""
+    rejection.
+
+    This test is seeded using the set_seed fixture defined in tests/conftest.py.
+
+    Args:
+        set_seed: fixture for manual seeding, see tests/conftest.py.
+    """
 
     num_dim = 2
 

--- a/tests/linearGaussian_sre_test.py
+++ b/tests/linearGaussian_sre_test.py
@@ -45,7 +45,7 @@ def test_sre_on_linearGaussian_api(num_dim: int):
 
     posterior = infer(num_rounds=1, num_simulations_per_round=1000)
 
-    _ = posterior.sample(num_samples=10, num_chains=2)
+    posterior.sample(num_samples=10, num_chains=2)
 
     # XXX log_prob is not implemented yet for SRE
     # posterior.log_prob(samples)
@@ -62,16 +62,19 @@ def test_sre_on_linearGaussian_api(num_dim: int):
     ),
 )
 def test_sre_on_linearGaussian_based_on_mmd(
-    num_dim: int, prior_str: str, classifier_loss: str
+    num_dim: int, prior_str: str, classifier_loss: str, set_seed,
 ):
     """Test MMD accuracy of inference with SRE on linear Gaussian model.
 
     NOTE: The mmd threshold is calculated based on a number of test runs and taking the
     mean plus 2 stds.
 
+    This test is seeded using the set_seed fixture defined in tests/conftest.py.
+
     Args:
         num_dim: parameter dimension of the gaussian model
         prior_str: one of "gaussian" or "uniform"
+        set_seed: fixture for manual seeding, see tests/conftest.py
     """
 
     x_o = torch.zeros(1, num_dim)
@@ -150,12 +153,15 @@ def test_sre_on_linearGaussian_based_on_mmd(
         ("slice", "uniform"),
     ),
 )
-def test_sre_posterior_correction(mcmc_method: str, prior_str: str):
+def test_sre_posterior_correction(mcmc_method: str, prior_str: str, set_seed):
     """Test leakage correction both for MCMC and rejection sampling.
+
+    This test is seeded using the set_seed fixture defined in tests/conftest.py.
 
     Args:
         mcmc_method: which mcmc method to use for sampling
         prior_str: one of "gaussian" or "uniform"
+        set_seed: fixture for manual seeding, see tests/conftest.py
     """
 
     num_dim = 2

--- a/tests/nonlinearGaussian_snpe_c_test.py
+++ b/tests/nonlinearGaussian_snpe_c_test.py
@@ -7,12 +7,11 @@ from sbi.simulators.nonlinear_gaussian import (
     get_ground_truth_posterior_samples_nonlinear_gaussian,
     non_linear_gaussian,
 )
-from sbi.utils.torchutils import BoxUniform
 from sbi.simulators.simutils import prepare_sbi_problem
+from sbi.utils.torchutils import BoxUniform
 
 # use cpu by default
 torch.set_default_tensor_type("torch.FloatTensor")
-torch.manual_seed(0)
 
 
 @pytest.mark.slow
@@ -20,6 +19,7 @@ def test_nonlinearGaussian_based_on_mmd():
 
     # Ground truth parameters as specified in 'Sequential Neural Likelihood' paper.
     theta_o = torch.tensor([-0.7, -2.9, -1.0, -0.9, 0.6])
+    theta_dim = theta_o.numel()
     # ground truth observation using same seed as 'Sequential Neural Likelihood' paper.
     x_o = torch.tensor(
         [
@@ -33,10 +33,6 @@ def test_nonlinearGaussian_based_on_mmd():
             -2.42716377,
         ]
     )
-
-    # assume batch dims
-    theta_dim = theta_o.shape[0]
-    x_o_dim = x_o.shape[0]
 
     prior = BoxUniform(low=-3 * torch.ones(theta_dim), high=3 * torch.ones(theta_dim),)
 

--- a/tests/nonlinearGaussian_snpe_c_test.py
+++ b/tests/nonlinearGaussian_snpe_c_test.py
@@ -15,7 +15,14 @@ torch.set_default_tensor_type("torch.FloatTensor")
 
 
 @pytest.mark.slow
-def test_nonlinearGaussian_based_on_mmd():
+def test_nonlinearGaussian_based_on_mmd(set_seed):
+    """Run inference with snpe-c and test against average mmd.
+
+    This test is seeded using the set_seed fixture defined in tests/conftest.py.
+
+    Args:
+        set_seed: fixture for manual seeding, see tests/conftest.py
+    """
 
     # Ground truth parameters as specified in 'Sequential Neural Likelihood' paper.
     theta_o = torch.tensor([-0.7, -2.9, -1.0, -0.9, 0.6])

--- a/tests/simulator_utils_test.py
+++ b/tests/simulator_utils_test.py
@@ -1,32 +1,34 @@
 from __future__ import annotations
 
-from typing import Callable, Union
+from typing import Callable, Optional, Union
+
+import numpy as np
 import pytest
 import torch
-from torch.distributions import Uniform, MultivariateNormal, Distribution
+from scipy.stats import beta, multivariate_normal, uniform
 from torch import Tensor
+from torch.distributions import Distribution, MultivariateNormal, Uniform
+
+from sbi.inference.snpe import SnpeC
+from sbi.simulators.linear_gaussian import linear_gaussian
 from sbi.simulators.simutils import (
+    CustomPytorchWrapper,
+    ScipyPytorchWrapper,
     prepare_sbi_problem,
     process_prior,
-    process_x_o,
     process_simulator,
-    ScipyPytorchWrapper,
-    CustomPytorchWrapper,
+    process_x_o,
     simulate_in_batches,
 )
-from scipy.stats import multivariate_normal, uniform, beta
-from sbi.simulators.linear_gaussian import linear_gaussian
-from sbi.utils.torchutils import BoxUniform
 from sbi.utils.get_nn_models import posterior_nn
-from sbi.inference.snpe import SnpeC
-import numpy as np
+from sbi.utils.torchutils import BoxUniform
 
 
 class UserNumpyUniform:
-    """User defined numpy uniform prior. 
-    
-    Used for testing to mimick a user-defined prior with valid .sample and .log_prob 
-    methods. 
+    """User defined numpy uniform prior.
+
+    Used for testing to mimick a user-defined prior with valid .sample and .log_prob
+    methods.
     """
 
     def __init__(self, lower: Tensor, upper: Tensor, return_numpy: bool = False):
@@ -243,7 +245,7 @@ def test_prepare_sbi_problem(
     Args:
         simulator: simulator function
         prior: prior as defined by the user (pytorch, scipy, custom)
-        x_o: data as defined by the user. 
+        x_o: data as defined by the user.
     """
 
     simulator, prior, x_o = prepare_sbi_problem(simulator, prior, x_o)
@@ -293,6 +295,4 @@ def test_inference_with_pilot_samples_many_samples():
 
     # Run inference.
     num_rounds, num_simulations_per_round = 2, 100
-    posterior = infer(
-        num_rounds=num_rounds, num_simulations_per_round=num_simulations_per_round
-    )
+    infer(num_rounds=num_rounds, num_simulations_per_round=num_simulations_per_round)

--- a/tests/torchutils_test.py
+++ b/tests/torchutils_test.py
@@ -8,6 +8,7 @@ import torchtestcase
 from sbi.utils import torchutils
 from tests.utils_for_testing.dkl import dkl_via_monte_carlo
 
+
 # XXX move to pytest? - investigate how to derive from TorchTestCase
 class TorchUtilsTest(torchtestcase.TorchTestCase):
     def test_split_leading_dim(self):

--- a/tests/torchutils_test.py
+++ b/tests/torchutils_test.py
@@ -107,17 +107,17 @@ def test_box_uniform_distribution():
 def test_ensure_batch_dim():
     # test if batch dimension is added when parameter is ndim==1
     t1 = torch.tensor([0.0, -1.0, 1.0])
-    t2 = torchutils.ensure_parameter_batched(t1)
+    t2 = torchutils.ensure_theta_batched(t1)
     assert t2.ndim == 2
 
     # test if batch dimension is added when observation is ndim==1
     t1 = torch.tensor([0.0, -1.0, 1.0])
-    t2 = torchutils.ensure_observation_batched(t1)
+    t2 = torchutils.ensure_x_batched(t1)
     assert t2.ndim == 2
 
     # then test if batch dimension is added when observation is ndim==2, e.g. an image
     t1 = torch.tensor([[1, 2, 3], [1, 2, 3]])
-    t2 = torchutils.ensure_observation_batched(t1)
+    t2 = torchutils.ensure_x_batched(t1)
     assert t2.ndim == 3
 
 

--- a/tests/utils_for_testing/linearGaussian_logprob.py
+++ b/tests/utils_for_testing/linearGaussian_logprob.py
@@ -80,6 +80,6 @@ def get_normalization_uniform_prior(
     )
 
     # Estimate acceptance ratio through rejection sampling.
-    acceptance_prob = posterior.get_leakage_correction(context=true_observation)
+    acceptance_prob = posterior.get_leakage_correction(x=true_observation)
 
     return posterior_likelihood_unnorm, posterior_likelihood_norm, acceptance_prob


### PR DESCRIPTION
## General outline
Refactor all variables to `theta`, `x`, `x_o`

## Limitations
- `context` and `inputs` are still used when the neural_net is called. This is part of pyknos or nflows and will have to go in another PR

## Further Details
### Handling of plural and singular:
- `x_o` is currently only used as in singular
- when variables are batched as `(N, size_of_a_single_theta_or_x)` with `N>1` we use `thetas` and `xs`
- when variables are batched as `(1, size_of_a_single_theta_or_x)` we use `theta` and `x`
- when variables are not batched, i.e. `(size_of_a_single_theta_or_x)` we also use `theta` and `x`
- when it is unclear which of the above cases apply (e.g. user inputs such as to `log_prob()` where our code can handle different cases), I decided on a "most reasonable scenario" and named them accordingly.
### Protected variables
- `self.x_o` in `Posterior` class is not protected anymore. Before: `self._true_observation`, now: `self.x_o`. Users might want to interact here (e.g. check the observation etc)
### Comments and docstrings
- comments are trimmed to 88 characters max (warnings not yet)
- docstrings always mention `p(theta, x)` to make the variable naming `theta` and `x` clear to the user