### PR TITLE
Leakage correction

### DIFF
--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -198,15 +198,15 @@ class NeuralInference(ABC):
         x_o: Tensor,
         theta_bank: List[Tensor],
         x_bank: List[Tensor],
-        posterior_samples_acceptance_rate: Optional[float]=None,
+        posterior_samples_acceptance_rate: Optional[Tensor] = None,
     ) -> None:
         """Update the summary_writer with statistics for a given round.
 
         Statistics are extracted from the arguments and from entries in self._summary
         created during training.
         """
-        
-        # XXX: This is a subset of the logging from the conormdurkan/lfi. A big
+
+        # NB. This is a subset of the logging from the conormdurkan/lfi. A big
         # part of the logging was removed because of API changes, e.g., logging
         # comparisons to ground truth parameters and samples.
 
@@ -227,7 +227,7 @@ class NeuralInference(ABC):
         # Rejection sampling acceptance rate, only for SNPE.
         if posterior_samples_acceptance_rate is not None:
             self._summary["rejection_sampling_acceptance_rates"].append(
-                posterior_samples_acceptance_rate
+                posterior_samples_acceptance_rate.item()
             )
 
             self._summary_writer.add_scalar(

--- a/sbi/inference/posteriors/sbi_posterior.py
+++ b/sbi/inference/posteriors/sbi_posterior.py
@@ -103,7 +103,7 @@ class Posterior:
         try:
             log_prob_fn = getattr(self, f"_log_prob_{self._alg_family}")
         except AttributeError:
-            raise ValueError(f"{self.alg_family} cannot evaluate probabilities.")
+            raise ValueError(f"{self._alg_family} cannot evaluate probabilities.")
 
         return log_prob_fn(theta, x, normalize_snpe_density=normalize_snpe_density)
 

--- a/sbi/inference/posteriors/sbi_posterior.py
+++ b/sbi/inference/posteriors/sbi_posterior.py
@@ -1,21 +1,19 @@
-from typing import Callable, Optional, Union
-from numpy import ndarray
+from typing import Callable, Optional
 from warnings import warn
 
 from pyro.infer.mcmc import HMC, NUTS
 from pyro.infer.mcmc.api import MCMC
 import torch
-from torch import nn, Tensor, log, as_tensor
+from torch import Tensor, as_tensor, log, nn
 from torch import multiprocessing as mp
 
 from sbi.mcmc import Slice, SliceSampler
+from sbi.types import Array
 import sbi.utils as utils
 from sbi.utils.torchutils import atleast_2d
 
 
 NEG_INF = torch.tensor(float("-inf"), dtype=torch.float32)
-
-Array = Union[torch.Tensor, np.ndarray]
 
 
 class Posterior:

--- a/sbi/inference/snl/snl.py
+++ b/sbi/inference/snl/snl.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
-from typing import Callable, Dict, List, Optional, Union
+from typing import Callable, Dict, Optional
 import warnings
 import logging
 
 import numpy as np
-from numpy.core.fromnumeric import clip
 import torch
 from torch import Tensor, nn, optim
 from torch.nn.utils import clip_grad_norm_
@@ -14,6 +13,7 @@ from torch.utils.tensorboard import SummaryWriter
 
 from sbi.inference.base import NeuralInference
 from sbi.inference.posteriors.sbi_posterior import Posterior
+from sbi.types import ScalarFloat, OneOrMore
 import sbi.utils as utils
 
 
@@ -89,7 +89,7 @@ class SNL(NeuralInference):
     def __call__(
         self,
         num_rounds: int,
-        num_simulations_per_round: Union[List[int], int],
+        num_simulations_per_round: OneOrMore[int],
         batch_size: int = 100,
         learning_rate: float = 5e-4,
         validation_fraction: float = 0.1,
@@ -337,7 +337,7 @@ class PotentialFunctionProvider:
         else:
             return self.np_potential
 
-    def np_potential(self, theta: np.array) -> Union[Tensor, float]:
+    def np_potential(self, theta: np.array) -> ScalarFloat:
         r"""Return posterior log prob. of theta $p(\theta|x)$"
 
         Args:

--- a/sbi/inference/snl/snl.py
+++ b/sbi/inference/snl/snl.py
@@ -29,7 +29,7 @@ class SNL(NeuralInference):
         device: Optional[torch.device] = None,
         num_workers: int = 1,
         worker_batch_size: int = 20,
-        mcmc_method: str = "slice-np",
+        mcmc_method: str = "slice_np",
         skip_input_checks: bool = False,
         show_progressbar: bool = True,
         show_round_summary: bool = False,

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -1,6 +1,6 @@
 from abc import ABC
 from copy import deepcopy
-from typing import Callable, List, Optional, Union, Tuple
+from typing import Callable, Optional, Tuple, Dict
 import warnings
 import logging
 
@@ -14,6 +14,7 @@ from torch.utils.tensorboard import SummaryWriter
 
 from sbi.inference.base import NeuralInference
 from sbi.inference.posteriors.sbi_posterior import Posterior
+from sbi.types import ScalarFloat, OneOrMore
 import sbi.utils as utils
 from sbi.utils import Standardize
 
@@ -116,7 +117,7 @@ class SnpeBase(NeuralInference, ABC):
     def __call__(
         self,
         num_rounds: int,
-        num_simulations_per_round: Union[List[int], int],
+        num_simulations_per_round: OneOrMore[int],
         batch_size: int = 100,
         learning_rate: float = 5e-4,
         validation_fraction: float = 0.1,
@@ -476,7 +477,7 @@ class PotentialFunctionProvider:
         r"""Return posterior theta log prob. $p(\theta|x)$, $-\infty$ if outside prior."
 
         Args:
-            theta: Parameters $\theta$, batch dimension 1
+            theta: Parameters $\theta$, batch dimension 1.
 
         Returns:
             Posterior log probability $\log(p(\theta|x))$.
@@ -493,7 +494,7 @@ class PotentialFunctionProvider:
 
         return target_log_prob
 
-    def pyro_potential(self, theta: dict) -> Tensor:
+    def pyro_potential(self, theta: Dict[str, Tensor]) -> Tensor:
         r"""Return posterior log prob. of theta $p(\theta|x)$, -inf where outside prior.
 
         Args:

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -33,7 +33,7 @@ class SnpeBase(NeuralInference, ABC):
         discard_prior_samples: bool = False,
         device: Optional[torch.device] = None,
         sample_with_mcmc: bool = False,
-        mcmc_method: str = "slice-np",
+        mcmc_method: str = "slice_np",
         num_workers: int = 1,
         worker_batch_size: int = 20,
         summary_writer: Optional[SummaryWriter] = None,

--- a/sbi/inference/snpe/snpe_c.py
+++ b/sbi/inference/snpe/snpe_c.py
@@ -30,7 +30,7 @@ class SnpeC(SnpeBase):
         worker_batch_size: int = 20,
         device: Optional[torch.device] = None,
         sample_with_mcmc: bool = False,
-        mcmc_method: str = "slice-np",
+        mcmc_method: str = "slice_np",
         skip_input_checks: bool = False,
         show_progressbar: bool = True,
         show_round_summary: bool = False,

--- a/sbi/inference/sre/sre.py
+++ b/sbi/inference/sre/sre.py
@@ -17,6 +17,7 @@ import sbi.utils as utils
 from sbi.inference.base import NeuralInference
 from sbi.inference.posteriors.sbi_posterior import Posterior
 from sbi.utils.torchutils import ensure_x_batched, ensure_theta_batched
+from sbi.types import ScalarFloat, OneOrMore
 
 
 class SRE(NeuralInference):
@@ -120,7 +121,7 @@ class SRE(NeuralInference):
     def __call__(
         self,
         num_rounds: int,
-        num_simulations_per_round: Union[List[int], int],
+        num_simulations_per_round: OneOrMore[int],
         batch_size: int = 100,
         learning_rate: float = 5e-4,
         validation_fraction: float = 0.1,
@@ -423,7 +424,7 @@ class PotentialFunctionProvider:
         else:
             return self.np_potential
 
-    def np_potential(self, theta: np.array) -> Union[Tensor, float]:
+    def np_potential(self, theta: np.array) -> ScalarFloat:
         """Return potential for Numpy slice sampler."
 
         Args:

--- a/sbi/inference/sre/sre.py
+++ b/sbi/inference/sre/sre.py
@@ -28,7 +28,7 @@ class SRE(NeuralInference):
         classifier: Optional[nn.Module] = None,
         num_atoms: Optional[int] = None,
         simulation_batch_size: int = 1,
-        mcmc_method: str = "slice-np",
+        mcmc_method: str = "slice_np",
         summary_net: Optional[nn.Module] = None,
         classifier_loss: str = "sre",
         retrain_from_scratch_each_round: bool = False,

--- a/sbi/types.py
+++ b/sbi/types.py
@@ -1,0 +1,12 @@
+from typing import Sequence, TypeVar, Union
+
+import numpy as np
+import torch
+from torch import Tensor
+
+Array = Union[np.ndarray, torch.Tensor]
+
+T = TypeVar("T")
+OneOrMore = Union[T, Sequence[T]]
+
+ScalarFloat = Union[Tensor, float]

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -167,7 +167,7 @@ def sample_posterior_within_prior(
         pbar.update(num_accepted)
 
         # To avoid endless sampling when leakage is high, we raise a warning if the
-        # acceptance rate is too after the first 1.000 samples.
+        # acceptance rate is too low after the first 1_000 samples.
         acceptance_rate = (num_samples - num_remaining) / num_sampled_total
         if (
             num_sampled_total > 1000

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -1,10 +1,9 @@
-import time
 import warnings
 from typing import Sequence, Tuple, Union
 
 import torch
 import torch.nn as nn
-from torch import Tensor
+from torch import Tensor, as_tensor, kthvalue
 
 import sbi.utils as utils
 from tqdm.auto import tqdm
@@ -31,7 +30,7 @@ def match_shapes_of_theta_and_x(
     x: Union[Sequence[float], float],
     x_o: Tensor,
     correct_for_leakage: bool,
-) -> (Tensor, Tensor):
+) -> Tuple[Tensor, Tensor]:
     r"""
     Formats parameters theta and simulation outputs x into shapes that can be processed
      by neural density estimators for the posterior $p(\theta|x)$.
@@ -85,6 +84,9 @@ def match_shapes_of_theta_and_x(
 
     # if multiple observations, with snpe avoid expensive leakage
     # correction by rejection sampling
+    # TODO: can we move this test to sbi_posterior::get_leakage_correction, or will it
+    # eventually break if run after x = x.repeat(theta.shape[0], 1) below. If so,
+    # consider moving that line to where needed.
     if x.shape[0] > 1 and correct_for_leakage:
         raise ValueError(
             "Only a single conditioning variable x allowed for log-prob when "
@@ -105,92 +107,83 @@ def match_shapes_of_theta_and_x(
 
 
 def sample_posterior_within_prior(
-    posterior_nn: torch.nn.Module,
-    prior: torch.distributions.Distribution,
+    posterior_nn: nn.Module,
+    prior,
     x: Tensor,
     num_samples: int = 1,
     show_progressbar: bool = False,
-) -> Tuple[Tensor, float]:
-    r"""Return samples from a posterior $p(\theta|x)$ within the support of the prior
-     via rejection sampling.
+    warn_acceptance: float = 0.01,
+) -> Tuple[Tensor, Tensor]:
+    r"""Return samples from a posterior $p(\theta|x)$ only within the prior support.
 
     This is relevant for snpe methods and flows for which the posterior tends to have
      mass outside the prior boundaries.
 
-    This function uses rejection sampling with samples from posterior, to do two things:
-        1) obtain posterior samples within the prior support.
+    This function uses rejection sampling with samples from posterior in order to
+        1) obtain posterior samples within the prior support, and
         2) calculate the fraction of accepted samples as a proxy for correcting the
-         density during evaluation of the posterior.
+           density during evaluation of the posterior.
 
     Args:
-        posterior_nn: neural net representing the posterior
-        prior: torch distribution prior
-        x: conditioning variable $x$ for the posterior $p(\theta|x)$
-        num_samples: number of sample to generate
-        show_progressbar: whether to show a progressbar during sampling
+        posterior_nn: Neural net representing the posterior.
+        prior: Distribution-like object that evaluates probabilities with `log_prob`.
+        x: Conditioning variable $x$ for the posterior $p(\theta|x)$.
+        num_samples: Desired number of samples.
+        show_progressbar: Whether to show a progressbar during sampling.
+        warn_acceptance: A minimum acceptance rate under which to warn about slowness.
 
     Returns:
-        Accepted samples, and estimated acceptance
-         probability
+        Accepted samples and acceptance rate as scalar Tensor.
     """
 
-    assert (
-        not posterior_nn.training
-    ), "posterior nn is in training mode, but has to be in eval mode for sampling."
+    assert not posterior_nn.training, "Posterior nn must be in eval mode for sampling."
 
-    samples = []
-    num_remaining = num_samples
-    num_sampled_total = 0
-    leakage_warning_raised = False
-
-    # we might not always want a progressbar for sampling. E.g. we want to display that,
-    # after each round, we also draw samples just for logging. Thus, the progressbar
-    # can be turned off with the show_progressbar argument.
+    # Progress bar can be skipped, e.g. when sampling after each round just for logging.
     pbar = tqdm(
-        total=num_remaining,
         disable=not show_progressbar,
-        desc="Drawing {0} posterior samples".format(num_remaining),
+        total=num_samples,
+        desc=f"Drawing {num_samples} posterior samples",
     )
 
-    with pbar:
-        while num_remaining > 0:
+    num_remaining, num_sampled_total = num_samples, 0
+    accepted, acceptance_rate = [], float("Nan")
+    leakage_warning_raised = False
+    # In each iteration of the loop we sample the remaining number of samples from the
+    # posterior. Some of these samples have 0 probability under the prior, i.e. there
+    # is leakage (acceptance rate<1) so sample again until reaching `num_samples`.
+    while num_remaining > 0:
 
-            # XXX: we need this reshape here because posterior_nn.sample sometimes return
-            # leading singleton dimension instead of (num_samples), e.g., (1, 10000, 4)
-            # instead of (10000, 4). and this can't be handled by MultipleIndependent. issue #141
-            sample = posterior_nn.sample(num_remaining, context=x).reshape(
-                num_remaining, -1
+        candidates = posterior_nn.sample(num_remaining, context=x)
+        # TODO we need this reshape here because posterior_nn.sample sometimes return
+        # leading singleton dimension instead of (num_samples), e.g., (1, 10000, 4)
+        # instead of (10000, 4). This can't be handled by MultipleIndependent, see #141.
+        candidates = candidates.reshape(num_remaining, -1)
+        num_sampled_total += num_remaining
+
+        are_within_prior = torch.isfinite(prior.log_prob(candidates))
+        accepted.append(candidates[are_within_prior])
+
+        num_accepted = are_within_prior.sum().item()
+        pbar.update(num_accepted)
+
+        # To avoid endless sampling when leakage is high, we raise a warning if the
+        # acceptance rate is too after the first 1.000 samples.
+        acceptance_rate = (num_samples - num_remaining) / num_sampled_total
+        if (
+            num_sampled_total > 1000
+            and acceptance_rate < warn_acceptance
+            and not leakage_warning_raised
+        ):
+            warnings.warn(
+                f"""Only {acceptance_rate:.0%} posterior samples are within the
+                    prior support. It may take a long time to collect the remaining
+                    {num_remaining} samples. Consider interrupting (Ctrl-C)
+                    and switching to `sample_with_mcmc=True`."""
             )
-            num_sampled_total += num_remaining
+            leakage_warning_raised = True  # Ensure warning is raised just once.
 
-            is_within_prior = torch.isfinite(prior.log_prob(sample))
-            num_in_prior = is_within_prior.sum().item()
+        num_remaining -= num_accepted
 
-            if num_in_prior > 0:
-                samples.append(sample[is_within_prior,].reshape(num_in_prior, -1))
-                num_remaining -= num_in_prior
+    pbar.close()
 
-            # If leakage is very high, we might be caught in an infinite loop here.
-            # So, after at least 1000 drawn samples, we evaluate if less than 1% were
-            # accepted at this point. If so, we raise a warning.
-            num_accepted_total = num_samples - num_remaining
-            if (
-                num_sampled_total > 1000
-                and num_accepted_total < num_sampled_total * 0.01
-                and not leakage_warning_raised
-            ):
-                warnings.warn(
-                    "Leakage >99% detected. This will drastically slow down sampling."
-                    "Consider switching to sample_with_mcmc=True"
-                )
-                leakage_warning_raised = True  # make sure warning is raised just once
-
-            pbar.update(num_in_prior)
-
-    # collect all samples in the list into one tensor
-    samples = torch.cat(samples)
-
-    # estimate acceptance probability
-    acceptance_prob = float((samples.shape[0]) / num_sampled_total)
-
-    return samples, acceptance_prob
+    return torch.cat(accepted), as_tensor(acceptance_rate)

--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -247,7 +247,7 @@ def ensure_x_batched(x: Tensor) -> Tensor:
     return x
 
 
-def atleast_2d(*arys: Union[np.array, Tensor]) -> Union[Tensor, List[Tensor]]:
+def atleast_2d_many(*arys: Union[np.array, Tensor]) -> Union[Tensor, List[Tensor]]:
     """Return tensors with at least dimension 2.
 
     Tensors or arrays of dimension 0 or 1 will get additional dimension(s) prepended.
@@ -259,6 +259,10 @@ def atleast_2d(*arys: Union[np.array, Tensor]) -> Union[Tensor, List[Tensor]]:
         arr = arys[0]
         if isinstance(arr, np.ndarray):
             arr = torch.from_numpy(arr)
-        return arr if arr.ndim >= 2 else arr.reshape(1, -1)
+        return atleast_2d(arr)
     else:
-        return [atleast_2d(arr) for arr in arys]
+        return [atleast_2d_many(arr) for arr in arys]
+
+
+def atleast_2d(t: Tensor) -> Tensor:
+    return t if t.ndim >= 2 else t.reshape(1, -1)

--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -1,23 +1,22 @@
 """Various PyTorch utility functions."""
 
-from typing import List, Union
-
 import numpy as np
 import torch
 from torch import Tensor
 from torch.distributions import Independent, Uniform
 
 import sbi.utils as utils
+from sbi.types import Array, OneOrMore, ScalarFloat
 
 
 def get_default_device():
-    """Returns default device by creating a tensor for testing"""
+    """Returns default device by creating a tensor for testing."""
     return torch.ones((1,)).device
 
 
 def tile(x, n):
     if not utils.is_positive_int(n):
-        raise TypeError("Argument 'n' must be a positive integer.")
+        raise TypeError("Argument `n` must be a positive integer.")
     x_ = x.reshape(-1)
     x_ = x_.repeat(n)
     x_ = x_.reshape(n, -1)
@@ -183,23 +182,20 @@ def gaussian_kde_log_eval(samples, query):
 
 class BoxUniform(Independent):
     def __init__(
-        self,
-        low: Union[Tensor, float],
-        high: Union[Tensor, float],
-        reinterpreted_batch_ndims: int = 1,
+        self, low: ScalarFloat, high: ScalarFloat, reinterpreted_batch_ndims: int = 1,
     ):
         """Multidimensional uniform distribution defined on a box.
-        
+
         A `Uniform` distribution initialized with e.g. a parameter vector low or high of
          length 3 will result in a /batch/ dimension of length 3. A log_prob evaluation
          will then output three numbers, one for each of the independent Uniforms in
          the batch. Instead, a `BoxUniform` initialized in the same way has three
          /event/ dimensions, and returns a scalar log_prob corresponding to whether
          the evaluated point is in the box defined by low and high or outside.
-    
+
         Refer to torch.distributions.Uniform and torch.distributions.Independent for
          further documentation.
-    
+
         Args:
             low: lower range (inclusive).
             high: upper range (exclusive).
@@ -231,12 +227,12 @@ def ensure_theta_batched(theta: Tensor) -> Tensor:
 def ensure_x_batched(x: Tensor) -> Tensor:
     """
     Return simulation output x that has a batch dimension, i.e. has shape
-    (1, shape_of_single_x)
+    (1, shape_of_single_x).
 
     Args:
-         x: simulation output of shape (n) or (1,n)
+         x: simulation output of shape (n) or (1,n).
      Returns:
-         Batched simulation output x
+         Batched simulation output x.
     """
 
     # ensure x has shape (1, shape_of_single_x). If shape[0] > 1, we assume that
@@ -247,7 +243,7 @@ def ensure_x_batched(x: Tensor) -> Tensor:
     return x
 
 
-def atleast_2d_many(*arys: Union[np.array, Tensor]) -> Union[Tensor, List[Tensor]]:
+def atleast_2d_many(*arys: Array) -> OneOrMore[Tensor]:
     """Return tensors with at least dimension 2.
 
     Tensors or arrays of dimension 0 or 1 will get additional dimension(s) prepended.

--- a/tests/linearGaussian_snl_test.py
+++ b/tests/linearGaussian_snl_test.py
@@ -39,7 +39,7 @@ def test_snl_on_linearGaussian_api(num_dim: int):
         x_o=x_o,
         density_estimator=None,  # Use default MAF.
         simulation_batch_size=50,
-        mcmc_method="slice-np",
+        mcmc_method="slice_np",
     )
 
     posterior = infer(num_rounds=1, num_simulations_per_round=1000)
@@ -87,7 +87,7 @@ def test_snl_on_linearGaussian_based_on_mmd(num_dim: int, prior_str: str, set_se
         prior=prior,
         x_o=x_o,
         density_estimator=None,  # Use default MAF.
-        mcmc_method="slice-np",
+        mcmc_method="slice_np",
     )
 
     posterior = infer(num_rounds=1, num_simulations_per_round=1000)
@@ -160,8 +160,8 @@ def test_multi_round_snl_on_linearGaussian_based_on_mmd(set_seed):
 @pytest.mark.parametrize(
     "mcmc_method, prior_str",
     (
-        ("slice-np", "gaussian"),
-        ("slice-np", "uniform"),
+        ("slice_np", "gaussian"),
+        ("slice_np", "uniform"),
         ("slice", "gaussian"),
         ("slice", "uniform"),
     ),
@@ -199,7 +199,7 @@ def test_snl_posterior_correction(mcmc_method: str, prior_str: str, set_seed):
         x_o=x_o,
         density_estimator=None,  # Use default MAF.
         simulation_batch_size=50,
-        mcmc_method="slice-np",
+        mcmc_method="slice_np",
     )
 
     posterior = infer(num_rounds=1, num_simulations_per_round=1000)

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -252,7 +252,7 @@ def test_multi_round_snpe_deterministic_simulator(set_seed, z_score_min_std):
 @pytest.mark.parametrize(
     "sample_with_mcmc, mcmc_method, prior",
     (
-        (True, "slice-np", "gaussian"),
+        (True, "slice_np", "gaussian"),
         (True, "slice", "gaussian"),
         # XXX (True, "slice", "uniform"),
         # XXX takes very long. fix when refactoring pyro sampling

--- a/tests/linearGaussian_sre_test.py
+++ b/tests/linearGaussian_sre_test.py
@@ -39,7 +39,7 @@ def test_sre_on_linearGaussian_api(num_dim: int):
         x_o=x_o,
         classifier=None,  # Use default RESNET.
         simulation_batch_size=50,
-        mcmc_method="slice-np",
+        mcmc_method="slice_np",
     )
 
     posterior = infer(num_rounds=1, num_simulations_per_round=1000)
@@ -101,7 +101,7 @@ def test_sre_on_linearGaussian_based_on_mmd(
         classifier=None,  # Use default RESNET.
         classifier_loss=classifier_loss,
         simulation_batch_size=50,
-        mcmc_method="slice-np",
+        mcmc_method="slice_np",
     )
 
     posterior = infer(num_rounds=1, num_simulations_per_round=1000)
@@ -141,8 +141,8 @@ def test_sre_on_linearGaussian_based_on_mmd(
 @pytest.mark.parametrize(
     "mcmc_method, prior_str",
     (
-        ("slice-np", "gaussian"),
-        ("slice-np", "uniform"),
+        ("slice_np", "gaussian"),
+        ("slice_np", "uniform"),
         ("slice", "gaussian"),
         ("slice", "uniform"),
     ),

--- a/tests/torchutils_test.py
+++ b/tests/torchutils_test.py
@@ -123,11 +123,11 @@ def test_ensure_batch_dim():
     assert t2.ndim == 3
 
 
-def test_atleast_2d():
+def test_atleast_2d_many():
     t1 = np.array([0.0, -1.0, 1.0])
     t2 = torch.tensor([[1, 2, 3]])
 
-    t3, t4 = torchutils.atleast_2d(t1, t2)
+    t3, t4 = torchutils.atleast_2d_many(t1, t2)
 
     assert isinstance(t3, torch.Tensor)
     assert t3.ndim == 2

--- a/tests/utils_for_testing/linearGaussian_logprob.py
+++ b/tests/utils_for_testing/linearGaussian_logprob.py
@@ -71,12 +71,12 @@ def get_normalization_uniform_prior(
 
     # Compute unnormalized density, i.e. just the output of the density estimator.
     posterior_likelihood_unnorm = torch.exp(
-        posterior.log_prob(prior_sample, normalize_snpe_density=False)
+        posterior.log_prob(prior_sample, norm_posterior_snpe=False)
     )
     # Compute the normalized density, scale up output of the density
     # estimator by the ratio of posterior samples within the prior bounds.
     posterior_likelihood_norm = torch.exp(
-        posterior.log_prob(prior_sample, normalize_snpe_density=True)
+        posterior.log_prob(prior_sample, norm_posterior_snpe=True)
     )
 
     # Estimate acceptance ratio through rejection sampling.


### PR DESCRIPTION
This
- updates docs and comments in `sbi_posterior.py`
- fixes a bug when `x` and `self.x_o` are both None
- simpIifies substantially `get_leakage_correction`
- provides more information to the user when warning that leakage is high
- makes leakage threshold for warning a settable argument
- replaces `atleast_2d` with an arity 1 function that does not type-convert (old function is now `atleast_2d_many`, may want to deprecate).
- fixes a couple of typos (missing `_`, extra `,`) that would result in bugs (and where not caught by the tests...).

Happy to have a pair of eyes glance over, and merge quickly. 