### PR TITLE
Allow x_o=None

### DIFF
--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -181,7 +181,7 @@ class NeuralInference(ABC):
         -------------------------
         Epochs trained: {epochs}
         Best validation performance: {best_validation_log_probs:.4f}
-        Leakage: {1.-posterior_acceptance_prob:.4f}
+        Acceptance rate: {posterior_acceptance_prob:.4f}
         -------------------------
         """
 
@@ -263,12 +263,12 @@ class NeuralInference(ABC):
 
         self._summary_writer.flush()
 
-    def _infer_data_dimension(self) -> Tensor:
+    def _infer_data_dimension(self) -> torch.Size:
         """
         Infers the dimensionality of a single x.
 
-        Returns: ?
-
+        Returns:
+            Shape of simulation output (without batch dimension).
         """
         if self._x_o is None:
             return self._simulator(self._prior.sample((1,))).shape[1:]

--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -69,6 +69,8 @@ class NeuralInference(ABC):
             simulator, prior, x_o, skip_input_checks
         )
 
+        self._data_dimension = self._infer_data_dimension()
+
         self._show_progressbar = show_progressbar
         self._show_round_summary = show_round_summary
 
@@ -260,3 +262,15 @@ class NeuralInference(ABC):
         )
 
         self._summary_writer.flush()
+
+    def _infer_data_dimension(self) -> Tensor:
+        """
+        Infers the dimensionality of a single x.
+
+        Returns: ?
+
+        """
+        if self._x_o is None:
+            return self._simulator(self._prior.sample((1,))).shape[1:]
+        else:
+            return self._x_o.shape[1:]

--- a/sbi/inference/posteriors/sbi_posterior.py
+++ b/sbi/inference/posteriors/sbi_posterior.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional
+from typing import Callable, Optional, Union
 from warnings import warn
 
 from pyro.infer.mcmc import HMC, NUTS
@@ -149,7 +149,7 @@ class NeuralPosterior:
         num_rejection_samples: int = 10_000,
         force_update: bool = False,
         show_progressbar: bool = False,
-    ) -> Tensor:
+    ) -> Union[Tensor, None]:
         r"""Return leakage correction factor for a leaky posterior density estimate.
 
         The factor is estimated from the acceptance probability during rejection 
@@ -171,6 +171,9 @@ class NeuralPosterior:
         Returns:
             Saved or newly estimated correction factor (scalar Tensor).
         """
+
+        if x is None:
+            return None
 
         def acceptance_at(x: Tensor) -> Tensor:
             return utils.sample_posterior_within_prior(


### PR DESCRIPTION
Adresses #191 

This PR will implement a function that checks whether `x_o` was passed as `None` and if so, it will run a single simulation to infer the data dimension.

Todo:
- [ ] input checks have to be able to deal with` x_o=None`
- [ ] make an assert if `x_o=None` and `num_rounds>1`

Some development decisions (to be discussed):
- why not put it into the input checks? The input checks can be skipped. But if `x_o=None`, we **always** want to run a simlation to get `x.shape`
- why put it in `inference/base.py`? Because the data dimension is required by SNPE, SRE, and SNL