### PR TITLE
Z score fix deterministic sims

### DIFF
--- a/sbi/inference/snpe/snpe_a.py
+++ b/sbi/inference/snpe/snpe_a.py
@@ -25,6 +25,7 @@ class SnpeA(SnpeBase):
         discard_prior_samples=False,
         summary_writer=None,
         device=None,
+        z_score_min_std: float = 1e-7,
     ):
         """SNPE-A
 
@@ -43,6 +44,8 @@ class SnpeA(SnpeBase):
                 density estimator for the posterior from scratch each round.
             discard_prior_samples: whether to discard prior samples from round
                 two onwards.
+            z_score_min_std: Minimum value of the standard deviation to use when
+                standardizing inputs. This is typically needed when some simulator outputs are deterministic or nearly so.
         """
 
         raise NotImplementedError
@@ -59,6 +62,7 @@ class SnpeA(SnpeBase):
             retrain_from_scratch_each_round=retrain_from_scratch_each_round,
             discard_prior_samples=discard_prior_samples,
             device=device,
+            z_score_min_std=z_score_min_std,
         )
 
     def _get_log_prob_proposal_posterior(self, theta, x, masks):

--- a/sbi/inference/snpe/snpe_b.py
+++ b/sbi/inference/snpe/snpe_b.py
@@ -26,6 +26,7 @@ class SnpeB(SnpeBase):
         discard_prior_samples=False,
         summary_writer=None,
         device=None,
+        z_score_min_std: float = 1e-7,
     ):
         r"""
 
@@ -46,6 +47,8 @@ class SnpeB(SnpeBase):
                 density estimator for the posterior from scratch each round.
             discard_prior_samples: whether to discard prior samples from round
                 two onwards.
+            z_score_min_std: Minimum value of the standard deviation to use when
+                standardizing inputs. This is typically needed when some simulator outputs are deterministic or nearly so.
         """
 
         super(SnpeB, self).__init__(
@@ -61,6 +64,7 @@ class SnpeB(SnpeBase):
             retrain_from_scratch_each_round=retrain_from_scratch_each_round,
             discard_prior_samples=discard_prior_samples,
             device=device,
+            z_score_min_std=z_score_min_std,
         )
 
     def _get_log_prob_proposal_posterior(

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -36,6 +36,7 @@ class SnpeBase(NeuralInference, ABC):
         sample_with_mcmc: bool = False,
         mcmc_method: str = "slice-np",
         summary_writer: Optional[SummaryWriter] = None,
+        z_score_min_std: float = 1e-7,
     ):
         """
         See NeuralInference docstring for all other arguments.
@@ -53,6 +54,8 @@ class SnpeBase(NeuralInference, ABC):
                 density estimator for the posterior from scratch each round.
             discard_prior_samples: whether to discard prior samples from round
                 two onwards.
+            z_score_min_std: Minimum value of the standard deviation to use when
+                standardizing inputs. This is typically needed when some simulator outputs are deterministic or nearly so.
         """
 
         super().__init__(
@@ -105,7 +108,7 @@ class SnpeBase(NeuralInference, ABC):
         # new embedding_net contains z-scoring
         if not isinstance(self._neural_posterior.neural_net, MultivariateGaussianMDN):
             embedding = nn.Sequential(
-                utils.Standardize(self.x_mean, self.x_std),
+                utils.Standardize(self.x_mean, self.x_std + z_score_min_std),
                 self._neural_posterior.neural_net._embedding_net,
             )
             self._neural_posterior.set_embedding_net(embedding)

--- a/sbi/inference/snpe/snpe_c.py
+++ b/sbi/inference/snpe/snpe_c.py
@@ -29,6 +29,7 @@ class SnpeC(SnpeBase):
         device=None,
         sample_with_mcmc=False,
         mcmc_method="slice-np",
+        z_score_min_std: float = 1e-7,
     ):
         r"""SNPE-C / APT
 
@@ -51,6 +52,8 @@ class SnpeC(SnpeBase):
             num_atoms: int
                 Number of atoms to use for classification.
                 If -1, use all other thetas in minibatch.
+            z_score_min_std: Minimum value of the standard deviation to use when
+                standardizing inputs. This is typically needed when some simulator outputs are deterministic or nearly so.
         """
 
         super(SnpeC, self).__init__(
@@ -68,6 +71,7 @@ class SnpeC(SnpeBase):
             device=device,
             sample_with_mcmc=sample_with_mcmc,
             mcmc_method=mcmc_method,
+            z_score_min_std=z_score_min_std,
         )
 
         assert isinstance(num_atoms, int), "Number of atoms must be an integer."


### PR DESCRIPTION
Just a simple fix with accompanying test.

Note that the test demonstrates that deterministic simulators lead to infinites in log prob posterior, which we currently catch with an assertion.

Bundling management of z-scoring into a method and reducing complexity of the API by merging  `num_pilot_sims` and `z_score_x` into a single argument will be the subject of a subsequent PR.