### PR TITLE
refactor torch zeros, ones and eye imports.

### DIFF
--- a/sbi/inference/posteriors/sbi_posterior.py
+++ b/sbi/inference/posteriors/sbi_posterior.py
@@ -3,9 +3,8 @@ from warnings import warn
 
 from pyro.infer.mcmc import HMC, NUTS
 from pyro.infer.mcmc.api import MCMC
-from torch import Tensor
 import torch
-from torch import nn
+from torch import nn, Tensor
 from torch import multiprocessing as mp
 
 from sbi.mcmc import Slice, SliceSampler

--- a/sbi/inference/snl/snl.py
+++ b/sbi/inference/snl/snl.py
@@ -3,8 +3,6 @@ from copy import deepcopy
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import numpy as np
-from pyro.infer.mcmc import HMC, NUTS
-from pyro.infer.mcmc.api import MCMC
 import torch
 from torch import Tensor, nn, optim
 from torch.nn.utils import clip_grad_norm_

--- a/sbi/inference/snpe/snpe_b.py
+++ b/sbi/inference/snpe/snpe_b.py
@@ -1,12 +1,8 @@
 from __future__ import annotations
 
-import os
-
 import torch
-from torch import distributions
-from torch.utils.tensorboard import SummaryWriter
+from torch import Tensor
 
-import sbi.utils as utils
 from sbi.inference.snpe.snpe_base import SnpeBase
 
 
@@ -73,8 +69,8 @@ class SnpeB(SnpeBase):
         )
 
     def _get_log_prob_proposal_posterior(
-        self, theta: torch.Tensor, x: torch.Tensor, masks: torch.Tensor
-    ) -> torch.Tensor:
+        self, theta: Tensor, x: Tensor, masks: Tensor
+    ) -> Tensor:
         r"""
         Return importance weighted log probability as proposed in
          Lueckmann, Goncalves et al 2017.

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -6,7 +6,7 @@ import warnings
 import numpy as np
 from pyknos.mdn.mdn import MultivariateGaussianMDN
 import torch
-from torch import Tensor, nn, optim
+from torch import Tensor, nn, optim, zeros, ones
 from torch.nn.utils import clip_grad_norm_
 from torch.utils import data
 from torch.utils.data.sampler import SubsetRandomSampler
@@ -112,8 +112,8 @@ class SnpeBase(NeuralInference, ABC):
             self.x_mean = torch.mean(self.pilot_x, dim=0)
             self.x_std = torch.std(self.pilot_x, dim=0)
         else:
-            self.x_mean = torch.zeros(self._x_o.shape)
-            self.x_std = torch.ones(self._x_o.shape)
+            self.x_mean = zeros(self._x_o.shape)
+            self.x_std = ones(self._x_o.shape)
 
         # new embedding_net contains z-scoring
         if not isinstance(self._neural_posterior.neural_net, MultivariateGaussianMDN):
@@ -127,7 +127,7 @@ class SnpeBase(NeuralInference, ABC):
 
         # calibration kernels proposed in Lueckmann, Goncalves et al 2017
         if calibration_kernel is None:
-            self.calibration_kernel = lambda x: torch.ones([len(x)])
+            self.calibration_kernel = lambda x: ones([len(x)])
         else:
             self.calibration_kernel = calibration_kernel
 
@@ -274,7 +274,7 @@ class SnpeBase(NeuralInference, ABC):
                 the one fixed for the round if leakage correction through sampling is active and `patience` is not enough to reach it. 
         """
 
