### PR TITLE
Local config for all users of vscode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ var/
 .installed.cfg
 *.egg
 
+# Virtual environment
+.sbi_env/
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ sbi/_version.py
 
 # System
 .DS_Store
-.vscode
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -86,3 +85,9 @@ target/
 *.out
 *.gz
 *.toc
+
+# IDEs (VSCode, etc.)
+.env
+
+# Class diagram
+*.pyns

--- a/.vscode/.ropeproject/config.py
+++ b/.vscode/.ropeproject/config.py
@@ -1,0 +1,114 @@
+# The default ``config.py``
+# flake8: noqa
+
+
+def set_prefs(prefs):
+    """This function is called before opening the project"""
+
+    # Specify which files and folders to ignore in the project.
+    # Changes to ignored resources are not added to the history and
+    # VCSs.  Also they are not returned in `Project.get_files()`.
+    # Note that ``?`` and ``*`` match all characters but slashes.
+    # '*.pyc': matches 'test.pyc' and 'pkg/test.pyc'
+    # 'mod*.pyc': matches 'test/mod1.pyc' but not 'mod/1.pyc'
+    # '.svn': matches 'pkg/.svn' and all of its children
+    # 'build/*.o': matches 'build/lib.o' but not 'build/sub/lib.o'
+    # 'build//*.o': matches 'build/lib.o' and 'build/sub/lib.o'
+    prefs['ignored_resources'] = ['*.pyc', '*~', '.ropeproject',
+                                  '.hg', '.svn', '_svn', '.git', '.tox']
+
+    # Specifies which files should be considered python files.  It is
+    # useful when you have scripts inside your project.  Only files
+    # ending with ``.py`` are considered to be python files by
+    # default.
+    # prefs['python_files'] = ['*.py']
+
+    # Custom source folders:  By default rope searches the project
+    # for finding source folders (folders that should be searched
+    # for finding modules).  You can add paths to that list.  Note
+    # that rope guesses project source folders correctly most of the
+    # time; use this if you have any problems.
+    # The folders should be relative to project root and use '/' for
+    # separating folders regardless of the platform rope is running on.
+    # 'src/my_source_folder' for instance.
+    # prefs.add('source_folders', 'src')
+
+    # You can extend python path for looking up modules
+    # prefs.add('python_path', '~/python/')
+
+    # Should rope save object information or not.
+    prefs['save_objectdb'] = True
+    prefs['compress_objectdb'] = False
+
+    # If `True`, rope analyzes each module when it is being saved.
+    prefs['automatic_soa'] = True
+    # The depth of calls to follow in static object analysis
+    prefs['soa_followed_calls'] = 0
+
+    # If `False` when running modules or unit tests "dynamic object
+    # analysis" is turned off.  This makes them much faster.
+    prefs['perform_doa'] = True
+
+    # Rope can check the validity of its object DB when running.
+    prefs['validate_objectdb'] = True
+
+    # How many undos to hold?
+    prefs['max_history_items'] = 32
+
+    # Shows whether to save history across sessions.
+    prefs['save_history'] = True
+    prefs['compress_history'] = False
+
+    # Set the number spaces used for indenting.  According to
+    # :PEP:`8`, it is best to use 4 spaces.  Since most of rope's
+    # unit-tests use 4 spaces it is more reliable, too.
+    prefs['indent_size'] = 4
+
+    # Builtin and c-extension modules that are allowed to be imported
+    # and inspected by rope.
+    prefs['extension_modules'] = []
+
+    # Add all standard c-extensions to extension_modules list.
+    prefs['import_dynload_stdmods'] = True
+
+    # If `True` modules with syntax errors are considered to be empty.
+    # The default value is `False`; When `False` syntax errors raise
+    # `rope.base.exceptions.ModuleSyntaxError` exception.
+    prefs['ignore_syntax_errors'] = False
+
+    # If `True`, rope ignores unresolvable imports.  Otherwise, they
+    # appear in the importing namespace.
+    prefs['ignore_bad_imports'] = False
+
+    # If `True`, rope will insert new module imports as
+    # `from <package> import <module>` by default.
+    prefs['prefer_module_from_imports'] = False
+
+    # If `True`, rope will transform a comma list of imports into
+    # multiple separate import statements when organizing
+    # imports.
+    prefs['split_imports'] = False
+
+    # If `True`, rope will remove all top-level import statements and
+    # reinsert them at the top of the module when making changes.
+    prefs['pull_imports_to_top'] = True
+
+    # If `True`, rope will sort imports alphabetically by module name instead
+    # of alphabetically by import statement, with from imports after normal
+    # imports.
+    prefs['sort_imports_alphabetically'] = False
+
+    # Location of implementation of
+    # rope.base.oi.type_hinting.interfaces.ITypeHintingFactory In general
+    # case, you don't have to change this value, unless you're an rope expert.
+    # Change this value to inject you own implementations of interfaces
+    # listed in module rope.base.oi.type_hinting.providers.interfaces
+    # For example, you can add you own providers for Django Models, or disable
+    # the search type-hinting in a class hierarchy, etc.
+    prefs['type_hinting_factory'] = (
+        'rope.base.oi.type_hinting.factory.default_type_hinting_factory')
+
+
+def project_opened(project):
+    """This function is called after opening the project"""
+    # Do whatever you like here!

