### PR TITLE
add kwarg to turn off input checks.

### DIFF
--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -24,6 +24,7 @@ class NeuralInference(ABC):
         device: Optional[torch.device] = None,
         summary_writer: Optional[SummaryWriter] = None,
         simulator_name: Optional[str] = "simulator",
+        skip_input_checks: bool = False,
     ):
         r"""
         Args:
@@ -35,18 +36,19 @@ class NeuralInference(ABC):
                  interpreted as a batch dimension but *currently* only the first batch
                  element will be used to condition on.
             simulation_batch_size: number of parameter sets that the
-                simulator accepts and converts to data x at once. If -1, we simulate all
-                 parameter sets at the same time. If >= 1, the simulator has to process
-                 data of shape (simulation_batch_size, parameter_dimension).
+                simulator accepts and converts to data x at once. If -1, we simulate 
+                all parameter sets at the same time. If >= 1, the simulator has to 
+                process data of shape (simulation_batch_size, parameter_dimension).
+            device: torch.device on which to compute (optional).
             summary_writer: an optional SummaryWriter to control, among others, log     
                 file location (default is <current working directory>/logs.)
-            device: torch.device on which to compute (optional).
-            mcmc_method: MCMC method to use for posterior sampling, one of 
-                ['slice', 'hmc', 'nuts'].
+            skip_simulator_checks: Flag to turn off input checks,
+                e.g., for saving simulation budget as the input checks run the
+                simulator a couple of times.
         """
 
         self._simulator, self._prior, self._x_o = prepare_sbi_problem(
-            simulator, prior, x_o
+            simulator, prior, x_o, skip_input_checks
         )
 
         self._batched_simulator = lambda theta: simulate_in_batches(

--- a/sbi/inference/snl/snl.py
+++ b/sbi/inference/snl/snl.py
@@ -24,7 +24,7 @@ class SNL(NeuralInference):
         simulator: Callable,
         prior,
         x_o: Tensor,
-        density_estimator: Optional[nn.Module],
+        density_estimator: Optional[nn.Module] = None,
         simulation_batch_size: int = 1,
         summary_writer: SummaryWriter = None,
         device: torch.device = None,

--- a/sbi/inference/snl/snl.py
+++ b/sbi/inference/snl/snl.py
@@ -29,6 +29,7 @@ class SNL(NeuralInference):
         summary_writer: SummaryWriter = None,
         device: torch.device = None,
         mcmc_method: str = "slice-np",
+        skip_input_checks: bool = False,
     ):
         r"""Sequential Neural Likelihood
         
@@ -38,11 +39,20 @@ class SNL(NeuralInference):
 
         Args:
             density_estimator: Conditional density estimator $q(x|\theta)$, a nn.Module
-             with `.log_prob()` and `.sample()`
+                with `.log_prob()` and `.sample()`
+            skip_simulator_checks: Flag to turn off input checks,
+                e.g., for saving simulation budget as the input checks run the
+                simulator a couple of times.
         """
 
         super().__init__(
-            simulator, prior, x_o, simulation_batch_size, device, summary_writer,
+            simulator,
+            prior,
+            x_o,
+            simulation_batch_size,
+            device,
+            summary_writer,
+            skip_input_checks=skip_input_checks,
         )
 
         if density_estimator is None:

--- a/sbi/inference/snpe/snpe_a.py
+++ b/sbi/inference/snpe/snpe_a.py
@@ -26,6 +26,7 @@ class SnpeA(SnpeBase):
         summary_writer=None,
         device=None,
         z_score_min_std: float = 1e-7,
+        skip_input_checks: bool = False,
     ):
         """SNPE-A
 
@@ -46,6 +47,9 @@ class SnpeA(SnpeBase):
                 two onwards.
             z_score_min_std: Minimum value of the standard deviation to use when
                 standardizing inputs. This is typically needed when some simulator outputs are deterministic or nearly so.
+            skip_simulator_checks: Flag to turn off input checks,
+                e.g., for saving simulation budget as the input checks run the
+                simulator a couple of times.
         """
 
         raise NotImplementedError
@@ -63,6 +67,7 @@ class SnpeA(SnpeBase):
             discard_prior_samples=discard_prior_samples,
             device=device,
             z_score_min_std=z_score_min_std,
+            skip_input_checks=skip_input_checks,
         )
 
     def _get_log_prob_proposal_posterior(self, theta, x, masks):

--- a/sbi/inference/snpe/snpe_b.py
+++ b/sbi/inference/snpe/snpe_b.py
@@ -27,6 +27,7 @@ class SnpeB(SnpeBase):
         summary_writer=None,
         device=None,
         z_score_min_std: float = 1e-7,
