### PR TITLE
handle NaN data by excluding it from training.

### DIFF
--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -34,6 +34,7 @@ class NeuralInference(ABC):
         show_progressbar: bool = True,
         show_round_summary: bool = False,
         logging_level: Union[int, str] = "warning",
+        handle_nans: bool = False,
     ):
         r"""
         Args:
@@ -65,6 +66,9 @@ class NeuralInference(ABC):
             logging_level: Minimum severity of messages to log. One of the strings
                 "info", "warning", "debug", "error" and "critical". Currently only
                 applied when parallelization is requested for the simulator.
+            handle_nans: If True, simulations containing NaN or infinite values are
+                excluded from training, if False a warning is raised if NaNs or
+                infinite values occur.
         """
 
         self._simulator, self._prior, self._x_shape = prepare_sbi_problem(
@@ -95,6 +99,7 @@ class NeuralInference(ABC):
         # Initialize roundwise (theta, x) for storage of parameters and simulations.
         # XXX Rename self._roundwise_* or self._rounds_*
         self._theta_bank, self._x_bank = [], []
+        self.handle_nans = handle_nans
 
         # XXX We could instantiate here the Posterior for all children. Two problems:
         #     1. We must dispatch to right PotentialProvider for mcmc based on name

--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -34,7 +34,7 @@ class NeuralInference(ABC):
         show_progressbar: bool = True,
         show_round_summary: bool = False,
         logging_level: Union[int, str] = "warning",
-        handle_nans: bool = False,
+        exclude_invalid_x: bool = False,
     ):
         r"""
         Args:
@@ -66,8 +66,8 @@ class NeuralInference(ABC):
             logging_level: Minimum severity of messages to log. One of the strings
                 "info", "warning", "debug", "error" and "critical". Currently only
                 applied when parallelization is requested for the simulator.
-            handle_nans: If True, simulations containing NaN or infinite values are
-                excluded from training, if False a warning is raised if NaNs or
+            exclude_invalid_x: If True, simulations containing NaN or infinite values
+                are excluded from training, if False a warning is raised if NaNs or
                 infinite values occur.
         """
 
@@ -99,7 +99,7 @@ class NeuralInference(ABC):
         # Initialize roundwise (theta, x) for storage of parameters and simulations.
         # XXX Rename self._roundwise_* or self._rounds_*
         self._theta_bank, self._x_bank = [], []
-        self.handle_nans = handle_nans
+        self.exclude_invalid_x = exclude_invalid_x
 
         # XXX We could instantiate here the Posterior for all children. Two problems:
         #     1. We must dispatch to right PotentialProvider for mcmc based on name

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -14,7 +14,7 @@ from sbi.inference.posterior import NeuralPosterior
 from sbi.inference import NeuralInference
 from sbi.types import ScalarFloat, OneOrMore
 import sbi.utils as utils
-from sbi.utils.sbiutils import find_nan_in_simulations, warn_on_too_many_nans
+from sbi.utils import handle_invalid_x, warn_on_invalid_x
 
 
 class LikelihoodEstimator(NeuralInference, ABC):
@@ -34,7 +34,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
         show_progressbar: bool = True,
         show_round_summary: bool = False,
         logging_level: Union[int, str] = "warning",