--- a/.vscode/autodocstring.template
+++ b/.vscode/autodocstring.template
@@ -1,0 +1,28 @@
+{{! Google Docstring Template without types }}
+{{summaryPlaceholder}}
+
+{{extendedSummaryPlaceholder}}
+
+{{#parametersExist}}
+Args:
+{{#args}}
+    {{var}}: {{descriptionPlaceholder}}
+{{/args}}
+{{#kwargs}}
+    {{var}}: {{descriptionPlaceholder}}
+{{/kwargs}}
+{{/parametersExist}}
+
+{{#returnsExist}}
+Returns:
+{{#returns}}
+    {{typePlaceholder}}: {{descriptionPlaceholder}}
+{{/returns}}
+{{/returnsExist}}
+
+{{#yieldsExist}}
+Yields:
+{{#yields}}
+    {{typePlaceholder}}: {{descriptionPlaceholder}}
+{{/yields}}
+{{/yieldsExist}}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,18 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"stkb.rewrap",
+		"ms-pyright.pyright",
+		"eamodio.gitlens",
+		"ms-vsliveshare.vsliveshare",
+		"ms-vsliveshare.vsliveshare-audio",
+		"karigari.chat",
+		"njpwerner.autodocstring",
+		"oijaz.unicode-latex",
+		"donjayamanne.githistory"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": []
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,89 @@
+{
+    "python.envFile": ".env",
+    // XXX Unfortunately, pyright does not play well with the .env file approach for now
+    // see https://github.com/microsoft/pyright/issues/310
+    // One workaround: change manually environment, then back to sbi.
+    // This will taint the current file by inserting here a resolved absolute path
+    "python.pythonPath": "${env:PYTHON}",
+    //
+    // Testing: enable only one at a time (pytest, generally)
+    //
+    "python.testing.unittestEnabled": false,
+    "python.testing.nosetestsEnabled": false,
+    "python.testing.pytestEnabled": true,
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    //
+    // Editor settings for python
+    //
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.python",
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+            "source.sortImports": true
+        }, // OK as long as isort 3rd parties managed in setup.cfg?, see below
+        "editor.wordWrapColumn": 88,
+        "editor.renderWhitespace": "boundary",
+        "editor.wordWrap": "wordWrapColumn",
+        "editor.fontLigatures": true,
+    },
+    //
+    // Formatting
+    // https://code.visualstudio.com/docs/python/editing#_formatting
+    //
+    "python.formatting.provider": "black",
+    //"python.formatting.blackPath": "${env:BLACK}",
+    "python.formatting.blackArgs": [
+        "--line-length=88"
+    ],
+    //
+    // Sort imports
+    // https://github.com/microsoft/vscode-python/issues/5840#issuecomment-497321419
+    //
+    //"python.sortImports.path": "${env:ISORT}",
+    "python.sortImports.args": [
+        "--settings-path=${workspaceFolder}/setup.cfg"
+    ],
+    //
+    // Linting
+    // https://code.visualstudio.com/docs/python/linting#_specific-linters
+    //
+    "python.linting.enabled": true,
+    "python.linting.lintOnSave": true,
+    "python.linting.flake8Enabled": true,
+    //"python.linting.flake8Path": "${env:FLAKE8}",
+    "python.linting.args": [
+        "--settings-path=${workspaceFolder}/setup.cfg"
+    ],
+    // flake8 works better than pylint, e.g. no need specify generated members.
+    "python.linting.pylintEnabled": true,
+    // "python.linting.pylintArgs": [
+    //     "--generated-members=numpy.* ,torch.*",
+    //     "--disable=invalid-name"
+    // ],
+    //
+    // Files to exclude
+    //
+    "files.exclude": {
+        "**/__pycache__": true,
+        "**/.pytest_cache": true,
+        "**/.ipynb_checkpoints": true,
+        "**/*.egg-info": true,
+    },
+    //
+    // Rewrap vscode plugin (stkb.rewrap)
+    // Needs manual installation (!) -- added to recommended extensions
+    // https://marketplace.visualstudio.com/items?itemName=stkb.rewrap
+    //
+    "rewrap.autoWrap.enabled": true,
+    "rewrap.wrappingColumn": 88,
+    //
+    // autoDocstring vscode plugin (njpwerner.autodocstring)
+    // Needs manual installation (!) -- added to recommended extensions
+    // https://marketplace.visualstudio.com/items?itemName=njpwerner.autodocstring
+    //
+    "autoDocstring.customTemplatePath": ".vscode/autodocstring.template",
+    // just showing how customizable this is
+    "window.title": "Simulation Based Inference -- ${dirty}${activeEditorShort}${separator}${rootName}${separator}${appName}",
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -88,6 +88,7 @@
     //
     "autoDocstring.customTemplatePath": ".vscode/autodocstring.template",
     // just showing how customizable this is
+    "window.title": "SBI.vscode:: ${dirty}${activeEditorShort}${separator}${rootName}${separator}${appName}",
     "workbench.colorCustomizations": {
         "editorRuler.foreground": "#444444"
     }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,6 +27,9 @@
         "editor.renderWhitespace": "boundary",
         "editor.wordWrap": "wordWrapColumn",
         "editor.fontLigatures": true,
+        "editor.rulers": [
+            88
+        ],
     },
     //
     // Formatting
@@ -85,5 +88,7 @@
     //
     "autoDocstring.customTemplatePath": ".vscode/autodocstring.template",
     // just showing how customizable this is
-    "window.title": "Simulation Based Inference -- ${dirty}${activeEditorShort}${separator}${rootName}${separator}${appName}",
+    "workbench.colorCustomizations": {
+        "editorRuler.foreground": "#444444"
+    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,6 +30,15 @@
         "editor.rulers": [
             88
         ],
+        "rewrap.wholeComment": false,
+        "rewrap.doubleSentenceSpacing": true,
+        //
+        // Rewrap vscode plugin (stkb.rewrap)
+        // Needs manual installation (!) -- added to recommended extensions
+        // https://marketplace.visualstudio.com/items?itemName=stkb.rewrap
+        // Still pending https://github.com/stkb/Rewrap/issues/88 for full python docstring support
+        "rewrap.autoWrap.enabled": true,
+        "rewrap.wrappingColumn": 88,
     },
     //
     // Formatting
@@ -74,13 +83,6 @@
         "**/.ipynb_checkpoints": true,
         "**/*.egg-info": true,
     },
-    //
-    // Rewrap vscode plugin (stkb.rewrap)
-    // Needs manual installation (!) -- added to recommended extensions
-    // https://marketplace.visualstudio.com/items?itemName=stkb.rewrap
-    //
-    "rewrap.autoWrap.enabled": true,
-    "rewrap.wrappingColumn": 88,
     //
     // autoDocstring vscode plugin (njpwerner.autodocstring)
     // Needs manual installation (!) -- added to recommended extensions

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,5 @@
 {
-    "python.envFile": ".env",
-    // XXX Unfortunately, pyright does not play well with the .env file approach for now
-    // see https://github.com/microsoft/pyright/issues/310
-    // One workaround: change manually environment, then back to sbi.
-    // This will taint the current file by inserting here a resolved absolute path
-    "python.pythonPath": "${env:PYTHON}",
+    "python.pythonPath": ".sbi_env/bin/python",
     //
     // Testing: enable only one at a time (pytest, generally)
     //

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -69,7 +69,7 @@
         "--settings-path=${workspaceFolder}/setup.cfg"
     ],
     // flake8 works better than pylint, e.g. no need specify generated members.
-    "python.linting.pylintEnabled": true,
+    // "python.linting.pylintEnabled": true,
     // "python.linting.pylintArgs": [
     //     "--generated-members=numpy.* ,torch.*",
     //     "--disable=invalid-name"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,27 +28,26 @@
         "rewrap.wholeComment": false,
         "rewrap.doubleSentenceSpacing": true,
         //
-        // Rewrap vscode plugin (stkb.rewrap)
-        // Needs manual installation (!) -- added to recommended extensions
-        // https://marketplace.visualstudio.com/items?itemName=stkb.rewrap
+        // Please add the rewrap vscode plugin (stkb.rewrap)
         // Still pending https://github.com/stkb/Rewrap/issues/88 for full python docstring support
         "rewrap.autoWrap.enabled": true,
         "rewrap.wrappingColumn": 88,
+    },
+    "workbench.colorCustomizations": {
+        "editorRuler.foreground": "#444444"
     },
     //
     // Formatting
     // https://code.visualstudio.com/docs/python/editing#_formatting
     //
     "python.formatting.provider": "black",
-    //"python.formatting.blackPath": "${env:BLACK}",
     "python.formatting.blackArgs": [
         "--line-length=88"
     ],
     //
     // Sort imports
     // https://github.com/microsoft/vscode-python/issues/5840#issuecomment-497321419
-    //
-    //"python.sortImports.path": "${env:ISORT}",
+    // 
     "python.sortImports.args": [
         "--settings-path=${workspaceFolder}/setup.cfg"
     ],
@@ -59,16 +58,9 @@
     "python.linting.enabled": true,
     "python.linting.lintOnSave": true,
     "python.linting.flake8Enabled": true,
-    //"python.linting.flake8Path": "${env:FLAKE8}",
     "python.linting.args": [
         "--settings-path=${workspaceFolder}/setup.cfg"
     ],
-    // flake8 works better than pylint, e.g. no need specify generated members.
-    // "python.linting.pylintEnabled": true,
-    // "python.linting.pylintArgs": [
-    //     "--generated-members=numpy.* ,torch.*",
-    //     "--disable=invalid-name"
-    // ],
     //
     // Files to exclude
     //
@@ -79,14 +71,10 @@
         "**/*.egg-info": true,
     },
     //
-    // autoDocstring vscode plugin (njpwerner.autodocstring)
-    // Needs manual installation (!) -- added to recommended extensions
-    // https://marketplace.visualstudio.com/items?itemName=njpwerner.autodocstring
+    // Please add the autoDocstring vscode plugin (njpwerner.autodocstring)
     //
     "autoDocstring.customTemplatePath": ".vscode/autodocstring.template",
-    // just showing how customizable this is
-    "window.title": "SBI.vscode:: ${dirty}${activeEditorShort}${separator}${rootName}${separator}${appName}",
-    "workbench.colorCustomizations": {
-        "editorRuler.foreground": "#444444"
-    }
+    //
+    // Signal that we are using shared workspace settings in .vscode
+    "window.title": "SBI.vscode:: ${dirty}${activeEditorShort}${separator}${rootName}${separator}${appName}"
 }

--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,13 @@
 # create:
-# conda env create --file environment.yml
+# conda env create --prefix .sbi_env --file environment.yml
+#
 # update:
-# conda env update --file environment.yml --prune
-name: sbi
+# conda env update --prefix .sbi_env --file environment.yml --prune
+#
+# activate (see below for auto-activation):
+# conda activate ~/path/to/sbi/.sbi_env 
+#
+name: sbi_env
 
 channels:
   - conda-forge
@@ -38,3 +43,23 @@ dependencies:
   - tensorboard
   - tqdm
  
+
+# ADDITIONAL INSTRUCTIONS
+#
+# --- Nicer prompt ---
+# $ conda config --set env_prompt '({name}) '
+# (adds in ~/.condarc the line: env_prompt '({name}) ')
+#
+# --- Automatic activation of environments upon cd (bash) ---
+# Add the following in your .bashrc
+# function cd {
+#          builtin cd "$@"
+#          RET=$?
+#          venv
+#          return $RET
+# }
+# venv (){
+#      conda activate $PWD/.${PWD##*/}_env > /dev/null 2>&1
+# }
+
+  


### PR DESCRIPTION
## Preamble
Condition for merge: review from **ALL**.

This has costed me a good few hours because of byzantine interactions and weird bugs. Hence, I request your help in testing and finding solutions (see issues below)
## How to test
Get this branch locally and switch to it. Be sure to create a `.env` file in the root of your repo, along these lines:
```
# Base paths - if using conda, customize just this
CONDA=/home/alvar/Local/miniconda3/envs/sbi

# We build here in .env the paths because while settings.json 
# supports "X={env:X_PATH}", it doesn't seem to support "X={env:X_PATH}/something/else"
PYTHON=${CONDA}/bin/python

#XXX Some of these may not be necessary at all. Comment in `settings.json` to check
BLACK=${CONDA}/bin/black
ISORT=${CONDA}/bin/isort
FLAKE8=${CONDA}/bin/flake8
```
## Outstanding issues
* flake8 does not play well with the default whitespace on empty lines on VSCode, at least not here. Could somebody investigate a setting to turn off the mustard-colored wiggly underlines? (or fix the insertion of whitespaces from VSCode's side). I had not this problem with pylint.
* pyright does not honor the setting of the python interpreter from the `.env` file, see [this issue](https://github.com/microsoft/pyright/issues/310). If my understanding is correct, we need to live with a workaround for a while, which could be to manually set the pythonpath in settings.json and living with it being tainted (i.e. it will be marked for addition), or we have to export an environment variable ourselves, like `SBI_PYTHON` (I haven't tried this).
* word-wrapping does not seem to work anymore via `Alt-q`, e.g. try L51 of `snpe_b.py` where flake complains that line length is 122 > 88.

## Nonlimitative checklist for you to test this locally (please, add further checks as you come up with them).
* test that sorting imports on save works, and that it is stable
* no warnings that `isort`, `black`, `flake8` cannot be found
* test discovery works. If it doesn't, before working more on the config please run `pytest --collect-only` to make sure that there are no import problems with the tests.
* test that pyright does not have problems with imports (it will... see above).
* test if indicating paths from `.env` in your `settings.json` (by uncommenting lines) really adds something. In principle black, isort and flake should be findable at the location of the python interpreter and thus these lines should be superfluous.
* test that you get new recommended extensions in the recommended extensions sidebar; find out if there are ones that we don't want so as to blacklist them in `extensions.json`.