### PR TITLE
Check prior floattype

### DIFF
--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -90,7 +90,7 @@ class SnpeBase(NeuralInference, ABC):
         self._neural_posterior = Posterior(
             algorithm_family="snpe",
             neural_net=density_estimator,
-            prior=prior,
+            prior=self._prior,
             x_o=self._x_o,
             sample_with_mcmc=sample_with_mcmc,
             mcmc_method=mcmc_method,

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -86,6 +86,11 @@ class SnpeBase(NeuralInference, ABC):
             density_estimator = utils.posterior_nn(
                 model="maf", prior=self._prior, x_o=self._x_o,
             )
+        # else: check density estimator for valid prior etc.
+        # XXX: here, the user could sneak in an invalid prior and x_o by providing a
+        # density estimator with invalid .prior and .x_o, thus bypassing
+        # the input checks.
+
         # create the neural posterior which can sample(), log_prob()
         self._neural_posterior = Posterior(
             algorithm_family="snpe",

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -4,6 +4,7 @@ from typing import Sequence, Tuple, Union
 
 import torch
 import torch.nn as nn
+from torch import Tensor
 
 import sbi.utils as utils
 
@@ -27,9 +28,9 @@ class Standardize(nn.Module):
 def match_shapes_of_theta_and_x(
     theta: Union[Sequence[float], float],
     x: Union[Sequence[float], float],
-    x_o: torch.Tensor,
+    x_o: Tensor,
     correct_for_leakage: bool,
-) -> (torch.Tensor, torch.Tensor):
+) -> (Tensor, Tensor):
     r"""
     Formats parameters theta and simulation outputs x into shapes that can be processed
      by neural density estimators for the posterior $p(\theta|x)$.
@@ -105,10 +106,10 @@ def match_shapes_of_theta_and_x(
 def sample_posterior_within_prior(
     posterior_nn: torch.nn.Module,
     prior: torch.distributions.Distribution,
-    x: torch.Tensor,
+    x: Tensor,
     num_samples: int = 1,
     patience: int = 5,
-) -> Tuple[torch.Tensor, float]:
+) -> Tuple[Tensor, float]:
     r"""Return samples from a posterior $p(\theta|x)$ within the support of the prior
      via rejection sampling.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 from torch import manual_seed
 
 # Seed for fixture. Change to change random state of all seeded tests.
-seed = 0
+seed = 1
 
 
 # Fixture will be visible in all test files.


### PR DESCRIPTION
prior float type is not checked for `Distribution` priors. This will result in float type erros down in sbi if a user manages to define a PyTorch prior with return type `float64`. 

In this PR we add the corresponding checks, wrappers and tests. 

In this process we have noticed issue #135 

This PR fixes the checks and wraps a float64 prior into float32. issue #135 will be handled in a separate PR. 