-        handle_nans: bool = False,
+        exclude_invalid_x: bool = False,
     ):
         r"""Sequential Neural Likelihood.
 
@@ -62,7 +62,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
             show_progressbar=show_progressbar,
             show_round_summary=show_round_summary,
             logging_level=logging_level,
-            handle_nans=handle_nans,
+            exclude_invalid_x=exclude_invalid_x,
         )
 
         if density_estimator is None:
@@ -87,7 +87,6 @@ class LikelihoodEstimator(NeuralInference, ABC):
 
         # SNLE-specific summary_writer fields.
         self._summary.update({"mcmc_times": []})  # type: ignore
-        self.handle_nans = handle_nans
 
     def __call__(
         self,
@@ -151,20 +150,14 @@ class LikelihoodEstimator(NeuralInference, ABC):
             # not necessarily have the same order as the theta we define above. We
             # therefore return a theta vector with the same ordering as x.
             theta, x = self._batched_simulator(theta)
-            # Store (theta, x) pairs.
-            # Check for NaNs in data.
-            x_not_nan = ~find_nan_in_simulations(x)
-            print(
-                f"""Found {x_not_nan.numel() - x_not_nan.sum()} NaN simulations. They
-                will be exluded from training."""
-            )
-            if not self.handle_nans:
-                assert x_not_nan.all(), "Simulated data must be finite."
-            else:
-                warn_on_too_many_nans(x)
 
-            self._theta_bank.append(theta[x_not_nan])
-            self._x_bank.append(x[x_not_nan])
+            # Check for NaNs in simulations.
+            is_valid_x, num_nans, num_infs = handle_invalid_x(x, self.exclude_invalid_x)
+            warn_on_invalid_x(num_nans, num_infs, self.exclude_invalid_x)
+
+            # Store (theta, x) pairs.
+            self._theta_bank.append(theta[is_valid_x])
+            self._x_bank.append(x[is_valid_x])
 
             # Fit neural likelihood to newly aggregated dataset.
             self._train(

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -14,8 +14,7 @@ from sbi.inference import NeuralInference
 from sbi.inference.posterior import NeuralPosterior
 from sbi.types import ScalarFloat, OneOrMore
 import sbi.utils as utils
-from sbi.utils import Standardize
-from sbi.utils.sbiutils import warn_on_too_many_nans, find_nan_in_simulations
+from sbi.utils import Standardize, handle_invalid_x, warn_on_invalid_x
 
 
 class PosteriorEstimator(NeuralInference, ABC):
@@ -41,7 +40,7 @@ class PosteriorEstimator(NeuralInference, ABC):
         show_progressbar: bool = True,
         show_round_summary: bool = False,
         logging_level: Union[int, str] = "warning",
-        handle_nans: bool = False,
+        exclude_invalid_x: bool = False,
     ):
         """ Base class for Sequential Neural Posterior Estimation algorithms.
 
@@ -74,7 +73,7 @@ class PosteriorEstimator(NeuralInference, ABC):
             show_progressbar=show_progressbar,
             show_round_summary=show_round_summary,
             logging_level=logging_level,
-            handle_nans=handle_nans,
+            exclude_invalid_x=exclude_invalid_x,
         )
 
         if density_estimator is None:
@@ -166,18 +165,14 @@ class PosteriorEstimator(NeuralInference, ABC):
             # Run simulations for the round.
             theta, x, prior_mask = self._run_simulations(round_, num_sims)
 
-            # Check for NaNs in data.
-            x_not_nan = ~find_nan_in_simulations(x)
-            print(
-                f"""Found {x_not_nan.numel() - x_not_nan.sum()} NaN simulations. They
-                will be exluded from training."""
-            )
-            warn_on_too_many_nans(x)
+            # Check for NaNs in simulations.
+            is_valid_x, num_nans, num_infs = handle_invalid_x(x, self.exclude_invalid_x)
+            warn_on_invalid_x(num_nans, num_infs, self.exclude_invalid_x)
 
             # XXX Rename bank -> rounds/roundwise.
