### PR TITLE
Pass prior statistics and shapes to density estimator utils directly.

### DIFF
--- a/sbi/inference/snl/snl.py
+++ b/sbi/inference/snl/snl.py
@@ -47,7 +47,9 @@ class SNL(NeuralInference):
 
         if density_estimator is None:
             density_estimator = utils.likelihood_nn(
-                model="maf", prior=self._prior, x_o=self._x_o,
+                model="maf",
+                theta_shape=self._prior.sample().shape,
+                x_o_shape=self._x_o.shape,
             )
 
         # create neural posterior which can sample()

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -79,8 +79,12 @@ class SnpeBase(NeuralInference, ABC):
         # create the deep neural density estimator
         if density_estimator is None:
             density_estimator = utils.posterior_nn(
-                model="maf", prior=self._prior, x_o=self._x_o,
+                model="maf",
+                prior_mean=self._prior.mean,
+                prior_std=self._prior.stddev,
+                x_o_shape=self._x_o.shape,
             )
+
         # else: check density estimator for valid prior etc.
         # XXX: here, the user could sneak in an invalid prior and x_o by providing a
         # density estimator with invalid .prior and .x_o, thus bypassing

--- a/sbi/inference/sre/sre.py
+++ b/sbi/inference/sre/sre.py
@@ -71,7 +71,9 @@ class SRE(NeuralInference):
 
         if classifier is None:
             classifier = utils.classifier_nn(
-                model="resnet", prior=self._prior, x_o=self._x_o,
+                model="resnet",
+                theta_shape=self._prior.sample().shape,
+                x_o_shape=self._x_o.shape,
             )
 
         # create posterior object which can sample()

--- a/sbi/user_input/user_input_checks.py
+++ b/sbi/user_input/user_input_checks.py
@@ -30,7 +30,8 @@ def process_prior(prior) -> Tuple[Distribution, int, bool]:
 
     Returns:
         prior: prior that emits samples and log probabilities as PyTorch tensors.
-        theta_dim: event shape of the prior, number of parameters.
+        theta_numel: number of parameters, number of elements of a single sample from
+            the prior.
         prior_returns_numpy: whether the return type of the prior was a numpy array.
     """
 
@@ -68,7 +69,8 @@ def process_custom_prior(prior) -> Tuple[Distribution, int, bool]:
 
     Returns:
         prior: corrected prior.
-        theta_dim: event dimension of the prior, size of single parameter vector.
+        theta_numel: number of parameters, number of elements of a single sample from
+            the prior.
         is_prior_numpy: whether the prior returned numpy before wrapping.
     """
 
@@ -80,9 +82,9 @@ def process_custom_prior(prior) -> Tuple[Distribution, int, bool]:
 
     check_prior_return_type(prior)
 
-    theta_dim = prior.sample().numel()
+    theta_numel = prior.sample().numel()
 
-    return prior, theta_dim, is_prior_numpy
+    return prior, theta_numel, is_prior_numpy
 
 
 def maybe_wrap_prior_to_pytorch(prior) -> Tuple[Distribution, bool]:
@@ -134,7 +136,8 @@ def process_pytorch_prior(prior: Distribution) -> Tuple[Distribution, int, bool]
 
     Returns:
         prior: PyTorch distribution prior.
