### PR TITLE
Fix retrain_from_scratch bug

### DIFF
--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -25,6 +25,7 @@ class NeuralInference(ABC):
         prior,
         x_shape: Optional[torch.Size] = None,
         simulation_batch_size: int = 1,
+        retrain_from_scratch_each_round: bool = False,
         device: Optional[torch.device] = None,
         summary_writer: Optional[SummaryWriter] = None,
         simulator_name: str = "simulator",
@@ -75,6 +76,7 @@ class NeuralInference(ABC):
         self._skip_input_checks = skip_input_checks
         self._show_progressbar = show_progressbar
         self._show_round_summary = show_round_summary
+        self._retrain_from_scratch_each_round = retrain_from_scratch_each_round
 
         self._batched_simulator = lambda theta: simulate_in_batches(
             self._simulator,

--- a/sbi/inference/snpe/snpe_c.py
+++ b/sbi/inference/snpe/snpe_c.py
@@ -7,6 +7,7 @@ from torch.utils.tensorboard import SummaryWriter
 from sbi.inference.snpe.snpe_base import PosteriorEstimator
 from sbi.inference.posterior import NeuralPosterior
 from sbi.utils import repeat_rows, clamp_and_warn, del_entries
+from sbi.types import OneOrMore
 
 
 class SNPE_C(PosteriorEstimator):

--- a/sbi/inference/snre/snre_a.py
+++ b/sbi/inference/snre/snre_a.py
@@ -37,6 +37,13 @@ class SNRE_A(RatioEstimator):
         return super().__call__(**kwargs, num_atoms=2)
 
     def _loss(self, theta: Tensor, x: Tensor, num_atoms: int) -> Tensor:
+        """
+        Returns the binary cross-entropy loss for the trained classifier.
+
+        The classifier takes as input a $(\theta,x)$ pair. It is trained to predict 1
+        if the pair was sampled from the joint $p(\theta,x)$, and to predict 0 if the
+        pair was sampled from the marginals $p(\theta)p(x)$.
+        """
 
         assert theta.shape[0] == x.shape[0], "Batch sizes for theta and x must match."
         batch_size = theta.shape[0]

--- a/sbi/inference/snre/snre_b.py
+++ b/sbi/inference/snre/snre_b.py
@@ -8,7 +8,14 @@ from sbi.inference.snre.snre_base import RatioEstimator
 
 class SNRE_B(RatioEstimator):
     def _loss(self, theta: Tensor, x: Tensor, num_atoms: int) -> Tensor:
-        """Return cross-entropy loss for 1-out-of-`num_atoms` classification."""
+        """
+        Return cross-entropy loss for 1-out-of-`num_atoms` classification.
+
+        The classifier takes as input `num_atoms` $(\theta,x)$ pairs. Out of these
+        pairs, one pair was sampled from the joint $p(\theta,x)$ and all others from the
+        marginals $p(\theta)p(x)$. The classifier is trained to predict which of the
+        pairs was sampled from the joint $p(\theta,x)$.
+        """
 
         assert theta.shape[0] == x.shape[0], "Batch sizes for theta and x must match."
         batch_size = theta.shape[0]

--- a/sbi/utils/get_nn_models.py
+++ b/sbi/utils/get_nn_models.py
@@ -20,7 +20,7 @@ def posterior_nn(
     prior_mean: Tensor,
     prior_std: Tensor,
     x_o_shape: torch.Size,
-    embedding: Optional[nn.Module] = None,
+    embedding: nn.Module = nn.Identity(),
     hidden_features: int = 50,
     mdn_num_components: int = 20,
     made_num_mixture_components: int = 10,


### PR DESCRIPTION
- before this PR, the optimizer was still pointing to the wrong neural network when using `retrain_from_scratch_each_round`

### Fixes
- re-initialize the optimizer if `retrain_from_scratch_each_round`
- implement `retrain_from_scratch_each_round` for SNLE
- hence, all algorithms now have a `retrain_from_scratch_each_round` option -> moved it to `NeuralInference`.
- for SNPE_C, the performance is very poor when using `retrain_from_scratch_each_round`. It is unclear to me why, I am raising a warning in this case.