-            self._theta_bank.append(theta[x_not_nan])
-            self._x_bank.append(x[x_not_nan])
-            self._prior_masks.append(prior_mask[x_not_nan])
+            self._theta_bank.append(theta[is_valid_x])
+            self._x_bank.append(x[is_valid_x])
+            self._prior_masks.append(prior_mask[is_valid_x])
 
             # Fit posterior using newly aggregated data set.
             self._train(
@@ -292,14 +287,14 @@ class PosteriorEstimator(NeuralInference, ABC):
     def _z_score_embedding(self, x: Tensor) -> nn.Module:
         """Return embedding net with a standardizing step preprended."""
 
-        # XXX Mouthful, rename self.posterior.nn
         embed_nn = self._posterior.net._embedding_net
 
-        # Exclude NaNs from zscoring.
-        x_not_nan = ~find_nan_in_simulations(x)
-        x_std = torch.std(x[x_not_nan], dim=0)
+        # Maybe exclude NaNs and infs from zscoring.
+        # No warning on invalid x here because warning will occur in __call__.
+        is_valid_x, *_ = handle_invalid_x(x, self.exclude_invalid_x)
+        x_std = torch.std(x[is_valid_x], dim=0)
         x_std[x_std == 0] = self._z_score_min_std
-        preprocess = Standardize(torch.mean(x[x_not_nan], dim=0), x_std)
+        preprocess = Standardize(torch.mean(x[is_valid_x], dim=0), x_std)
 
         # If Sequential has a None component, forward will TypeError.
         return preprocess if embed_nn is None else nn.Sequential(preprocess, embed_nn)

--- a/sbi/inference/snpe/snpe_c.py
+++ b/sbi/inference/snpe/snpe_c.py
@@ -33,6 +33,7 @@ class SNPE_C(PosteriorEstimator):
         show_progressbar: bool = True,
         show_round_summary: bool = False,
         logging_level: Union[int, str] = "warning",
+        exclude_invalid_x: bool = False,
     ):
         r"""SNPE-C / APT [1].
 
@@ -69,6 +70,7 @@ class SNPE_C(PosteriorEstimator):
             show_progressbar=show_progressbar,
             show_round_summary=show_round_summary,
             logging_level=logging_level,
+            exclude_invalid_x=exclude_invalid_x,
         )
 
     def __call__(

--- a/sbi/inference/snre/snre_a.py
+++ b/sbi/inference/snre/snre_a.py
@@ -36,18 +36,19 @@ class SNRE_A(RatioEstimator):
         kwargs = del_entries(locals(), entries=("self", "__class__"))
         return super().__call__(**kwargs, num_atoms=2)
 
-    def _loss(
-        self, theta: Tensor, x: Tensor, clipped_batch_size: int, num_atoms: int
-    ) -> Tensor:
+    def _loss(self, theta: Tensor, x: Tensor, num_atoms: int) -> Tensor:
 
-        logits = self._classifier_logits(theta, x, clipped_batch_size, num_atoms)
+        assert theta.shape[0] == x.shape[0], "Batch sizes for theta and x must match."
+        batch_size = theta.shape[0]
+
+        logits = self._classifier_logits(theta, x, num_atoms)
         likelihood = torch.sigmoid(logits).squeeze()
 
         # Alternating pairs where there is one sampled from the joint and one
         # sampled from the marginals. The first element is sampled from the
         # joint p(theta, x) and is labelled 1. The second element is sampled
         # from the marginals p(theta)p(x) and is labelled 0. And so on.
-        labels = ones(2 * clipped_batch_size)  # two atoms
+        labels = ones(2 * batch_size)  # two atoms
         labels[1::2] = 0.0
 
         # Binary cross entropy to learn the likelihood (AALR-specific)

--- a/sbi/inference/snre/snre_b.py
+++ b/sbi/inference/snre/snre_b.py
@@ -7,17 +7,17 @@ from sbi.inference.snre.snre_base import RatioEstimator
 
 
 class SNRE_B(RatioEstimator):
-    def _loss(
-        self, theta: Tensor, x: Tensor, clipped_batch_size: int, num_atoms: int
-    ) -> Tensor:
+    def _loss(self, theta: Tensor, x: Tensor, num_atoms: int) -> Tensor:
         """Return cross-entropy loss for 1-out-of-`num_atoms` classification."""
 
-        logits = self._classifier_logits(theta, x, clipped_batch_size, num_atoms)
+        assert theta.shape[0] == x.shape[0], "Batch sizes for theta and x must match."
+        batch_size = theta.shape[0]
+        logits = self._classifier_logits(theta, x, num_atoms)
 
         # For 1-out-of-`num_atoms` classification each datapoint consists
         # of `num_atoms` points, with one of them being the correct one.
-        # We have a batch of `clipped_batch_size` such datapoints.
-        logits = logits.reshape(clipped_batch_size, num_atoms)
+        # We have a batch of `batch_size` such datapoints.
+        logits = logits.reshape(batch_size, num_atoms)
 
         # Index 0 is the theta-x-pair sampled from the joint p(theta,x) and hence the
         # "correct" one for the 1-out-of-N classification.

--- a/sbi/simulators/simutils.py
+++ b/sbi/simulators/simutils.py
@@ -85,7 +85,7 @@ def simulate_in_batches(
     num_sims, *_ = theta.shape
 
     if num_sims == 0:
-        logging.warn("Zero-length parameter theta implies zero simulations.")
+        logging.warning("Zero-length parameter theta implies zero simulations.")
         x = torch.tensor([])
     elif sim_batch_size is not None and sim_batch_size < num_sims:
         # Dev note: pyright complains of torch.split lacking a type stub

--- a/sbi/utils/__init__.py
+++ b/sbi/utils/__init__.py
@@ -7,6 +7,8 @@ from sbi.utils.sbiutils import (
     sample_posterior_within_prior,
     del_entries,
     clamp_and_warn,
+    handle_invalid_x,
+    warn_on_invalid_x,
 )
 from sbi.utils.torchutils import (
     BoxUniform,

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -119,3 +119,30 @@ def sample_posterior_within_prior(
     pbar.close()
 
     return torch.cat(accepted), as_tensor(acceptance_rate)
+
+
+def find_nan_in_simulations(x: Tensor) -> Tensor:
+    """Return mask for finding simulated data that contain NaNs from a batch of x.
+
+    Args:
+        x: a batch of simulated data x
+
+    Returns:
+        mask: True for NaN simulations.
+    """
+
+    # Check for any NaNs in every simulation (dim 1 checks across columns).
+    return torch.isnan(x).any(dim=1)
+
+
+def warn_on_too_many_nans(x: Tensor, percent_nan_threshold=0.5) -> None:
+    """Raises warning if too many (above threshold) NaNs are in given batch of x."""
+
+    percent_nan = find_nan_in_simulations(x).sum() / float(len(x))
+
+    if percent_nan > percent_nan_threshold:
+        logging.warning(
+            f"""Found {100 * percent_nan} NaNs in simulations. They
+            will be excluded from training which the effective number of
+            training samples and can impact training performance."""
+        )

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -1,9 +1,8 @@
 import logging
 from typing import Tuple, Dict, Sequence, Any
-import warnings
 
 import torch
-from torch import Tensor, as_tensor
+from torch import Tensor, as_tensor, ones
 import torch.nn as nn
 from tqdm.auto import tqdm
 
@@ -108,7 +107,7 @@ def sample_posterior_within_prior(
             and acceptance_rate < warn_acceptance
             and not leakage_warning_raised
         ):
-            warnings.warn(
+            logging.warning(
                 f"""Only {acceptance_rate:.0%} posterior samples are within the
                     prior support. It may take a long time to collect the remaining
                     {num_remaining} samples. Consider interrupting (Ctrl-C)