-        prior_mask_values = torch.ones if round_ == 0 else torch.zeros
+        prior_mask_values = ones if round_ == 0 else zeros
         return prior_mask_values((num_simulations, 1), dtype=torch.bool)
 
     def _train(

--- a/sbi/inference/sre/sre.py
+++ b/sbi/inference/sre/sre.py
@@ -5,9 +5,7 @@ from typing import Callable, Dict, List, Optional, Union
 
 import numpy as np
 import torch
-from pyro.infer.mcmc import HMC, NUTS
-from pyro.infer.mcmc.api import MCMC
-from torch import Tensor, nn, optim
+from torch import Tensor, nn, optim, ones
 from torch.utils import data
 from torch.utils.data.sampler import SubsetRandomSampler
 from torch.utils.tensorboard import SummaryWriter
@@ -267,7 +265,7 @@ class SRE(NeuralInference):
             assert 0 < num_atoms - 1 < clipped_batch_size
             probs = (
                 (1 / (clipped_batch_size - 1))
-                * torch.ones(clipped_batch_size, clipped_batch_size)
+                * ones(clipped_batch_size, clipped_batch_size)
                 * (1 - torch.eye(clipped_batch_size))
             )
             choices = torch.multinomial(
@@ -289,7 +287,7 @@ class SRE(NeuralInference):
                 # sampled from the marginals. The first element is sampled from the
                 # joint p(theta, x) and is labelled 1. The second element is sampled
                 # from the marginals p(theta)p(x) and is labelled 0. And so on.
-                labels = torch.ones(2 * clipped_batch_size)  # two atoms
+                labels = ones(2 * clipped_batch_size)  # two atoms
                 labels[1::2] = 0.0
                 # binary cross entropy to learn the likelihood
                 loss = criterion(likelihood, labels)

--- a/tests/linearGaussian_snl_test.py
+++ b/tests/linearGaussian_snl_test.py
@@ -1,6 +1,6 @@
 import pytest
 import torch
-from torch import distributions
+from torch import distributions, zeros, ones, eye
 
 import sbi.utils as utils
 from sbi.inference.snl.snl import SNL
@@ -28,12 +28,10 @@ def test_snl_on_linearGaussian_api(num_dim: int):
     num_samples = 10
 
     prior = distributions.MultivariateNormal(
-        loc=torch.zeros(num_dim), covariance_matrix=torch.eye(num_dim)
+        loc=zeros(num_dim), covariance_matrix=eye(num_dim)
     )
 
-    simulator, prior, x_o = prepare_sbi_problem(
-        linear_gaussian, prior, torch.zeros(num_dim)
-    )
+    simulator, prior, x_o = prepare_sbi_problem(linear_gaussian, prior, zeros(num_dim))
 
     neural_likelihood = utils.likelihood_nn(model="maf", prior=prior, x_o=x_o,)
 
@@ -68,18 +66,18 @@ def test_snl_on_linearGaussian_based_on_mmd(num_dim: int, prior_str: str, set_se
         set_seed: fixture for manual seeding, see tests/conftest.py
     """
 
-    x_o = torch.zeros((1, num_dim))
+    x_o = zeros((1, num_dim))
     num_samples = 200
 
     if prior_str == "gaussian":
         prior = distributions.MultivariateNormal(
-            loc=torch.zeros(num_dim), covariance_matrix=torch.eye(num_dim)
+            loc=zeros(num_dim), covariance_matrix=eye(num_dim)
         )
         target_samples = get_true_posterior_samples_linear_gaussian_mvn_prior(
             x_o, num_samples=num_samples
         )
     else:
-        prior = utils.BoxUniform(-1.0 * torch.ones(num_dim), torch.ones(num_dim))
+        prior = utils.BoxUniform(-1.0 * ones(num_dim), ones(num_dim))
         target_samples = get_true_posterior_samples_linear_gaussian_uniform_prior(
             x_o, num_samples=num_samples, prior=prior
         )
@@ -126,11 +124,11 @@ def test_multi_round_snl_on_linearGaussian_based_on_mmd(set_seed):
     """
 
     num_dim = 3
-    x_o = torch.zeros((1, num_dim))
+    x_o = zeros((1, num_dim))
     num_samples = 200
 
     prior = distributions.MultivariateNormal(
-        loc=torch.zeros(num_dim), covariance_matrix=torch.eye(num_dim)
+        loc=zeros(num_dim), covariance_matrix=eye(num_dim)
     )
     target_samples = get_true_posterior_samples_linear_gaussian_mvn_prior(
         x_o, num_samples=num_samples
@@ -190,14 +188,14 @@ def test_snl_posterior_correction(mcmc_method: str, prior_str: str, set_seed):
 
     num_dim = 2
     num_samples = 30
-    x_o = torch.zeros((1, num_dim))
+    x_o = zeros((1, num_dim))
 
     if prior_str == "gaussian":
         prior = distributions.MultivariateNormal(
-            loc=torch.zeros(num_dim), covariance_matrix=torch.eye(num_dim)
+            loc=zeros(num_dim), covariance_matrix=eye(num_dim)
         )
     else:
-        prior = utils.BoxUniform(-1.0 * torch.ones(num_dim), torch.ones(num_dim))
+        prior = utils.BoxUniform(-1.0 * ones(num_dim), ones(num_dim))
 
     simulator, prior, x_o = prepare_sbi_problem(linear_gaussian, prior, x_o)
 

--- a/tests/linearGaussian_sre_test.py
+++ b/tests/linearGaussian_sre_test.py
@@ -1,6 +1,6 @@
 import pytest
 import torch
-from torch import distributions
+from torch import distributions, eye, zeros, ones
 
 import sbi.utils as utils
 import tests.utils_for_testing.linearGaussian_logprob as test_utils
@@ -26,9 +26,9 @@ def test_sre_on_linearGaussian_api(num_dim: int):
         num_dim: parameter dimension of the Gaussian model
     """
 
-    x_o = torch.zeros(num_dim)
+    x_o = zeros(num_dim)
     prior = distributions.MultivariateNormal(
-        loc=torch.zeros(num_dim), covariance_matrix=torch.eye(num_dim)
+        loc=zeros(num_dim), covariance_matrix=eye(num_dim)
     )
 
     # XXX this breaks the test! (and #76 doesn't seem to fix)
@@ -80,18 +80,18 @@ def test_sre_on_linearGaussian_based_on_mmd(
         set_seed: fixture for manual seeding, see tests/conftest.py
     """
 
-    x_o = torch.zeros(1, num_dim)
+    x_o = zeros(1, num_dim)
     num_samples = 300
 
     if prior_str == "gaussian":
         prior = distributions.MultivariateNormal(
-            loc=torch.zeros(num_dim), covariance_matrix=torch.eye(num_dim)
+            loc=zeros(num_dim), covariance_matrix=eye(num_dim)
         )
         target_samples = get_true_posterior_samples_linear_gaussian_mvn_prior(
             x_o, num_samples=num_samples
         )
     else:
-        prior = utils.BoxUniform(-1.0 * torch.ones(num_dim), torch.ones(num_dim))
+        prior = utils.BoxUniform(-1.0 * ones(num_dim), ones(num_dim))
         target_samples = get_true_posterior_samples_linear_gaussian_uniform_prior(
             x_o, num_samples=num_samples, prior=prior
         )
@@ -168,15 +168,13 @@ def test_sre_posterior_correction(mcmc_method: str, prior_str: str, set_seed):
     """
 
     num_dim = 2
-    x_o = torch.zeros(num_dim)
+    x_o = zeros(num_dim)
     if prior_str == "gaussian":
         prior = distributions.MultivariateNormal(
-            loc=torch.zeros(num_dim), covariance_matrix=torch.eye(num_dim)
+            loc=zeros(num_dim), covariance_matrix=eye(num_dim)
         )
     else:
-        prior = utils.BoxUniform(
-            low=-1.0 * torch.ones(num_dim), high=torch.ones(num_dim)
-        )
+        prior = utils.BoxUniform(low=-1.0 * ones(num_dim), high=ones(num_dim))
 
     simulator, prior, x_o = prepare_sbi_problem(linear_gaussian, prior, x_o)
 

--- a/tests/simulator_utils_test.py
+++ b/tests/simulator_utils_test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 import torch
 from torch.distributions import MultivariateNormal
+from torch import zeros, ones, eye
 
 from sbi.inference.snpe import SnpeC
 from sbi.simulators.linear_gaussian import linear_gaussian
@@ -21,7 +22,7 @@ def test_simulate_in_batches(
     num_sims,
     batch_size,
     simulator=linear_gaussian,
-    prior=BoxUniform(torch.zeros(5), torch.ones(5)),
+    prior=BoxUniform(zeros(5), ones(5)),
 ):
     """Test combinations of num_sims and simulation_batch_size. """
 
@@ -33,11 +34,9 @@ def test_inference_with_pilot_samples_many_samples():
     """Test whether num_pilot_sims can be same as num_simulations_per_round."""
 
     num_dim = 3
-    x_o = torch.zeros(num_dim)
+    x_o = zeros(num_dim)
 
-    prior = MultivariateNormal(
-        loc=torch.zeros(num_dim), covariance_matrix=torch.eye(num_dim)
-    )
+    prior = MultivariateNormal(loc=zeros(num_dim), covariance_matrix=eye(num_dim))
 
     infer = SnpeC(
         simulator=linear_gaussian, x_o=x_o, prior=prior, simulation_batch_size=100,

--- a/tests/torchutils_test.py
+++ b/tests/torchutils_test.py
@@ -6,6 +6,7 @@ import torch.distributions as distributions
 import torchtestcase
 
 from sbi.utils import torchutils
+from torch import zeros, ones, eye
 from tests.utils_for_testing.dkl import dkl_via_monte_carlo
 
 
@@ -73,7 +74,7 @@ class TorchUtilsTest(torchtestcase.TorchTestCase):
         self.assertIsInstance(matrix, torch.Tensor)
         self.assertEqual(matrix.shape, torch.Size([size, size]))
         self.eps = 1e-5
-        unit = torch.eye(size, size)
+        unit = eye(size, size)
         self.assertEqual(matrix @ matrix.t(), unit)
         self.assertEqual(matrix.t() @ matrix, unit)
         self.assertEqual(matrix.t(), matrix.inverse())
@@ -140,11 +141,11 @@ def test_dkl_gauss():
     """
     dist1 = (
         distributions.Normal(loc=0.0, scale=1.0),
-        distributions.MultivariateNormal(torch.zeros(2), torch.eye(2)),
+        distributions.MultivariateNormal(zeros(2), eye(2)),
     )
     dist2 = (
         distributions.Normal(loc=1.0, scale=0.5),
-        distributions.MultivariateNormal(torch.ones(2), 0.5 * torch.eye(2)),
+        distributions.MultivariateNormal(ones(2), 0.5 * eye(2)),
     )
 
     for d1, d2 in zip(dist1, dist2):


### PR DESCRIPTION
replace `torch.zeros` by `zeros` in most files, same for `torch.ones` and `torch.eye`.

Related to #153 

One approval and I will merge it. 