### PR TITLE
Retrain from scratch

### DIFF
--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -25,6 +25,7 @@ class NeuralInference(ABC):
         prior,
         x_shape: Optional[torch.Size] = None,
         simulation_batch_size: Optional[int] = 1,
+        retrain_from_scratch_each_round: bool = False,
         device: Optional[torch.device] = None,
         summary_writer: Optional[SummaryWriter] = None,
         simulator_name: str = "simulator",
@@ -74,6 +75,7 @@ class NeuralInference(ABC):
         self._skip_input_checks = skip_input_checks
         self._show_progressbar = show_progressbar
         self._show_round_summary = show_round_summary
+        self._retrain_from_scratch_each_round = retrain_from_scratch_each_round
 
         if num_workers > 1:
             self._batched_simulator = lambda theta: simulate_in_batches_mp(


### PR DESCRIPTION
adresses #200 

This turned out to be a bit more involved, so I made a PR.

### Changes
- SNL now also has a `retrain_from_scratch_each_round` attribute
- all methods (SRE, SNL, SNPE) have this argument now, so I moved it to NeuralInference.
- fixed bugs related to the argument in SRE and SNPE
- however, the performance of SNPE is really poor when using `retrain_from_scratch_each_round=True`. Hence, I give a warning if the user sets it to `True` for SNPE

This does not have to go into master urgently, so it's probably best if I wait for Alvaro's PR and then rebase it (there will be merge conflicts in SRE).