@@ -121,28 +120,45 @@ def sample_posterior_within_prior(
     return torch.cat(accepted), as_tensor(acceptance_rate)
 
 
-def find_nan_in_simulations(x: Tensor) -> Tensor:
-    """Return mask for finding simulated data that contain NaNs from a batch of x.
+def handle_invalid_x(
+    x: Tensor, exclude_invalid_x: bool = True
+) -> Tuple[Tensor, int, int]:
+    """Return Tensor mask that is True where simulations x are valid.
 
-    Args:
-        x: a batch of simulated data x
+    Additionally return number of NaNs and Infs that were found.
 
-    Returns:
-        mask: True for NaN simulations.
+    Note: If `exclude_invalid` is False, then mask will be True everywhere, ignoring
+    potential NaNs and Infs.
     """
 
-    # Check for any NaNs in every simulation (dim 1 checks across columns).
-    return torch.isnan(x).any(dim=1)
+    batch_size = x.shape[0]
 
+    x_is_nan = torch.isnan(x).any(dim=1)
+    x_is_inf = torch.isinf(x).any(dim=1)
+    num_nans = int(x_is_nan.sum().item())
+    num_infs = int(x_is_inf.sum().item())
 
-def warn_on_too_many_nans(x: Tensor, percent_nan_threshold=0.5) -> None:
-    """Raises warning if too many (above threshold) NaNs are in given batch of x."""
-
-    percent_nan = find_nan_in_simulations(x).sum() / float(len(x))
-
-    if percent_nan > percent_nan_threshold:
-        logging.warning(
-            f"""Found {100 * percent_nan} NaNs in simulations. They
-            will be excluded from training which the effective number of
-            training samples and can impact training performance."""
+    if exclude_invalid_x:
+        x_is_valid = torch.logical_and(
+            torch.logical_not(x_is_nan), torch.logical_not(x_is_inf)
         )
+    else:
+        x_is_valid = ones(batch_size, dtype=torch.bool)
+
+    return x_is_valid, num_nans, num_infs
+
+
+def warn_on_invalid_x(num_nans: int, num_infs: int, exclude_invalid_x) -> None:
+    """Warn if there are NaNs or Infs. Warning text depends on `exclude_invalid_x`."""
+
+    if num_nans + num_infs > 0:
+        if exclude_invalid_x:
+            logging.warning(
+                f"Found {num_nans} NaN simulations and {num_infs} Inf simulations. "
+                "They will be excluded from training."
+            )
+        else:
+            logging.warning(
+                f"Found {num_nans} NaN simulations and {num_infs} Inf simulations. "
+                "Training might fail. Consider setting `exclude_invalid_x=True`."
+            )

--- a/tests/inference_with_NaN_simulator_test.py
+++ b/tests/inference_with_NaN_simulator_test.py
@@ -1,3 +1,4 @@
+from sbi.utils.sbiutils import handle_invalid_x
 import pytest
 import torch
 
@@ -11,7 +12,6 @@ from sbi.simulators.linear_gaussian import (
     linear_gaussian,
 )
 
-from sbi.utils.sbiutils import find_nan_in_simulations
 from tests.test_utils import check_c2st
 
 
@@ -24,60 +24,44 @@ from tests.test_utils import check_c2st
         torch.Size((10, 10)),
     ),
 )
-def test_find_nan_in_simulations(x_shape, set_seed):
+def test_handle_invalid_x(x_shape, set_seed):
 
     x = torch.rand(x_shape)
-    x[x < 0.5] = float("nan")
+    x[x < 0.1] = float("nan")
+    x[x > 0.9] = float("inf")
 
-    x_is_nan = find_nan_in_simulations(x)
+    x_is_valid, *_ = handle_invalid_x(x, exclude_invalid_x=True)
 
-    assert torch.isfinite(x[~x_is_nan]).all()
+    assert torch.isfinite(x[x_is_valid]).all()
 
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
-    ("method", "handle_nans", "percent_nans"),
-    (
-        (SNPE_C, True, 0.2),
-        (SNL, True, 0.2),
-        (SRE, True, 0.2),
-        pytest.param(
-            SNL,
-            False,
-            0.1,
-            marks=pytest.mark.xfail(
-                raises=AssertionError, reason="Handling NaNs is set False.",
-            ),
-        ),
-        pytest.param(
-            SNL,
-            False,
-            0.1,
-            marks=pytest.mark.xfail(
-                raises=AssertionError, reason="Handling NaNs is set False",
-            ),
-        ),
-    ),
+    ("method", "exclude_invalid_x", "percent_nans"),
+    ((SNPE_C, True, 0.05), (SNL, True, 0.05), (SRE, True, 0.05),),
 )
-def test_inference_with_nan_simulator(method, handle_nans, percent_nans, set_seed):
+def test_inference_with_nan_simulator(
+    method, exclude_invalid_x, percent_nans, set_seed
+):
 
     # likelihood_mean will be likelihood_shift+theta
     num_dim = 3
     likelihood_shift = -1.0 * ones(num_dim)
     likelihood_cov = 0.3 * eye(num_dim)
     x_o = zeros(1, num_dim)
-    num_samples = 100
+    num_samples = 500
+    num_simulations = 2000
 
     def linear_gaussian_nan(
         theta, likelihood_shift=likelihood_shift, likelihood_cov=likelihood_cov
     ):
         x = linear_gaussian(theta, likelihood_shift, likelihood_cov)
         # Set nan randomly.
-        x[torch.rand(x.shape) < (1.0 / x.shape[1]) * percent_nans] = float("nan")
+        x[torch.rand(x.shape) < (percent_nans * 1.0 / x.shape[1])] = float("nan")
 
         return x
 
-    prior = utils.BoxUniform(-1.0 * ones(num_dim), ones(num_dim))
+    prior = utils.BoxUniform(-2.0 * ones(num_dim), 2.0 * ones(num_dim))
     target_samples = samples_true_posterior_linear_gaussian_uniform_prior(
         x_o,
         likelihood_shift=likelihood_shift,
@@ -87,14 +71,22 @@ def test_inference_with_nan_simulator(method, handle_nans, percent_nans, set_see
     )
 
     if method == SNPE_C:
-        infer = method(simulator=linear_gaussian_nan, prior=prior)
+        infer = method(
+            simulator=linear_gaussian_nan,
+            prior=prior,
+            exclude_invalid_x=exclude_invalid_x,
+        )
     else:
         infer = method(
-            simulator=linear_gaussian_nan, prior=prior, handle_nans=handle_nans
+            simulator=linear_gaussian_nan,
+            prior=prior,
+            exclude_invalid_x=exclude_invalid_x,
         )
 
-    posterior = infer(num_rounds=1, num_simulations_per_round=2000).freeze(x_o)
+    posterior = infer(num_rounds=1, num_simulations_per_round=num_simulations).freeze(
+        x_o
+    )
     samples = posterior.sample(num_samples)
 
     # Compute the c2st and assert it is near chance level of 0.5.
-    check_c2st(samples, target_samples, alg="snpe_c")
+    check_c2st(samples, target_samples, alg=f"{method}")

--- a/tests/inference_with_NaN_simulator_test.py
+++ b/tests/inference_with_NaN_simulator_test.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 
 from sbi.inference import SNPE_C, SRE, SNL
-from torch import zeros, ones
+from torch import zeros, ones, eye
 
 import sbi.utils as utils
 
@@ -87,10 +87,10 @@ def test_inference_with_nan_simulator(method, handle_nans, percent_nans, set_see
     )
 
     if method == SNPE_C:
-        infer = method(simulator=linear_gaussian_nan, x_o=x_o, prior=prior)
+        infer = method(simulator=linear_gaussian_nan, prior=prior)
     else:
         infer = method(
-            simulator=linear_gaussian_nan, x_o=x_o, prior=prior, handle_nans=handle_nans
+            simulator=linear_gaussian_nan, prior=prior, handle_nans=handle_nans
         )
 
     posterior = infer(num_rounds=1, num_simulations_per_round=2000).freeze(x_o)

--- a/tests/inference_with_NaN_simulator_test.py
+++ b/tests/inference_with_NaN_simulator_test.py
@@ -1,0 +1,100 @@
+import pytest
+import torch
+
+from sbi.inference import SNPE_C, SRE, SNL
+from torch import zeros, ones
+
+import sbi.utils as utils
+
+from sbi.simulators.linear_gaussian import (
+    samples_true_posterior_linear_gaussian_uniform_prior,
+    linear_gaussian,
+)
+
+from sbi.utils.sbiutils import find_nan_in_simulations
+from tests.test_utils import check_c2st
+
+
+@pytest.mark.parametrize(
+    "x_shape",
+    (
+        torch.Size((1, 1)),
+        torch.Size((1, 10)),
+        torch.Size((10, 1)),
+        torch.Size((10, 10)),
+    ),
+)
+def test_find_nan_in_simulations(x_shape, set_seed):
+
+    x = torch.rand(x_shape)
+    x[x < 0.5] = float("nan")
+
+    x_is_nan = find_nan_in_simulations(x)
+
+    assert torch.isfinite(x[~x_is_nan]).all()
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    ("method", "handle_nans", "percent_nans"),
+    (
+        (SNPE_C, True, 0.2),
+        (SNL, True, 0.2),
+        (SRE, True, 0.2),
+        pytest.param(
+            SNL,
+            False,
+            0.1,
+            marks=pytest.mark.xfail(
+                raises=AssertionError, reason="Handling NaNs is set False.",
+            ),
+        ),
+        pytest.param(
+            SNL,
+            False,
+            0.1,
+            marks=pytest.mark.xfail(
+                raises=AssertionError, reason="Handling NaNs is set False",
+            ),
+        ),
+    ),
+)
+def test_inference_with_nan_simulator(method, handle_nans, percent_nans, set_seed):
+
+    # likelihood_mean will be likelihood_shift+theta
+    num_dim = 3
+    likelihood_shift = -1.0 * ones(num_dim)
+    likelihood_cov = 0.3 * eye(num_dim)
+    x_o = zeros(1, num_dim)
+    num_samples = 100
+
+    def linear_gaussian_nan(
+        theta, likelihood_shift=likelihood_shift, likelihood_cov=likelihood_cov
+    ):
+        x = linear_gaussian(theta, likelihood_shift, likelihood_cov)
+        # Set nan randomly.
+        x[torch.rand(x.shape) < (1.0 / x.shape[1]) * percent_nans] = float("nan")
+
+        return x
+
+    prior = utils.BoxUniform(-1.0 * ones(num_dim), ones(num_dim))
+    target_samples = samples_true_posterior_linear_gaussian_uniform_prior(
+        x_o,
+        likelihood_shift=likelihood_shift,
+        likelihood_cov=likelihood_cov,
+        num_samples=num_samples,
+        prior=prior,
+    )
+
+    if method == SNPE_C:
+        infer = method(simulator=linear_gaussian_nan, x_o=x_o, prior=prior)
+    else:
+        infer = method(
+            simulator=linear_gaussian_nan, x_o=x_o, prior=prior, handle_nans=handle_nans
+        )
+
+    posterior = infer(num_rounds=1, num_simulations_per_round=2000).freeze(x_o)
+    samples = posterior.sample(num_samples)
+
+    # Compute the c2st and assert it is near chance level of 0.5.
+    check_c2st(samples, target_samples, alg="snpe_c")

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -252,15 +252,10 @@ will have infinites, which we reject."""
         pytest.param(
             0.0,
             marks=pytest.mark.xfail(
-                raises=NotImplementedError, reason=_fail_reason_deterministic_sim,
+                raises=AssertionError, reason=_fail_reason_deterministic_sim,
             ),
         ),
-        pytest.param(
-            1e-7,
-            marks=pytest.mark.xfail(
-                raises=NotImplementedError, reason="""SNPE-B not implemented""",
-            ),
-        ),
+        1e-7,
     ),
 )
 def test_multi_round_snpe_deterministic_simulator(set_seed, z_score_min_std):

--- a/tests/simulator_utils_test.py
+++ b/tests/simulator_utils_test.py
@@ -13,7 +13,7 @@ torch.set_default_tensor_type("torch.FloatTensor")
 
 
 @pytest.mark.parametrize(
-    "num_sims", (pytest.param(0, marks=pytest.mark.xfail), 100, 1000)
+    "num_sims", (0, 100, 1000),
 )
 @pytest.mark.parametrize("batch_size", (1, 100, 1000))
 def test_simulate_in_batches(


### PR DESCRIPTION
This handles NaN simulations that simulators might return for invalid simulations. This is needed in sbibm where some ODE solvers fail for some parameters. 

- exclude nan x from theta and x banks 
- exclude nan in z_scoring

In principle, snpe would have another way of dealing with nan simulations - the calibration kernels. But these are not available in SRE and SNL, so this is a quick way to have binary calibration kernel (implicitly) for all inference algs. 

closes #184 
closes #210 