-        theta_dim: event shape of the prior, number of parameters.
+        theta_numel: number of parameters, number of elements of a single sample from
+            the prior.
         prior_returns_numpy: False.
     """
 
@@ -155,9 +158,9 @@ def process_pytorch_prior(prior: Distribution) -> Tuple[Distribution, int, bool]
     # This will fail for float64 priors.
     check_prior_return_type(prior)
 
-    theta_dim = prior.sample().numel()
+    theta_numel = prior.sample().numel()
 
-    return prior, theta_dim, False
+    return prior, theta_numel, False
 
 
 def check_prior_batch_dims(prior):

--- a/tests/linearGaussian_snl_test.py
+++ b/tests/linearGaussian_snl_test.py
@@ -35,13 +35,11 @@ def test_snl_on_linearGaussian_api(num_dim: int):
         linear_gaussian, prior, torch.zeros(num_dim)
     )
 
-    neural_likelihood = utils.likelihood_nn(model="maf", prior=prior, x_o=x_o,)
-
     infer = SNL(
         simulator=simulator,
         prior=prior,
         x_o=x_o,
-        density_estimator=neural_likelihood,
+        density_estimator=None,  # Use default MAF.
         simulation_batch_size=50,
         mcmc_method="slice-np",
     )
@@ -86,13 +84,11 @@ def test_snl_on_linearGaussian_based_on_mmd(num_dim: int, prior_str: str, set_se
 
     simulator, prior, x_o = prepare_sbi_problem(linear_gaussian, prior, x_o)
 
-    neural_likelihood = utils.likelihood_nn(model="maf", prior=prior, x_o=x_o,)
-
     infer = SNL(
         simulator=simulator,
         prior=prior,
         x_o=x_o,
-        density_estimator=neural_likelihood,
+        density_estimator=None,  # Use default MAF.
         mcmc_method="slice-np",
     )
 
@@ -138,13 +134,11 @@ def test_multi_round_snl_on_linearGaussian_based_on_mmd(set_seed):
 
     simulator, prior, x_o = prepare_sbi_problem(linear_gaussian, prior, x_o)
 
-    neural_likelihood = utils.likelihood_nn(model="maf", prior=prior, x_o=x_o,)
-
     infer = SNL(
         simulator=simulator,
         prior=prior,
         x_o=x_o,
-        density_estimator=neural_likelihood,
+        density_estimator=None,  # Use default MAF.
         simulation_batch_size=50,
         mcmc_method="slice",
     )
@@ -201,13 +195,11 @@ def test_snl_posterior_correction(mcmc_method: str, prior_str: str, set_seed):
 
     simulator, prior, x_o = prepare_sbi_problem(linear_gaussian, prior, x_o)
 
-    neural_likelihood = utils.likelihood_nn(model="maf", prior=prior, x_o=x_o,)
-
     infer = SNL(
         simulator=simulator,
         prior=prior,
         x_o=x_o,
-        density_estimator=neural_likelihood,
+        density_estimator=None,  # Use default MAF.
         simulation_batch_size=50,
         mcmc_method="slice-np",
     )

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -59,12 +59,10 @@ def test_snpe_on_linearGaussian_based_on_mmd(
 
     simulator, prior, x_o = prepare_sbi_problem(linear_gaussian, prior, x_o)
 
-    neural_net = utils.posterior_nn(model="maf", prior=prior, x_o=x_o)
-
     snpe_common_args = dict(
         simulator=simulator,
         x_o=x_o,
-        density_estimator=neural_net,
+        density_estimator=None,  # Use default MAF.
         prior=prior,
         z_score_x=True,
         simulation_batch_size=simulation_batch_size,
@@ -150,12 +148,10 @@ def test_multi_round_snpe_on_linearGaussian_based_on_mmd(algorithm_str: str, set
 
     simulator, prior, _ = prepare_sbi_problem(linear_gaussian, prior, true_observation)
 
-    neural_net = utils.posterior_nn(model="maf", prior=prior, x_o=true_observation,)
-
     snpe_common_args = dict(
         simulator=simulator,
         x_o=true_observation,
-        density_estimator=neural_net,
+        density_estimator=None,  # Use default MAF.
         prior=prior,
         z_score_x=True,
         use_combined_loss=False,
@@ -234,11 +230,10 @@ def test_multi_round_snpe_deterministic_simulator(set_seed, z_score_min_std):
 
         return result
 
-    neural_net = utils.posterior_nn(model="maf", prior=prior, x_o=true_observation)
     infer = SnpeB(
         simulator=deterministic_simulator,
         x_o=true_observation,
-        density_estimator=neural_net,
+        density_estimator=None,  # Use default MAF.
         prior=prior,
         z_score_x=True,
         use_combined_loss=False,
@@ -283,12 +278,10 @@ def test_snpec_posterior_correction(sample_with_mcmc, mcmc_method, prior, set_se
 
     simulator, prior, x_o = prepare_sbi_problem(linear_gaussian, prior, zeros(num_dim))
 
-    neural_net = utils.posterior_nn(model="maf", prior=prior, x_o=x_o,)
-
     infer = SnpeC(
         simulator=simulator,
         x_o=x_o,
-        density_estimator=neural_net,
+        density_estimator=None,  # Use default MAF.
         prior=prior,
         num_atoms=-1,
         z_score_x=True,

--- a/tests/linearGaussian_sre_test.py
+++ b/tests/linearGaussian_sre_test.py
@@ -35,13 +35,11 @@ def test_sre_on_linearGaussian_api(num_dim: int):
 
     simulator, prior, x_o = prepare_sbi_problem(linear_gaussian, prior, x_o)
 
-    classifier = utils.classifier_nn("resnet", prior=prior, x_o=x_o,)
-
     infer = SRE(
         simulator=simulator,
         prior=prior,
         x_o=x_o,
-        classifier=classifier,
+        classifier=None,  # Use default RESNET.
         simulation_batch_size=50,
         mcmc_method="slice-np",
     )
@@ -96,8 +94,6 @@ def test_sre_on_linearGaussian_based_on_mmd(
             x_o, num_samples=num_samples, prior=prior
         )
 
-    classifier = utils.classifier_nn("resnet", prior=prior, x_o=x_o,)
-
     simulator, prior, x_o = prepare_sbi_problem(linear_gaussian, prior, x_o)
 
     num_atoms = 2 if classifier_loss == "aalr" else -1
@@ -107,7 +103,7 @@ def test_sre_on_linearGaussian_based_on_mmd(
         prior=prior,
         x_o=x_o,
         num_atoms=num_atoms,
-        classifier=classifier,
+        classifier=None,  # Use default RESNET.
         classifier_loss=classifier_loss,
         simulation_batch_size=50,
         mcmc_method="slice-np",
@@ -180,13 +176,11 @@ def test_sre_posterior_correction(mcmc_method: str, prior_str: str, set_seed):
 
     simulator, prior, x_o = prepare_sbi_problem(linear_gaussian, prior, x_o)
 
-    classifier = utils.classifier_nn("resnet", prior=prior, x_o=x_o,)
-
     infer = SRE(
         simulator=simulator,
         prior=prior,
         x_o=x_o,
-        classifier=classifier,
+        classifier=None,  # Use default RESNET.
         simulation_batch_size=50,
         mcmc_method=mcmc_method,
     )


### PR DESCRIPTION
# Problem 
Density estimator utils like `utils.get_nn_models.posterior_nn()` used to get `prior` and `x_o` as args, allowing for passing unchecked prior and observation when used outside of sbi (e.g. in tests). See issue #135 .

# Solution 
Pass to density estimator utils only what is needed: 
- prior mean and std for constructing the standardize transform in `posterior_nn` 
- theta shape and x shape in `likelihood_nn` and 'classifier_nn`. 
- adapt usage in `inference` 
- adapt tests. 
- closes #135 

# Input needed 
With the help of @meteore I think I can improve on the naming / new docstrings in the changed utils functions. 