+        skip_input_checks: bool = False,
     ):
         r"""
 
@@ -49,6 +50,9 @@ class SnpeB(SnpeBase):
                 two onwards.
             z_score_min_std: Minimum value of the standard deviation to use when
                 standardizing inputs. This is typically needed when some simulator outputs are deterministic or nearly so.
+            skip_simulator_checks: Flag to turn off input checks,
+                e.g., for saving simulation budget as the input checks run the
+                simulator a couple of times.
         """
 
         super(SnpeB, self).__init__(
@@ -65,6 +69,7 @@ class SnpeB(SnpeBase):
             discard_prior_samples=discard_prior_samples,
             device=device,
             z_score_min_std=z_score_min_std,
+            skip_input_checks=skip_input_checks,
         )
 
     def _get_log_prob_proposal_posterior(

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -37,6 +37,7 @@ class SnpeBase(NeuralInference, ABC):
         mcmc_method: str = "slice-np",
         summary_writer: Optional[SummaryWriter] = None,
         z_score_min_std: float = 1e-7,
+        skip_input_checks: bool = False,
     ):
         """
         See NeuralInference docstring for all other arguments.
@@ -56,10 +57,19 @@ class SnpeBase(NeuralInference, ABC):
                 two onwards.
             z_score_min_std: Minimum value of the standard deviation to use when
                 standardizing inputs. This is typically needed when some simulator outputs are deterministic or nearly so.
+            skip_simulator_checks: Flag to turn off input checks,
+                e.g., for saving simulation budget as the input checks run the
+                simulator a couple of times.
         """
 
         super().__init__(
-            simulator, prior, x_o, simulation_batch_size, device, summary_writer,
+            simulator,
+            prior,
+            x_o,
+            simulation_batch_size,
+            device,
+            summary_writer,
+            skip_input_checks=skip_input_checks,
         )
 
         self._z_score_x = z_score_x

--- a/sbi/inference/snpe/snpe_c.py
+++ b/sbi/inference/snpe/snpe_c.py
@@ -30,6 +30,7 @@ class SnpeC(SnpeBase):
         sample_with_mcmc=False,
         mcmc_method="slice-np",
         z_score_min_std: float = 1e-7,
+        skip_input_checks: bool = False,
     ):
         r"""SNPE-C / APT
 
@@ -54,6 +55,9 @@ class SnpeC(SnpeBase):
                 If -1, use all other thetas in minibatch.
             z_score_min_std: Minimum value of the standard deviation to use when
                 standardizing inputs. This is typically needed when some simulator outputs are deterministic or nearly so.
+            skip_simulator_checks: Flag to turn off input checks,
+                e.g., for saving simulation budget as the input checks run the
+                simulator a couple of times.
         """
 
         super(SnpeC, self).__init__(
@@ -72,6 +76,7 @@ class SnpeC(SnpeBase):
             sample_with_mcmc=sample_with_mcmc,
             mcmc_method=mcmc_method,
             z_score_min_std=z_score_min_std,
+            skip_input_checks=skip_input_checks,
         )
 
         assert isinstance(num_atoms, int), "Number of atoms must be an integer."

--- a/sbi/inference/sre/sre.py
+++ b/sbi/inference/sre/sre.py
@@ -25,7 +25,7 @@ class SRE(NeuralInference):
         simulator: Callable,
         prior,
         x_o: Tensor,
-        classifier: nn.Module,
+        classifier: Optional[nn.Module] = None,
         num_atoms: int = -1,
         simulation_batch_size: int = 1,
         mcmc_method: str = "slice-np",

--- a/sbi/inference/sre/sre.py
+++ b/sbi/inference/sre/sre.py
@@ -34,6 +34,7 @@ class SRE(NeuralInference):
         retrain_from_scratch_each_round: bool = False,
         summary_writer: Optional[SummaryWriter] = None,
         device: Optional[torch.device] = None,
+        skip_input_checks: bool = False,
     ):
         r"""Sequential Ratio Estimation
 
@@ -53,15 +54,24 @@ class SRE(NeuralInference):
                 vectors f(x) for high-dimensional simulation outputs $x$.
             classifier_loss: `sre` implements the algorithm suggested in Durkan et al. 
                 2019, whereas `aalr` implements the algorithm suggested in
-                 Hermans et al. 2019. `sre` can use more than two atoms, potentially
-                 boosting performance, but does not allow for exact posterior density
-                 evaluation (only up to a normalizing constant), even when training
-                 only one round. `aalr` is limited to `num_atoms=2`, but allows for
-                 density evaluation when training for one round.
+                Hermans et al. 2019. `sre` can use more than two atoms, potentially
+                boosting performance, but does not allow for exact posterior density
+                evaluation (only up to a normalizing constant), even when training
+                only one round. `aalr` is limited to `num_atoms=2`, but allows for
+                density evaluation when training for one round.
+            skip_simulator_checks: Flag to turn off input checks,
+                e.g., for saving simulation budget as the input checks run the
+                simulator a couple of times.                
         """
 
         super().__init__(
-            simulator, prior, x_o, simulation_batch_size, device, summary_writer,
+            simulator,
+            prior,
+            x_o,
+            simulation_batch_size,
+            device,
+            summary_writer,
+            skip_input_checks=skip_input_checks,
         )
 
         self._classifier_loss = classifier_loss


### PR DESCRIPTION
Add a keyword arg in `base.py` to passed to user input checks that turns off
all input checks. This is useful for saving simulation budget.
- add flag and pass it through
- add warning
- add test
- cosmetics in tests: replace torch.ones by ones, etc.