### PR TITLE
Docstrings, rename algorithm->method, __repr__.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -76,5 +76,5 @@
     "autoDocstring.customTemplatePath": ".vscode/autodocstring.template",
     //
     // Signal that we are using shared workspace settings in .vscode
-    "window.title": "SBI.vscode:: ${dirty}${activeEditorShort}${separator}${rootName}${separator}${appName}"
+    "window.title": "sbi.vscode:: ${dirty}${activeEditorShort}${separator}${rootName}${separator}${appName}"
 }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Warning: pre-release stage
 
-SBI is currently under very active development leading up to a first stable release on 12th June.
+`sbi` is currently under very active development leading up to a first stable release on 12th June.
 
 Some aspects of the interface will change, and the documentation for running the
 inference methods (`SNPE_C / APT, SRE_A / AALR, SRE_B / SRE, SNL`) is not accessible  at the moment through

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ Building on code for "On Contrastive Learning for Likelihood-free Inference" in 
 
 Features neural likelihood-free methods from
 
-> Papamakarios et al., _Sequential Neural Likelihood_ (NSLE_A/SNL), 2019. [[arXiv]](https://arxiv.org/abs/1805.07226)
+> Papamakarios et al., _Sequential Neural Likelihood_ (SNL, "SNLE_A"), 2019. [[arXiv]](https://arxiv.org/abs/1805.07226)
 >
->Greenberg et al., _Automatic Posterior Transformation_ (SNPE_C/APT), 2019. [[arXiv]](https://arxiv.org/abs/1905.07488)
+>Greenberg et al., _Automatic Posterior Transformation_ (APT, "SNPE_C"), 2019. [[arXiv]](https://arxiv.org/abs/1905.07488)
 >
 >Hermans et al., _Likelihood-free Inference with Amortized Approximate Likelihood
->Ratios_ (SNRE_A/AALR), 2020.  [[arXiv]](https://arxiv.org/abs/1903.04057)
+>Ratios_ (AALR, "SNRE_A"), 2020.  [[arXiv]](https://arxiv.org/abs/1903.04057)
 >
->Durkan et al., _On Contrastive Learning for Likelihood-free Inference_, (SNRE_B/SRE), 2020 [[arXiv]](https://arxiv.org/abs/2002.03712) 
+>Durkan et al., _On Contrastive Learning for Likelihood-free Inference_, (SRE, "SNRE_B"), 2020 [[arXiv]](https://arxiv.org/abs/2002.03712) 
 
 ## Setup
 

--- a/docs/docs/credits.md
+++ b/docs/docs/credits.md
@@ -6,9 +6,9 @@ This code builds heavily on previous work by [Conor Durkan](https://conormdurkan
 Relevant repositories include [bayesiains/nsf](https://github.com/bayesiains/nsf) and [conormdurkan/lfi](https://github.com/conormdurkan/lfi).
 
 
-## Algorithms
+## Inference methods
 
-`sbi` implements algorithms from the following papers:
+`sbi` implements inference methods reported in the following contributions:
 
 - **Fast ε-free Inference of Simulation Models with Bayesian Conditional Density
   Estimation**<br> by Papamakarios G. and Murray I. (NeurIPS 2016)
@@ -25,4 +25,4 @@ Relevant repositories include [bayesiains/nsf](https://github.com/bayesiains/nsf
 - **On Contrastive Learning for Likelihood-free Inference**<br>Durkan C.,
   Murray I., and Papamakarios G.(ICML 2020) <br>[[PDF]](https://arxiv.org/abs/2002.03712).
 
-We refer to these algorithms as SNPE-A, SNPE-B, and SNPE-C/APT, respectively.
+We refer to these methods as SNPE-A, SNPE-B, and SNPE-C/APT, respectively.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -6,7 +6,7 @@ The focus of `sbi` is _Sequential Neural Posterior Estimation_ (SNPE). In SNPE, 
 
 - To see illustrations of SNPE on canonical problems in neuroscience, read our preprint:
 [Training deep neural density estimators to identify mechanistic models of neural dynamics](https://www.biorxiv.org/content/10.1101/838383v3).
-- To learn more about the general motivation behind simulation-based inference, and algorithms included in `sbi`, keep on reading.
+- To learn more about the general motivation behind simulation-based inference, and inference methods included in `sbi`, keep on reading.
 
 
 ## Motivation and approach
@@ -33,8 +33,7 @@ SNPE takes three inputs: A candidate mechanistic model, prior knowledge or const
 
 ## Publications
 
-Algorithms included in `sbi` were published in the following papers, which provide additional information:
-
+Refer to the following papers for additional details on the inference methods included in `sbi`: 
 
 - **Fast ε-free Inference of Simulation Models with Bayesian Conditional Density Estimation**<br> by Papamakarios & Murray (NeurIPS 2016) <br>[[PDF]](https://papers.nips.cc/paper/6084-fast-free-inference-of-simulation-models-with-bayesian-conditional-density-estimation.pdf) [[BibTeX]](https://papers.nips.cc/paper/6084-fast-free-inference-of-simulation-models-with-bayesian-conditional-density-estimation/bibtex)
 
@@ -45,7 +44,7 @@ Algorithms included in `sbi` were published in the following papers, which provi
 - **On Contrastive Learning for Likelihood-free Inference**<br>Durkan C.,
   Murray I., and Papamakarios G.(ICML 2020) <br>[[PDF]](https://arxiv.org/abs/2002.03712).
 
-We refer to these algorithms as SNPE-A, SNPE-B, and SNPE-C/APT, respectively.
+We refer to these methods as SNPE-A, SNPE-B, and SNPE-C/APT, respectively.
 
 
 As an alternative to directly estimating the posterior on parameters given data, it is also possible to estimate the likelihood of data given parameters, and then subsequently draw posterior samples using MCMC ([Papamakarios, Sterratt & Murray, 2019](http://proceedings.mlr.press/v89/papamakarios19a/papamakarios19a.pdf)[^1], [Lueckmann, Karaletsos, Bassetto, Macke, 2019](http://proceedings.mlr.press/v96/lueckmann19a/lueckmann19a.pdf)). Depending on the problem, approximating the likelihood can be more or less effective than SNPE techniques.

--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -51,7 +51,7 @@ def infer(
     """
 
     try:
-        method: Callable = getattr(sbi.inference, method.upper())
+        method_fun: Callable = getattr(sbi.inference, method.upper())
     except AttributeError:
         raise NameError(
             "Method not available. `method` must be one of 'SNPE', 'SNLE', 'SNRE'."
@@ -60,7 +60,7 @@ def infer(
     # Note this typically simulates once to find out the right `x_shape`.
     prior, simulator, x_shape = prepare_sbi_problem(simulator, prior, None)
 
-    infer_ = method(prior, simulator, x_shape=x_shape, num_workers=num_workers)
+    infer_ = method_fun(prior, simulator, x_shape=x_shape, num_workers=num_workers)
     posterior = infer_(num_rounds=1, num_simulations_per_round=num_simulations)
 
     return posterior

--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -11,7 +11,7 @@ from torch.utils.tensorboard import SummaryWriter
 
 import sbi.inference
 from sbi.simulators.simutils import simulate_in_batches
-from sbi.user_input.user_input_checks import process_x_o
+from sbi.user_input.user_input_checks import process_x
 from sbi.user_input.user_input_checks import prepare_sbi_problem
 from sbi.utils import get_log_root
 from sbi.utils.plot import pairplot
@@ -339,9 +339,11 @@ class NeuralInference(ABC):
 
         For multi-round inference, set `x_o` as the default observation.
 
-        Warns: if an `x_o` is provided when doing amortized inference (`num_rounds==1`).
+        Warns:
+            When `x_o` is provided, yet `num_rounds=1`, i.e. inference is amortized.
 
-        Raises: if `x_o` is absent but but multi-round inference is requested.
+        Raises:
+            When `x_o` is absent, yet `num_rounds>1`, i.e. inference is focused.
         """
 
         if num_rounds == 1 and x_o is not None:
@@ -355,5 +357,5 @@ class NeuralInference(ABC):
 
         if num_rounds > 1:
             self._posterior.x_o = (
-                x_o if self._skip_input_checks else process_x_o(x_o, self._x_shape)
+                x_o if self._skip_input_checks else process_x(x_o, self._x_shape)
             )

--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -335,9 +335,8 @@ class NeuralInference(ABC):
 
     def _handle_x_o_wrt_amortization(self, x_o: Tensor, num_rounds: int) -> None:
         """
-        Check if `x_o` is consistent with `num_rounds` and maybe set it as default.
-
-        For multi-round inference, set `x_o` as the default observation.
+        Check whether provided `x_o` is consistent with `num_rounds`. For multi-round
+        inference, set `x_o` as the default observation in the posterior.
 
         Warns:
             When `x_o` is provided, yet `num_rounds=1`, i.e. inference is amortized.
@@ -356,6 +355,6 @@ class NeuralInference(ABC):
             )
 
         if num_rounds > 1:
-            self._posterior.x_o = (
+            self._posterior.default_x = (
                 x_o if self._skip_input_checks else process_x(x_o, self._x_shape)
             )

--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -273,9 +273,9 @@ class NeuralInference(ABC):
         created during training.
         """
 
-        # NB. This is a subset of the logging from the conormdurkan/lfi. A big
+        # NB. This is a subset of the logging as done in `GH:conormdurkan/lfi`. A big
         # part of the logging was removed because of API changes, e.g., logging
-        # comparisons to ground truth parameters and samples.
+        # comparisons to ground-truth parameters and samples.
 
         # Median |x - x0| for most recent round.
         if x_o is not None:

--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -34,7 +34,7 @@ def infer(
     mackelab.org/sbi/tutorial/03_flexible_interface.html
 
     Args:
-        method: What inference algorithm to use. Either of ['SNPE'|'SNLE'|'SNRE'].
+        method: What inference method to use. Either of "SNPE", "SNLE" or "SNRE".
         simulator: A function that takes parameters $\theta$ and maps them to
             simulations, or observations, `x`, $\mathrm{sim}(\theta)\to x$. Any
             regular Python callable (i.e. function or class with `__call__` method)
@@ -84,7 +84,7 @@ class NeuralInference(ABC):
         show_round_summary: bool = False,
     ):
         r"""
-        Base class for inference algorithms.
+        Base class for inference methods.
 
         Args:
             simulator: A function that takes parameters $\theta$ and maps them to
@@ -138,7 +138,7 @@ class NeuralInference(ABC):
 
         # XXX We could instantiate here the Posterior for all children. Two problems:
         #     1. We must dispatch to right PotentialProvider for mcmc based on name
-        #     2. `alg_family` cannot be resolved only from `self.__class__.__name__`,
+        #     2. `method_family` cannot be resolved only from `self.__class__.__name__`,
         #         since SRE, AALR demand different handling but are both in SRE class.
 
         self._summary_writer = (

--- a/sbi/inference/posterior.py
+++ b/sbi/inference/posterior.py
@@ -86,7 +86,7 @@ class NeuralPosterior:
         self._leakage_density_correction_factor = None
 
     # When a type is not yet defined, one uses a string representation.
-    def set_default_x(self, /, x: Tensor) -> "NeuralPosterior":
+    def set_default_x(self, x: Tensor) -> "NeuralPosterior":
         """
         Return `NeuralPosterior` object with default conditioning context `x` set.
 

--- a/sbi/inference/posterior.py
+++ b/sbi/inference/posterior.py
@@ -49,21 +49,21 @@ class NeuralPosterior:
         method_family: str,
         neural_net: nn.Module,
         prior,
+        x_shape: Optional[torch.Size] = None,
         sample_with_mcmc: bool = True,
         mcmc_method: str = "slice_np",
-        x_shape: Optional[torch.Size] = None,
         get_potential_function: Optional[Callable] = None,
     ):
         """
         Args:
             method_family: One of 'snpe', 'snl', 'snre_a' or 'snre_b'.
             neural_net: A classifier for SNRE, a density estimator for SNPE and SNL.
+            x_shape: Simulator output shape. Provide it if you want any default `x` set 
+                via the `.set_default_x()` method checked against it.
             prior: Prior distribution with `.log_prob()` and `.sample()`.
             sample_with_mcmc: Whether to sample with MCMC. Will always be `True` for SRE
                 and SNL, but can also be set to `True` for SNPE if MCMC is preferred to
                 deal with leakage over rejection sampling.
-            x_shape: Simulator output shape. If present, it is used to check any default
-                `x` set via the `.set_default_x()` method.
         """
 
         self.net = neural_net
@@ -82,7 +82,7 @@ class NeuralPosterior:
 
         self._num_trained_rounds = 0
 
-        # Correction factor for SNPE leakage.
+        # Correction factor for leakage, only applicable to SNPE-family methods.
         self._leakage_density_correction_factor = None
 
     # When a type is not yet defined, one uses a string representation.
@@ -131,7 +131,7 @@ class NeuralPosterior:
                 `norm_posterior_snpe=False`. The returned log posterior is set to
                 -∞ outside of the prior support regardless of this setting.
             track_gradients: Whether the returned tensor supports tracking gradients.
-                This can be helpful for e.g. sensitivity analysis, but increases memory 
+                This can be helpful for e.g. sensitivity analysis, but increases memory
                 consumption.
 
         Returns:
@@ -415,7 +415,7 @@ class NeuralPosterior:
 
         samples = posterior_sampler.gen(num_samples)
 
-        # back to training mode
+        # Back to training mode.
         # XXX train exited in log_prob, entered here?
         self.net.train(True)
 

--- a/sbi/inference/posterior.py
+++ b/sbi/inference/posterior.py
@@ -16,7 +16,7 @@ from sbi.utils.torchutils import (
     atleast_2d_float32_tensor,
     batched_first_of_batch,
 )
-from sbi.user_input.user_input_checks import process_x_o
+from sbi.user_input.user_input_checks import process_x
 
 
 NEG_INF = torch.tensor(float("-inf"), dtype=torch.float32)
@@ -105,8 +105,7 @@ class NeuralPosterior:
             `NeuralPosterior` that will use a default `x` when not explicitly passed.
         """
 
-        # TODO `process_x_o` name feels out of place here.
-        self.x_o = process_x_o(x, self._x_shape)
+        self.x_o = process_x(x, self._x_shape)
 
         return self
 

--- a/sbi/inference/posterior.py
+++ b/sbi/inference/posterior.py
@@ -591,9 +591,29 @@ class NeuralPosterior:
         return x_matched
 
     def __repr__(self):
-        desc = f"""NeuralPosterior(method_family={self._method_family},
-                                net=<a {self.net.__class__.__name__}, see `.net` for details>,
-                                prior={self._prior!r},
-                                x_shape={self._x_shape!r}
-                                ) """
+        desc = f"""NeuralPosterior(
+               method_family={self._method_family},
+               net=<a {self.net.__class__.__name__}, see `.net` for details>,
+               prior={self._prior!r},
+               x_shape={self._x_shape!r})
+               """
+        return desc
+
+    def __str__(self):
+        msg = {0: "Untrained", 1: "Amortized"}
+
+        default_x_msg = (
+            f" with default evaluation at x={self.default_x.tolist()!r}"
+            if self.default_x is not None
+            else ""
+        )
+
+        desc = (
+            f"{msg.get(self._num_trained_rounds, 'Focused')} posterior conditional "
+            f"density p(θ|x){default_x_msg}.\n\n"
+            f"This neural posterior was obtained with a "
+            f"{self._method_family.upper()}-class "
+            f"method using a {self.net.__class__.__name__.lower()}."
+        )
+
         return desc

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -71,12 +71,12 @@ class LikelihoodEstimator(NeuralInference, ABC):
         # Create neural posterior which can sample().
         # TODO Notice use of `snle_a`, OK so long as it is the sole descendant.
         self._posterior = NeuralPosterior(
-            algorithm_family="snle_a",
+            method_family="snle_a",
             neural_net=density_estimator,
             prior=self._prior,
             mcmc_method=mcmc_method,
-            get_potential_function=PotentialFunctionProvider(),
             x_shape=self._x_shape,
+            get_potential_function=PotentialFunctionProvider(),
         )
 
         self._posterior.net.train(True)

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -168,7 +168,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
             # Update TensorBoard and summary dict.
             self._summarize(
                 round_=round_,
-                x_o=self._posterior.x_o,
+                x_o=self._posterior.default_x,
                 theta_bank=self._theta_bank,
                 x_bank=self._x_bank,
             )

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -74,8 +74,8 @@ class LikelihoodEstimator(NeuralInference, ABC):
             method_family="snle_a",
             neural_net=density_estimator,
             prior=self._prior,
-            mcmc_method=mcmc_method,
             x_shape=self._x_shape,
+            mcmc_method=mcmc_method,
             get_potential_function=PotentialFunctionProvider(),
         )
 

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -71,9 +71,9 @@ class PosteriorEstimator(NeuralInference, ABC):
             method_family="snpe",
             neural_net=density_estimator,
             prior=self._prior,
+            x_shape=self._x_shape,
             sample_with_mcmc=sample_with_mcmc,
             mcmc_method=mcmc_method,
-            x_shape=self._x_shape,
             get_potential_function=PotentialFunctionProvider(),
         )
 

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -218,11 +218,11 @@ class PosteriorEstimator(NeuralInference, ABC):
             # to make sure this update never gets lost when we e.g. do not log our
             # things to tensorboard anymore. Calling `leakage_correction()` is needed
             # to update the leakage after each round.
-            if self._posterior.x_o is None:
+            if self._posterior.default_x is None:
                 acceptance_rate = torch.tensor(float("nan"))
             else:
                 acceptance_rate = self._posterior.leakage_correction(
-                    x=self._posterior.x_o,
+                    x=self._posterior.default_x,
                     force_update=True,
                     show_progress_bars=self._show_progress_bars,
                 )
@@ -230,7 +230,7 @@ class PosteriorEstimator(NeuralInference, ABC):
             # Update tensorboard and summary dict.
             self._summarize(
                 round_=round_,
-                x_o=self._posterior.x_o,
+                x_o=self._posterior.default_x,
                 theta_bank=self._theta_bank,
                 x_bank=self._x_bank,
                 posterior_samples_acceptance_rate=acceptance_rate,
@@ -273,7 +273,7 @@ class PosteriorEstimator(NeuralInference, ABC):
             # XXX Make posterior.sample() accept tuples like prior.sample().
             theta = self._posterior.sample(
                 num_sims,
-                x=self._posterior.x_o,
+                x=self._posterior.default_x,
                 show_progress_bars=self._show_progress_bars,
             )
 

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -213,7 +213,7 @@ class PosteriorEstimator(NeuralInference, ABC):
             self._model_bank.append(deepcopy(self._posterior))
             self._model_bank[-1].net.eval()
 
-            # Making the call to `leakage_correction()`` and the update of
+            # Making the call to `leakage_correction()` and the update of
             # self._leakage_density_correction_factor explicit here. This is just
             # to make sure this update never gets lost when we e.g. do not log our
             # things to tensorboard anymore. Calling `leakage_correction()` is needed

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -188,7 +188,7 @@ class RatioEstimator(NeuralInference, ABC):
             # Update tensorboard and summary dict.
             self._summarize(
                 round_=round_,
-                x_o=self._posterior.x_o,
+                x_o=self._posterior.default_x,
                 theta_bank=self._theta_bank,
                 x_bank=self._x_bank,
             )

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -41,7 +41,7 @@ class RatioEstimator(NeuralInference, ABC):
     ):
         r"""Sequential Neural Ratio Estimation.
 
-        We implement two algorithms in the respective subclasses.
+        We implement two inference methods in the respective subclasses.
 
         - SNRE_A / AALR is limited to `num_atoms=2`, but allows for density evaluation
           when training for one round.
@@ -80,15 +80,15 @@ class RatioEstimator(NeuralInference, ABC):
             )
 
         # Create posterior object which can sample().
-        algorithm_family = self.__class__.__name__.lower()
+        method_family = self.__class__.__name__.lower()
 
         self._posterior = NeuralPosterior(
-            algorithm_family=algorithm_family,
+            method_family=method_family,
             neural_net=classifier,
             prior=self._prior,
             mcmc_method=mcmc_method,
-            get_potential_function=PotentialFunctionProvider(),
             x_shape=self._x_shape,
+            get_potential_function=PotentialFunctionProvider(),
         )
 
         self._posterior.net.train(True)

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -86,8 +86,8 @@ class RatioEstimator(NeuralInference, ABC):
             method_family=method_family,
             neural_net=classifier,
             prior=self._prior,
-            mcmc_method=mcmc_method,
             x_shape=self._x_shape,
+            mcmc_method=mcmc_method,
             get_potential_function=PotentialFunctionProvider(),
         )
 

--- a/sbi/user_input/user-input-checks.md
+++ b/sbi/user_input/user-input-checks.md
@@ -9,7 +9,7 @@
 - **observed data `x_o` ** as torch `Tensor` or `np.ndarray`, with non-nil batch shape, i.e., `x_o.shape = (1, obs_dims>=1)` 
   - if `obs dims > 1`, we will have to take care of that at the level of the NN in some cases (some architectures, e.g. convolutional embedding networks, will want to have the original data in its original shape).
 
-## What we require in SBI
+## What we require in sbi
 
 - simulator that takes and returns torch `Tensor`s, batched, e.g., it always assume a batch dimension, taking `(1, param dim)` for a single input and returning `(1, obs dim)`.
 - prior object with behavior as torch `Distribution`.

--- a/sbi/user_input/user_input_checks.py
+++ b/sbi/user_input/user_input_checks.py
@@ -67,7 +67,7 @@ def process_custom_prior(prior) -> Tuple[Distribution, int, bool]:
         prior: Prior object with `.sample()` and `.log_prob()` as provided by the user.
 
     Returns:
-        prior: SBI-compatible prior.
+        prior: sbi-compatible prior.
         theta_numel: Number of parameters - elements in a single sample from the prior.
         is_prior_numpy: Whether the prior returned Numpy arrays before wrapping.
     """
@@ -120,7 +120,7 @@ def maybe_wrap_prior_as_pytorch(prior) -> Tuple[Distribution, bool]:
 
 
 def process_pytorch_prior(prior: Distribution) -> Tuple[Distribution, int, bool]:
-    """Return PyTorch prior adapted to the requirements for SBI.
+    """Return PyTorch prior adapted to the requirements for sbi.
 
     Args:
         prior: PyTorch distribution prior provided by the user.
@@ -192,7 +192,7 @@ def check_prior_batch_dims(prior) -> None:
 def check_for_possibly_batched_x_shape(x_shape):
     """Raise `ValueError` if dimensionality of simulations doesn't match requirements.
 
-    SBI does not support multiple observations yet. For 2D observed data the leading
+    sbi does not support multiple observations yet. For 2D observed data the leading
     dimension will be interpreted as batch dimension and a `ValueError` is raised if the
     batch dimension is larger than 1.
 
@@ -208,7 +208,7 @@ def check_for_possibly_batched_x_shape(x_shape):
     # Reject multidimensional data with batch_shape > 1.
     if x_ndim > 1 and inferred_batch_shape > 1:
         raise ValueError(
-            """Observation/simulation `x` has D>1 dimensions. SBI interprets the
+            """Observation/simulation `x` has D>1 dimensions. sbi interprets the
             leading dimension as a batch dimension, but it *currently* only processes a
             single observation, a batch of several is not supported yet.
 
@@ -245,7 +245,7 @@ def check_for_possibly_batched_x_shape(x_shape):
     elif inferred_data_ndim > 1 and inferred_batch_shape == 1:
         warnings.warn(
             f"""Beware: The observed data (x_o) you passed was interpreted to have
-            matrix shape: {inferred_data_shape}. The current implementation of SBI
+            matrix shape: {inferred_data_shape}. The current implementation of sbi
             might not provide stable support for this and result in shape mismatches.
             """
         )
@@ -256,7 +256,7 @@ def check_for_possibly_batched_x_shape(x_shape):
 def check_for_possibly_batched_observations(x_o: Tensor):
     """Raise `ValueError` if dimensionality of data doesn't match requirements.
 
-    SBI does not support multiple observations yet. For 2D observed data the leading
+    sbi does not support multiple observations yet. For 2D observed data the leading
     dimension will be interpreted as batch dimension and a ValueError will be raised if
     the batch dimension is larger than 1.
     Multidimensional observations e.g., images, are allowed when they are passed with an
@@ -346,7 +346,7 @@ def check_prior_batch_behavior(prior) -> None:
 def process_simulator(
     user_simulator: Callable, prior, is_numpy_simulator: bool,
 ) -> Callable:
-    """Return a simulator that meets the requirements for usage in SBI.
+    """Return a simulator that meets the requirements for usage in sbi.
 
     Wraps the simulator to return only `torch.Tensor` and handle batches of parameters.
     """
@@ -464,7 +464,7 @@ def process_x_shape(
 
 
 def process_x_o(x_o: Tensor, x_shape: torch.Size) -> Tensor:
-    """Return observed data to SBI's shape and type requirements.
+    """Return observed data adapted to match sbi's shape and type requirements.
 
     Args:
         x_o: Observed data as provided by the user.
@@ -472,7 +472,7 @@ def process_x_o(x_o: Tensor, x_shape: torch.Size) -> Tensor:
             been inferred from a simulation.
 
     Returns:
-        x_o: Observed data with shape ready for usage in SBI.
+        x_o: Observed data with shape ready for usage in sbi.
     """
 
     # Maybe add batch dimension, cast to tensor.
@@ -496,9 +496,9 @@ def prepare_sbi_problem(
     user_x_shape: Optional[Shape] = None,
     skip_input_checks: bool = False,
 ) -> Tuple[Callable, Distribution, Optional[torch.Size]]:
-    """Prepare simulator, prior and observed data for usage in SBI.
+    """Prepare simulator, prior and observed data for usage in sbi.
 
-    One of the goals is to allow you to use SBI with inputs computed in numpy.
+    One of the goals is to allow you to use sbi with inputs computed in numpy.
 
     Attempts to meet the following requirements by reshaping and type-casting:
     - the simulator function receives as input and returns a Tensor.
@@ -516,12 +516,12 @@ def prepare_sbi_problem(
             budget, as the input checks run the simulator a couple of times.
 
     Returns:
-        Tuple (simulator, prior, x_shape) checked and matching the requirements of SBI.
+        Tuple (simulator, prior, x_shape) checked and matching the requirements of sbi.
     """
 
     if skip_input_checks:
         warnings.warn(
-            """SBI input checks are skipped, make sure to pass a valid prior, simulator
+            """sbi input checks are skipped, make sure to pass a valid prior, simulator
             and output shape. Consult the documentation for the exact requirements.""",
             UserWarning,
         )
@@ -536,7 +536,7 @@ def prepare_sbi_problem(
         # Check data shape, returns shape with leading batch dimension.
         x_shape, _ = process_x_shape(simulator, prior, user_x_shape)
 
-        # Consistency check after making ready for SBI.
+        # Consistency check after making ready for sbi.
         check_sbi_problem(simulator, prior, x_shape)
 
         return simulator, prior, x_shape
@@ -545,7 +545,7 @@ def prepare_sbi_problem(
 def check_sbi_problem(
     simulator: Callable, prior: Distribution, x_shape: torch.Size
 ) -> None:
-    """Assert requirements for simulator, prior and observation for usage in SBI.
+    """Assert requirements for simulator, prior and observation for usage in sbi.
 
     Args:
         simulator: simulator function

--- a/sbi/user_input/user_input_checks.py
+++ b/sbi/user_input/user_input_checks.py
@@ -463,31 +463,29 @@ def process_x_shape(
     return x_shape, x_dim
 
 
-def process_x_o(x_o: Tensor, x_shape: torch.Size) -> Tensor:
+def process_x(x: Tensor, x_shape: torch.Size) -> Tensor:
     """Return observed data adapted to match sbi's shape and type requirements.
 
     Args:
-        x_o: Observed data as provided by the user.
-        x_shape: The shape that had either been provided by the user at init or had
-            been inferred from a simulation.
+        x: Observed data as provided by the user.
+        x_shape: Prescribed shape - either directly provided by the user at init or
+            inferred by sbi by running a simulation and checking the output.
 
     Returns:
-        x_o: Observed data with shape ready for usage in sbi.
+        x: Observed data with shape ready for usage in sbi.
     """
 
-    # Maybe add batch dimension, cast to tensor.
-    x_o = atleast_2d(x_o)
-    x_o = torch.as_tensor(x_o, dtype=float32)
+    x = torch.as_tensor(atleast_2d(x), dtype=float32)
 
-    check_for_possibly_batched_observations(x_o)
-    x_o_shape = x_o.shape
+    check_for_possibly_batched_observations(x)
+    input_x_shape = x.shape
 
-    assert x_o_shape == x_shape, (
-        f"Observed data shape ({x_o_shape}) must match "
+    assert input_x_shape == x_shape, (
+        f"Observed data shape ({input_x_shape}) must match "
         f"the shape of simulated data x ({x_shape})."
     )
 
-    return x_o
+    return x
 
 
 def prepare_sbi_problem(

--- a/tests/inference_with_NaN_simulator_test.py
+++ b/tests/inference_with_NaN_simulator_test.py
@@ -70,16 +70,14 @@ def test_inference_with_nan_simulator(
         prior=prior,
     )
 
-    if method == SNPE_C:
-        infer = method(simulator=linear_gaussian_nan, prior=prior,)
-    else:
-        infer = method(simulator=linear_gaussian_nan, prior=prior,)
+    infer = method(simulator=linear_gaussian_nan, prior=prior,)
 
     posterior = infer(
         num_rounds=1,
         num_simulations_per_round=num_simulations,
         exclude_invalid_x=exclude_invalid_x,
-    ).freeze(x_o)
+    ).set_default_x(x_o)
+
     samples = posterior.sample(num_samples)
 
     # Compute the c2st and assert it is near chance level of 0.5.

--- a/tests/linearGaussian_snle_test.py
+++ b/tests/linearGaussian_snle_test.py
@@ -150,7 +150,7 @@ def test_c2st_snl_on_linearGaussian(num_dim: int, prior_str: str, set_seed):
         show_progress_bars=False,
     )
 
-    posterior = infer(num_rounds=1, num_simulations_per_round=1000).freeze(x_o)
+    posterior = infer(num_rounds=1, num_simulations_per_round=1000).set_default_x(x_o)
 
     samples = posterior.sample(num_samples=num_samples, thin=3)
 

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -352,3 +352,31 @@ def test_api_snpe_c_posterior_correction(
 
     # Evaluate the samples to check correction factor.
     posterior.log_prob(samples, x=x_o)
+
+
+def example_posterior():
+    """Return an inferred `NeuralPosterior` for interactive examination."""
+    num_dim = 2
+    x_o = zeros(1, num_dim)
+
+    # likelihood_mean will be likelihood_shift+theta
+    likelihood_shift = -1.0 * ones(num_dim)
+    likelihood_cov = 0.3 * eye(num_dim)
+
+    prior_mean = zeros(num_dim)
+    prior_cov = eye(num_dim)
+    prior = MultivariateNormal(loc=prior_mean, covariance_matrix=prior_cov)
+
+    def simulator(theta):
+        return linear_gaussian(theta, likelihood_shift, likelihood_cov)
+
+    infer = SNPE_C(
+        simulator=simulator,
+        prior=prior,
+        simulation_batch_size=10,
+        num_workers=6,
+        show_progress_bars=False,
+        sample_with_mcmc=False,
+    )
+
+    return infer(num_rounds=1, num_simulations_per_round=1000).set_default_x(x_o)

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -23,7 +23,7 @@ from sbi.simulators.linear_gaussian import (
 torch.set_default_tensor_type("torch.FloatTensor")
 # Seeding:
 # Some tests in this module have "set_seed" as an argument. This argument points to
-# tests/conftest.py to seed the test with the seed set in conftext.py.
+# tests/conftest.py to seed the test with the seed set in conftest.py.
 
 
 @pytest.mark.parametrize(
@@ -70,7 +70,7 @@ def test_c2st_snpe_on_linearGaussian(
         sample_with_mcmc=False,
     )
 
-    posterior = infer(num_rounds=1, num_simulations_per_round=2000).freeze(x_o)
+    posterior = infer(num_rounds=1, num_simulations_per_round=2000).set_default_x(x_o)
     samples = posterior.sample(num_samples)
 
     # Compute the c2st and assert it is near chance level of 0.5.
@@ -174,7 +174,7 @@ def test_c2st_snpe_on_linearGaussian_different_dims(set_seed):
 # Test multi-round SNPE.
 @pytest.mark.slow
 @pytest.mark.parametrize(
-    "algorithm_str",
+    "method_str",
     (
         pytest.param(
             "snpe_b",
@@ -185,7 +185,7 @@ def test_c2st_snpe_on_linearGaussian_different_dims(set_seed):
         "snpe_c",
     ),
 )
-def test_c2st_multi_round_snpe_on_linearGaussian(algorithm_str: str, set_seed):
+def test_c2st_multi_round_snpe_on_linearGaussian(method_str: str, set_seed):
     """Test whether SNPE B/C infer well a simple example with available ground truth.
 
     Args:
@@ -219,10 +219,10 @@ def test_c2st_multi_round_snpe_on_linearGaussian(algorithm_str: str, set_seed):
     )
     call_args = dict(num_rounds=2, x_o=x_o, num_simulations_per_round=1000)
 
-    if algorithm_str == "snpe_b":
+    if method_str == "snpe_b":
         infer = SNPE_B(simulation_batch_size=10, **creation_args)
         posterior = infer(**call_args)
-    elif algorithm_str == "snpe_c":
+    elif method_str == "snpe_c":
         infer = SNPE_C(
             simulation_batch_size=50, sample_with_mcmc=False, **creation_args
         )
@@ -231,7 +231,7 @@ def test_c2st_multi_round_snpe_on_linearGaussian(algorithm_str: str, set_seed):
     samples = posterior.sample(num_samples)
 
     # Compute the c2st and assert it is near chance level of 0.5.
-    check_c2st(samples, target_samples, alg=algorithm_str)
+    check_c2st(samples, target_samples, alg=method_str)
 
 
 _fail_reason_deterministic_sim = """If the simulator has truely deterministic (even

--- a/tests/linearGaussian_snre_test.py
+++ b/tests/linearGaussian_snre_test.py
@@ -110,7 +110,7 @@ def test_c2st_sre_on_linearGaussian_different_dims(set_seed):
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
-    "num_dim, prior_str, algorithm_str",
+    "num_dim, prior_str, method_str",
     (
         (2, "gaussian", "sre"),
         (1, "gaussian", "sre"),
@@ -119,7 +119,7 @@ def test_c2st_sre_on_linearGaussian_different_dims(set_seed):
     ),
 )
 def test_c2st_sre_on_linearGaussian(
-    num_dim: int, prior_str: str, algorithm_str: str, set_seed,
+    num_dim: int, prior_str: str, method_str: str, set_seed,
 ):
     """Test c2st accuracy of inference with SRE on linear Gaussian model.
 
@@ -162,18 +162,18 @@ def test_c2st_sre_on_linearGaussian(
         show_progress_bars=False,
     )
 
-    infer = SRE(**kwargs) if algorithm_str == "sre" else AALR(**kwargs)
+    infer = SRE(**kwargs) if method_str == "sre" else AALR(**kwargs)
 
     # Should use default `num_atoms=10` for SRE; `num_atoms=2` for AALR
-    posterior = infer(num_rounds=1, num_simulations_per_round=1000).freeze(x_o)
+    posterior = infer(num_rounds=1, num_simulations_per_round=1000).set_default_x(x_o)
 
     samples = posterior.sample(num_samples=num_samples, thin=3)
 
     # Check performance based on c2st accuracy.
-    check_c2st(samples, target_samples, alg=f"sre-{prior_str}-{algorithm_str}")
+    check_c2st(samples, target_samples, alg=f"sre-{prior_str}-{method_str}")
 
     # Checks for log_prob()
-    if prior_str == "gaussian" and algorithm_str == "aalr":
+    if prior_str == "gaussian" and method_str == "aalr":
         # For the Gaussian prior, we compute the KLd between ground truth and
         # posterior. We can do this only if the classifier_loss was as described in
         # Hermans et al. 2020 ('aalr') since Durkan et al. 2020 version only allows

--- a/tests/posterior_nn_test.py
+++ b/tests/posterior_nn_test.py
@@ -20,7 +20,7 @@ def test_log_prob_with_different_x():
     posterior.log_prob(theta, x=ones(num_dim))
     posterior.log_prob(theta, x=ones(num_dim))
     posterior.log_prob(theta, x=ones(1, num_dim))
-    posterior = posterior.freeze(x_o=ones(1, num_dim))
+    posterior = posterior.set_default_x(ones(1, num_dim))
     posterior.log_prob(theta, x=None)
     posterior.sample(10, x=None)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -120,7 +120,7 @@ def get_normalization_uniform_prior(
     )
 
     # Estimate acceptance ratio through rejection sampling.
-    acceptance_prob = posterior.get_leakage_correction(x=true_observation)
+    acceptance_prob = posterior.leakage_correction(x=true_observation)
 
     return posterior_likelihood_unnorm, posterior_likelihood_norm, acceptance_prob
 

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -15,7 +15,7 @@ from sbi.user_input.user_input_checks import (
     process_prior,
     process_simulator,
     process_x_shape,
-    process_x_o,
+    process_x,
 )
 from sbi.user_input.user_input_checks_utils import (
     CustomPytorchWrapper,
@@ -180,10 +180,10 @@ def test_process_x_shape(
 
 
 @pytest.mark.parametrize(
-    "x_o, x_shape", ((ones(3), torch.Size([1, 3])), (ones(1, 3), torch.Size([1, 3])),),
+    "x, x_shape", ((ones(3), torch.Size([1, 3])), (ones(1, 3), torch.Size([1, 3])),),
 )
-def test_process_x_o(x_o, x_shape):
-    process_x_o(x_o, x_shape)
+def test_process_x(x, x_shape):
+    process_x(x, x_shape)
 
 
 def test_process_matrix_observation():


### PR DESCRIPTION
* Renamed algorithm to (inference) method throughout.
* `freeze` is now `set_default_x`, closer to actual semantics. Further PR will make the difference between amortised and focused posterior.
* Cross-check of docstrings in `NeuralPosterior` please have a look in case I oversaw something.