### PR TITLE
Add pyro utils for transforms

### DIFF
--- a/sbi/utils/pyroutils.py
+++ b/sbi/utils/pyroutils.py
@@ -1,0 +1,32 @@
+from typing import Callable, Any
+
+import pyro.distributions as dist
+import pyro.poutine as poutine
+from torch.distributions import biject_to
+
+
+def get_transforms(model: Callable, *model_args: Any, **model_kwargs: Any):
+    """Get automatic transforms to unbounded space
+
+    Args:
+        model: Pyro model
+        model_args: Arguments passed to model
+        model_args: Keyword arguments passed to model
+    
+    Example:
+        ```python
+        def prior():
+            return pyro.sample("theta", pyro.distributions.Uniform(0., 1.))
+            
+        transform_to_unbounded = get_transforms(prior)["theta"]
+        ```
+    """
+    transforms = {}
+
+    model_trace = poutine.trace(model).get_trace(*model_args, **model_kwargs)
+
+    for name, node in model_trace.iter_stochastic_nodes():
+        fn = node["fn"]
+        transforms[name] = biject_to(fn.support).inv
+
+    return transforms

--- a/tests/pyroutils_test.py
+++ b/tests/pyroutils_test.py
@@ -1,0 +1,24 @@
+import torch
+import pyro
+
+from sbi.utils.pyroutils import get_transforms
+
+
+def test_unbounded_transform():
+    prior_dim = 10
+    prior_params = {
+        "low": -1.0 * torch.ones((prior_dim,)),
+        "high": +1.0 * torch.ones((prior_dim,)),
+    }
+    prior_dist = pyro.distributions.Uniform(**prior_params).to_event(1)
+
+    def prior(num_samples=1):
+        return pyro.sample("theta", prior_dist.expand_by([num_samples]))
+
+    transforms = get_transforms(prior)
+
+    to_unbounded = transforms["theta"]
+    to_bounded = transforms["theta"].inv
+
+    assert to_unbounded(prior(1000)).max() > 1.0
+    assert to_bounded(to_unbounded(prior(1000))).max() < 1.0


### PR DESCRIPTION
Adds pyro utils to allow automatic transformation of variables. 

See `tests/pyroutils_test.py` for an example using a multivariate box uniform prior.