### PR TITLE
add abc methods to sbi.

### DIFF
--- a/sbi/inference/__init__.py
+++ b/sbi/inference/__init__.py
@@ -28,7 +28,9 @@ SRE = SNRE_B
 AALR = SNRE_A
 _snre_family = ["SNRE_A", "AALR", "SNRE_B", "SNRE", "SRE"]
 
-_abc_family = ["MCABC", "SMCABC"]
+ABC = MCABC
+SMC = SMCABC
+_abc_family = ["ABC", "MCABC", "SMC", "SMCABC"]
 
 
-__all__ = _snpe_family + _snre_family + _snle_family
+__all__ = _snpe_family + _snre_family + _snle_family + _abc_family

--- a/sbi/inference/__init__.py
+++ b/sbi/inference/__init__.py
@@ -12,6 +12,9 @@ from sbi.inference.snpe.snpe_c import SNPE_C  # noqa: F401
 
 from sbi.inference.snre import SNRE, SNRE_A, SNRE_B  # noqa: F401
 
+from sbi.inference.abc.mcabc import MCABC
+from sbi.inference.abc.smcabc import SMCABC
+
 
 SNL = SNLE = SNLE_A
 _snle_family = ["SNL"]
@@ -24,6 +27,8 @@ _snpe_family = ["SNPE_C", "SNPE", "APT"]
 SRE = SNRE_B
 AALR = SNRE_A
 _snre_family = ["SNRE_A", "AALR", "SNRE_B", "SNRE", "SRE"]
+
+_abc_family = ["MCABC", "SMCABC"]
 
 
 __all__ = _snpe_family + _snre_family + _snle_family

--- a/sbi/inference/abc/abc_base.py
+++ b/sbi/inference/abc/abc_base.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
-from abc import ABC
 
-import torch
+from abc import ABC
 from typing import Callable, Union
 
-from sbi.simulators.simutils import simulate_in_batches
-from sbi.user_input.user_input_checks import process_x, prepare_for_sbi
-from numpy import ndarray
+import torch
 from torch import Tensor
+
+from sbi.simulators.simutils import simulate_in_batches
 
 
 class ABCBASE(ABC):

--- a/sbi/inference/abc/abc_base.py
+++ b/sbi/inference/abc/abc_base.py
@@ -1,0 +1,87 @@
+import torch
+from typing import Callable, Optional, Union
+
+from sbi.simulators.simutils import simulate_in_batches
+
+
+class ABCBASE:
+    def __init__(
+        self,
+        simulator,
+        prior,
+        x_o,
+        distance: Union[str, Callable] = "l2",
+        num_workers: int = 1,
+        simulation_batch_size: int = 1,
+        show_progress_bars: bool = True,
+    ) -> None:
+
+        # TODO: User input checks
+
+        self.prior = prior
+        self._simulator = simulator
+        self.x_o = x_o
+        self._show_progress_bars = show_progress_bars
+        if type(distance) == str:
+            distances = ["l1", "l2", "mse"]
+            assert (
+                distance in distances
+            ), f"Distance function str must be one of {distances}."
+            self.distance = eval(f"self.{distance}")
+
+        self._batched_simulator = lambda theta: simulate_in_batches(
+            self._simulator,
+            theta,
+            simulation_batch_size,
+            num_workers,
+            self._show_progress_bars,
+        )
+
+    @staticmethod
+    def mse(observation: torch.Tensor, simulated_data: torch.Tensor) -> torch.Tensor:
+        """Take mean squared distance over batch dimension
+
+        Args:
+            observation: observed data, could be 1D
+            simulated_data: batch of simulated data, has batch dimension
+
+        Returns:
+            Torch tensor with batch of distances
+        """
+        assert simulated_data.ndim == 2, "simulated data needs batch dimension"
+
+        return torch.mean((observation - simulated_data) ** 2, dim=-1)
+
+    @staticmethod
+    def l2(observation: torch.Tensor, simulated_data: torch.Tensor) -> torch.Tensor:
+        """Take L2 distance over batch dimension
+
+        Args:
+            observation: observed data, could be 1D
+            simulated_data: batch of simulated data, has batch dimension
+
+        Returns:
+            Torch tensor with batch of distances
+        """
+        assert (
+            simulated_data.ndim == 2
+        ), f"Simulated data needs batch dimension, is {simulated_data.shape}."
+
+        return torch.norm((observation - simulated_data), dim=-1)
+
+    @staticmethod
+    def l1(observation: torch.Tensor, simulated_data: torch.Tensor) -> torch.Tensor:
+        """Take mean absolute distance over batch dimension
+
+        Args:
+            observation: observed data, could be 1D
+            simulated_data: batch of simulated data, has batch dimension
+
+        Returns:
+            Torch tensor with batch of distances
+        """
+        assert (
+            simulated_data.ndim == 2
+        ), f"Simulated data needs batch dimension, is {simulated_data.shape}."
+
+        return torch.mean(abs(observation - simulated_data), dim=-1)

--- a/sbi/inference/abc/abc_base.py
+++ b/sbi/inference/abc/abc_base.py
@@ -1,15 +1,20 @@
+from __future__ import annotations
+from abc import ABC
+
 import torch
-from typing import Callable, Optional, Union
+from typing import Callable, Union
 
 from sbi.simulators.simutils import simulate_in_batches
+from numpy import ndarray
+from torch import Tensor
 
 
-class ABCBASE:
+class ABCBASE(ABC):
     def __init__(
         self,
-        simulator,
+        simulator: Callable,
         prior,
-        x_o,
+        x_o: Union[Tensor, ndarray],
         distance: Union[str, Callable] = "l2",
         num_workers: int = 1,
         simulation_batch_size: int = 1,
@@ -38,7 +43,7 @@ class ABCBASE:
         )
 
     @staticmethod
-    def mse(observation: torch.Tensor, simulated_data: torch.Tensor) -> torch.Tensor:
+    def mse(observation: Tensor, simulated_data: Tensor) -> Tensor:
         """Take mean squared distance over batch dimension
 
         Args:
@@ -53,7 +58,7 @@ class ABCBASE:
         return torch.mean((observation - simulated_data) ** 2, dim=-1)
 
     @staticmethod
-    def l2(observation: torch.Tensor, simulated_data: torch.Tensor) -> torch.Tensor:
+    def l2(observation: Tensor, simulated_data: Tensor) -> Tensor:
         """Take L2 distance over batch dimension
 
         Args:
@@ -70,7 +75,7 @@ class ABCBASE:
         return torch.norm((observation - simulated_data), dim=-1)
 
     @staticmethod
-    def l1(observation: torch.Tensor, simulated_data: torch.Tensor) -> torch.Tensor:
+    def l1(observation: Tensor, simulated_data: Tensor) -> Tensor:
         """Take mean absolute distance over batch dimension
 
         Args:

--- a/sbi/inference/abc/abc_base.py
+++ b/sbi/inference/abc/abc_base.py
@@ -15,7 +15,6 @@ class ABCBASE(ABC):
         self,
         simulator: Callable,
         prior,
-        x_o: Union[Tensor, ndarray],
         distance: Union[str, Callable] = "l2",
         num_workers: int = 1,
         simulation_batch_size: int = 1,
@@ -32,9 +31,8 @@ class ABCBASE(ABC):
                 parameters, e.g. which ranges are meaningful for them. Any
                 object with `.log_prob()`and `.sample()` (for example, a PyTorch
                 distribution) can be used.
-            x_o: Observed data.
-            distance: Distance function to compare observed and simulated data. Can be  
-                a custom function or one of "l1", "l2", "mse".
+            distance: Distance function to compare observed and simulated data. Can be
+                a custom function or one of `l1`, `l2`, `mse`.
             num_workers: Number of parallel workers to use for simulations.
             simulation_batch_size: Number of parameter sets that the simulator
                 maps to data x at once. If None, we simulate all parameter sets at the
@@ -44,13 +42,8 @@ class ABCBASE(ABC):
                 sampling.
         """
 
-        # User input checks.
-        simulator, prior, x_shape = prepare_for_sbi(simulator, prior)
-        x_o = process_x(x_o, x_shape)
-
         self.prior = prior
         self._simulator = simulator
-        self.x_o = x_o
         self._show_progress_bars = show_progress_bars
 
         # Select distance function.
@@ -83,14 +76,14 @@ class ABCBASE(ABC):
             raise ValueError(r"Distance {distance_type} not supported.")
 
         def distance_fun(observed_data: Tensor, simulated_data: Tensor) -> Tensor:
-            """Take distance over batch dimension
+            """Return distance over batch dimension.
 
             Args:
-                observed_data: observed data, could be 1D
-                simulated_data: batch of simulated data, has batch dimension
+                observed_data: Observed data, could be 1D.
+                simulated_data: Batch of simulated data, has batch dimension.
 
             Returns:
-                Torch tensor with batch of distances
+                Torch tensor with batch of distances.
             """
             assert simulated_data.ndim == 2, "simulated data needs batch dimension"
 

--- a/sbi/inference/abc/mcabc.py
+++ b/sbi/inference/abc/mcabc.py
@@ -1,20 +1,20 @@
 from __future__ import annotations
-from abc import ABC
 
 from pyro.distributions.empirical import Empirical
-from torch import log
 from sbi.inference.abc.abc_base import ABCBASE
 from typing import Callable, Optional, Union
 
 import torch
+from torch import Tensor, ones
+from numpy import ndarray
 
 
-class MCABC(ABCBASE, ABC):
+class MCABC(ABCBASE):
     def __init__(
         self,
-        simulator,
+        simulator: Callable,
         prior,
-        x_o,
+        x_o: Union[Tensor, ndarray],
         distance: Union[str, Callable] = "l2",
         num_workers: int = 1,
         simulation_batch_size: int = 1,
@@ -71,9 +71,7 @@ class MCABC(ABCBASE, ABC):
         else:
             raise ValueError("One of epsilon or quantile has to be passed.")
 
-        posterior = Empirical(
-            theta_accepted, log_weights=torch.ones(theta_accepted.shape[0])
-        )
+        posterior = Empirical(theta_accepted, log_weights=ones(theta_accepted.shape[0]))
 
         if return_distances:
             return posterior, distances_accepted

--- a/sbi/inference/abc/mcabc.py
+++ b/sbi/inference/abc/mcabc.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
-from typing import Callable, Optional, Union, Tuple
-from pyro.distributions.empirical import Empirical
-from torch.distributions.distribution import Distribution
-from sbi.inference.abc.abc_base import ABCBASE
-from sbi.user_input.user_input_checks import process_x, process_x_shape
+from typing import Callable, Optional, Tuple, Union
 
 import torch
-from torch import Tensor, ones
 from numpy import ndarray
+from pyro.distributions.empirical import Empirical
+from torch import Tensor, ones
+from torch.distributions.distribution import Distribution
+
+from sbi.inference.abc.abc_base import ABCBASE
+from sbi.user_input.user_input_checks import process_x, process_x_shape
 
 
 class MCABC(ABCBASE):
@@ -68,7 +69,7 @@ class MCABC(ABCBASE):
         # Exactly one of eps or quantile need to be passed.
         assert (eps is not None) ^ (
             quantile is not None
-        ), "Eps xor quantile must be passed."
+        ), "Eps or quantile must be passed, but not both."
 
         self.x_shape, _ = process_x_shape(self._simulator, self.prior)
         self.x_o = process_x(x_o, self.x_shape)

--- a/sbi/inference/abc/mcabc.py
+++ b/sbi/inference/abc/mcabc.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+from abc import ABC
+
+from pyro.distributions.empirical import Empirical
+from torch import log
+from sbi.inference.abc.abc_base import ABCBASE
+from typing import Callable, Optional, Union
+
+import torch
+
+
+class MCABC(ABCBASE, ABC):
+    def __init__(
+        self,
+        simulator,
+        prior,
+        x_o,
+        distance: Union[str, Callable] = "l2",
+        num_workers: int = 1,
+        simulation_batch_size: int = 1,
+        show_progress_bars: bool = True,
+    ):
+        """ Base class for Sequential Neural Posterior Estimation methods.
+
+        density_estimator: Density estimator that can `.log_prob()` and `.sample()`.
+
+        See docstring of `NeuralInference` class for all other arguments.
+        """
+
+        super().__init__(
+            simulator=simulator,
+            prior=prior,
+            x_o=x_o,
+            distance=distance,
+            num_workers=num_workers,
+            simulation_batch_size=simulation_batch_size,
+            show_progress_bars=show_progress_bars,
+        )
+
+    def __call__(
+        self,
+        num_simulations: int,
+        eps: Optional[float] = None,
+        quantile: Optional[float] = None,
+        return_distances: bool = False,
+    ):
+        # Exactly one of eps or quantile needs to be passed.
+        assert (eps is not None) ^ (
+            quantile is not None
+        ), "Eps xor quantile must be passed."
+
+        # Simulate and calculate distances.
+        theta = self.prior.sample((num_simulations,))
+        x = self._batched_simulator(theta)
+        distances = self.distance(self.x_o, x)
+
+        if eps is not None:
+            is_accepted = distances < eps
+            num_accepted = is_accepted.sum().item()
+            assert num_accepted > 0, f"No parameters accepted, eps={eps} too small"
+
+            theta_accepted = theta[is_accepted]
+            distances_accepted = distances[is_accepted]
+
+        elif quantile is not None:
+            num_top_samples = int(num_simulations * quantile)
+            sort_idx = torch.argsort(distances)
+            theta_accepted = theta[sort_idx][:num_top_samples]
+            distances_accepted = distances[sort_idx][:num_top_samples]
+
+        else:
+            raise ValueError("One of epsilon or quantile has to be passed.")
+
+        posterior = Empirical(
+            theta_accepted, log_weights=torch.ones(theta_accepted.shape[0])
+        )
+
+        if return_distances:
+            return posterior, distances_accepted
+        else:
+            return posterior

--- a/sbi/inference/abc/smcabc.py
+++ b/sbi/inference/abc/smcabc.py
@@ -1,0 +1,414 @@
+from __future__ import annotations
+
+from pyro.distributions.empirical import Empirical
+from sbi.inference.abc.abc_base import ABCBASE
+from typing import Callable, Optional, Tuple, Union
+
+import torch
+from torch import Tensor, ones, tensor
+from torch.distributions import Distribution, Multinomial, MultivariateNormal
+from pyro.distributions import Uniform
+from numpy import ndarray
+import logging
+
+
+class SMCABC(ABCBASE):
+    """ABC PMC as in Beaumont 2002 and 2009."""
+
+    def __init__(
+        self,
+        simulator: Callable,
+        prior: Distribution,
+        x_o: Union[Tensor, ndarray],
+        distance: Union[str, Callable] = "l2",
+        kernel: Optional[str] = "gaussian",
+        num_workers: int = 1,
+        simulation_batch_size: int = 1,
+        show_progress_bars: bool = True,
+    ):
+
+        super().__init__(
+            simulator=simulator,
+            prior=prior,
+            x_o=x_o,
+            distance=distance,
+            num_workers=num_workers,
+            simulation_batch_size=simulation_batch_size,
+            show_progress_bars=show_progress_bars,
+        )
+
+        assert kernel in ("gaussian", "uniform"), f"Kernel '{kernel}' not supported."
+
+        self.distance_to_x0 = lambda x: self.distance(self.x_o, x)
+        self.num_simulations = 0
+        self.num_simulation_budget = 0
+        self.kernel = kernel
+
+        self.logger = logging.getLogger(__name__)
+
+        # Define simulator that keeps track of budget.
+        def simulate_with_budget(theta):
+            self.num_simulations += theta.shape[0]
+            return self._batched_simulator(theta)
+
+        self._simulate_with_budget = simulate_with_budget
+
+    def __call__(
+        self,
+        num_particles: int,
+        num_initial_pop: int,
+        epsilon_decay: float,
+        num_simulation_budget: int,
+        batch_size: int = 100,
+        qt_decay: bool = False,
+        ess_min: Optional[float] = None,
+        kernel_variance_scale: float = 1.0,
+        use_last_pop_samples: bool = True,
+        return_summary: bool = False,
+    ):
+        pop_idx = 0
+        self.num_simulation_budget = num_simulation_budget
+
+        # run initial population
+        particles, epsilon, distances = self._sample_initial_population(
+            num_particles, num_initial_pop
+        )
+        log_weights = torch.log(1 / num_particles * ones(num_particles))
+
+        self.logger.info(
+            (
+                f"population={pop_idx}, eps={epsilon}, ess={1.0}, "
+                "num_sims={num_initial_pop}"
+            )
+        )
+
+        all_particles = [particles]
+        all_log_weights = [log_weights]
+        all_distances = [distances]
+        all_epsilons = [epsilon]
+
+        while self.num_simulations < num_simulation_budget:
+
+            pop_idx += 1
+            if qt_decay:
+                epsilon = self._get_next_epsilon(
+                    all_distances[pop_idx - 1], epsilon_decay
+                )
+            else:
+                epsilon *= epsilon_decay
+
+            # Get kernel variance from previous pop.
+            self.kernel_variance = self.get_kernel_variance(
+                all_particles[pop_idx - 1],
+                torch.exp(all_log_weights[pop_idx - 1]),
+                num_samples=1000,
+                kernel_variance_scale=kernel_variance_scale,
+            )
+            particles, log_weights, distances = self._sample_next_population(
+                particles=all_particles[pop_idx - 1],
+                log_weights=all_log_weights[pop_idx - 1],
+                distances=all_distances[pop_idx - 1],
+                epsilon=epsilon,
+                use_last_pop_samples=use_last_pop_samples,
+            )
+
+            # Resample weights if ess too low.
+            ess = (1 / torch.sum(torch.exp(2.0 * log_weights), dim=0)) / num_particles
+            if ess_min is not None:
+                if ess < ess_min:
+                    self.logger.info(
+                        f"ESS={ess:.2f} too low, resampling pop {pop_idx}..."
+                    )
+                    particles = self.sample_from_population_with_weights(
+                        particles, torch.exp(log_weights), num_samples=num_particles
+                    )
+                    log_weights = torch.log(1 / num_particles * ones(num_particles))
+
+            self.logger.info(
+                (
+                    f"population={pop_idx} done: eps={epsilon:.6f}, ess={ess:.2f},"
+                    " num_sims={self.num_simulations}, acc={acc:.4f}."
+                )
+            )
+
+            # collect results
+            all_particles.append(particles)
+            all_log_weights.append(log_weights)
+            all_distances.append(distances)
+            all_epsilons.append(epsilon)
+
+        posterior = Empirical(all_particles[-1], log_weights=all_log_weights[-1])
+
+        if return_summary:
+            return (
+                posterior,
+                dict(
+                    particles=all_particles,
+                    weights=all_log_weights,
+                    epsilons=all_epsilons,
+                    distances=all_distances,
+                ),
+            )
+        else:
+            return posterior
+
+    def _sample_initial_population(
+        self, num_particles: int, num_initial_pop: int,
+    ) -> Tuple[Tensor, float, Tensor]:
+
+        assert (
+            num_particles <= num_initial_pop
+        ), "number of initial round simulations must be greater than population size"
+
+        theta = self.prior.sample((num_initial_pop,))
+        x = self._simulate_with_budget(theta)
+        distances = self.distance_to_x0(x)
+        sortidx = torch.argsort(distances)
+        particles = theta[sortidx][:num_particles]
+        # Take last accepted distance as epsilon.
+        initial_epsilon = distances[sortidx][num_particles - 1]
+
+        if not torch.isfinite(initial_epsilon):
+            initial_epsilon = 1e8
+
+        return particles, initial_epsilon, distances[sortidx][:num_particles]
+
+    def _sample_next_population(
+        self,
+        particles: Tensor,
+        log_weights: Tensor,
+        distances: Tensor,
+        epsilon: float,
+        use_last_pop_samples: bool = True,
+    ) -> Tuple[Tensor, Tensor, Tensor]:
+
+        # new_particles = zeros_like(particles)
+        # new_log_weights = zeros_like(log_weights)
+        new_particles = []
+        new_log_weights = []
+        new_distances = []
+
+        num_accepted_particles = 0
+        num_particles = particles.shape[0]
+
+        while num_accepted_particles < num_particles:
+
+            # Upperbound for batch size to not exceed simulation budget.
+            num_batch = min(
+                num_particles - num_accepted_particles,
+                self.num_simulation_budget - self.num_simulations,
+            )
+
+            # Sample from previous population and perturb.
+            particle_candidates = self._sample_and_perturb(
+                particles, torch.exp(log_weights), num_samples=num_batch
+            )
+            # Simulate and select based on distance.
+            x = self._simulate_with_budget(particle_candidates)
+            dists = self.distance_to_x0(x)
+            is_accepted = dists <= epsilon
+            num_accepted_batch = is_accepted.sum().item()
+
+            if num_accepted_batch > 0:
+                new_particles.append(particle_candidates[is_accepted])
+                new_log_weights.append(
+                    self._calculate_new_log_weights(
+                        particle_candidates[is_accepted], particles, log_weights,
+                    )
+                )
+                new_distances.append(dists[is_accepted])
+                num_accepted_particles += num_accepted_batch
+
+            # If simulation budget was exceeded and we still need particles, take
+            # previous population or fill up with previous population.
+            if (
+                self.num_simulations >= self.num_simulation_budget
+                and num_accepted_particles < num_particles
+            ):
+                if use_last_pop_samples:
+                    num_remaining = num_particles - num_accepted_particles
+                    self.logger.info(
+                        f"""Simulation Budget exceeded, filling up with {num_remaining}
+                        samples from last population."""
+                    )
+                    # Some new particles have been accepted already, therefore
+                    # fill up the remaining once with old particles and weights.
+                    new_particles.append(particles[:num_remaining, :])
+                    # Recalculate weights with new particles.
+                    new_log_weights = [
+                        self._calculate_new_log_weights(
+                            torch.cat(new_particles), particles, log_weights,
+                        )
+                    ]
+                    new_distances.append(distances[:num_remaining])
+                else:
+                    self.logger.info(
+                        "Simulation Budget exceeded, returning previous population."
+                    )
+                    new_particles = [particles]
+                    new_log_weights = [log_weights]
+                    new_distances = [distances]
+
+                break
+
+        # collect lists of tensors into tensors
+        new_particles = torch.cat(new_particles)
+        new_log_weights = torch.cat(new_log_weights)
+        new_distances = torch.cat(new_distances)
+
+        # normalize the new weights
+        new_log_weights -= torch.logsumexp(new_log_weights, dim=0)
+
+        return new_particles, new_log_weights, new_distances
+
+    def _get_next_epsilon(self, distances: Tensor, quantile: float) -> float:
+        """Return epsilon for next round based on quantile of this round's distances.
+
+        Note: distances are made unique to avoid repeated distances from simulations
+        that result in the same observation.
+
+        Arguments:
+            distances  -- The distances accepted in this round.
+            quantile -- quantile in the distance distribution to determine new epsilon
+
+        Returns:
+            epsilon -- epsilon for the next population.
+        """
+        # Make distances unique to skip simulations with same outcome.
+        # NOTE: unique sorts the input already, so no sorting needed below?
+        distances = torch.unique(distances)
+        distances = distances[torch.argsort(distances)]
+        # Cumsum as cdf proxy.
+        distances_cdf = torch.cumsum(distances, dim=0) / distances.sum()
+        # Take the q quantile of distances.
+        try:
+            qidx = torch.where(distances_cdf >= quantile)[0][0]
+        except IndexError:
+            self.logger.warning(
+                (
+                    f"Accepted unique distances={distances} dont match "
+                    "quantile={quantile:.2f}. Selecting last distance."
+                )
+            )
+            qidx = -1
+
+        # The new epsilon is given by that distance.
+        return distances[qidx].item()
+
+    def _calculate_new_log_weights(
+        self, new_particles: Tensor, old_particles: Tensor, log_weights: Tensor,
+    ) -> Tensor:
+
+        # Prior can be batched across new particles.
+        prior_log_probs = self.prior.log_prob(new_particles)
+
+        # Contstruct function to get kernel log prob for given new particle.
+        # The kernel is centered on each new particle.
+        def kernel_log_prob(new_particle):
+            return self.get_new_kernel(new_particle).log_prob(old_particles)
+
+        # We still have to loop over particles here because
+        # the kernel log probs are already batched across old particles.
+        log_weighted_sum = tensor(
+            [
+                torch.logsumexp(log_weights + kernel_log_prob(new_particle), dim=0)
+                for new_particle in new_particles
+            ],
+            dtype=torch.float32,
+        )
+        # new weights are prior probs over weighted sum:
+        return prior_log_probs - log_weighted_sum
+
+    @staticmethod
+    def sample_from_population_with_weights(
+        particles: Tensor, weights: Tensor, num_samples: int = 1
+    ):
+        # define multinomial with weights as probs
+        multi = Multinomial(probs=weights)
+        # sample num samples, with replacement
+        samples = multi.sample(sample_shape=(num_samples,))
+        # get indices of success trials
+        indices = torch.where(samples)[1]
+        # return those indices from trace
+        return particles[indices]
+
+    def _sample_and_perturb(
+        self, particles: Tensor, weights: Tensor, num_samples: int = 1
+    ):
+        """Sample and perturb batch of new parameters from trace.
+
+        Reject sampled and perturbed parameters outside of prior.
+
+        Args:
+            trace {Tensor} -- [description]
+            weights {Tensor} -- [description]
+
+        Kwargs:
+            num_samples {int} -- [description] (default: {1})
+        """
+
+        num_accepted = 0
+        parameters = []
+        while num_accepted < num_samples:
+            parms = self.sample_from_population_with_weights(
+                particles, weights, num_samples=num_samples - num_accepted
+            )
+
+            # Create kernel on params and perturb.
+            parms_perturbed = self.get_new_kernel(parms).sample()
+
+            is_within_prior = torch.isfinite(self.prior.log_prob(parms_perturbed))
+            num_accepted += is_within_prior.sum().item()
+
+            if num_accepted > 0:
+                parameters.append(parms_perturbed[is_within_prior])
+
+        return torch.cat(parameters)
+
+    def get_kernel_variance(
+        self,
+        particles: Tensor,
+        weights: Tensor,
+        num_samples: int = 1000,
+        kernel_variance_scale: float = 1.0,
+    ) -> Tensor:
+
+        # get weighted samples
+        samples = self.sample_from_population_with_weights(
+            particles, weights, num_samples=num_samples
+        )
+
+        if self.kernel == "gaussian":
+            mean = torch.mean(samples, dim=0).unsqueeze(0)
+
+            # take double the weighted sample cov as proposed in Beaumont 2009
+            population_cov = torch.matmul(samples.T, samples) / (
+                num_samples - 1
+            ) - torch.matmul(mean.T, mean)
+
+            return kernel_variance_scale * population_cov
+
+        elif self.kernel == "uniform":
+            # Variance spans the range of parameters for every dimension.
+            return kernel_variance_scale * tensor(
+                [max(theta_column) - min(theta_column) for theta_column in samples.T]
+            )
+        else:
+            raise ValueError(f"Kernel, '{self.kernel}' not supported.")
+
+    def get_new_kernel(self, thetas: Tensor) -> Distribution:
+        """Return new kernel distribution for a given set of paramters."""
+
+        if self.kernel == "gaussian":
+            return MultivariateNormal(
+                loc=thetas, covariance_matrix=self.kernel_variance
+            )
+
+        elif self.kernel == "uniform":
+            low = thetas - self.kernel_variance
+            high = thetas + self.kernel_variance
+            # Move batch shape to event shape to get Uniform that is multivariate in
+            # parameter dimension.
+            return Uniform(low=low, high=high).to_event(1)
+        else:
+            raise ValueError(f"Kernel, '{self.kernel}' not supported.")

--- a/sbi/inference/abc/smcabc.py
+++ b/sbi/inference/abc/smcabc.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import pdb
 
 from pyro.distributions.empirical import Empirical
 from sbi.inference.abc.abc_base import ABCBASE
@@ -10,6 +11,18 @@ from torch.distributions import Distribution, Multinomial, MultivariateNormal
 from pyro.distributions import Uniform
 from numpy import ndarray
 import logging
+
+
+"""Notes about differences in SMCABC algorithms:
+We distinguish between three different SMC methods here:
+- A: The one proposed by Toni et al. 2010 (Phd Thesis)
+- B: The one proposed by Sisson et al. 2007 (with correction from 2009)
+- C: The one proposed by Beaumont et al. 2009, called "SMCABC-C"
+
+In Toni et al. 2010 we find an overview of the differences on page 34:
+- B: same as A except for resampling after weight normalization.
+- C: same as A except for calculation of the covariance of the perturbation kernel.
+"""
 
 
 class SMCABC(ABCBASE):
@@ -25,6 +38,7 @@ class SMCABC(ABCBASE):
         num_workers: int = 1,
         simulation_batch_size: int = 1,
         show_progress_bars: bool = True,
+        algorithm_variant: str = "C",
     ):
 
         super().__init__(
@@ -37,7 +51,16 @@ class SMCABC(ABCBASE):
             show_progress_bars=show_progress_bars,
         )
 
-        assert kernel in ("gaussian", "uniform"), f"Kernel '{kernel}' not supported."
+        kernels = ("gaussian", "uniform")
+        assert (
+            kernel in kernels
+        ), f"Kernel '{kernel}' not supported. Choose one from {kernels}."
+        algorithm_variants = ("A", "B", "C")
+        assert algorithm_variant in algorithm_variants, (
+            f"SMCABC variant '{algorithm_variant}' not supported, choose one from"
+            " {algorithm_variants}."
+        )
+        self.algorithm_variant = algorithm_variant
 
         self.distance_to_x0 = lambda x: self.distance(self.x_o, x)
         self.num_simulations = 0
@@ -57,11 +80,11 @@ class SMCABC(ABCBASE):
         self,
         num_particles: int,
         num_initial_pop: int,
-        epsilon_decay: float,
         num_simulation_budget: int,
+        epsilon_decay: float,
+        distance_based_decay: bool = False,
         batch_size: int = 100,
-        qt_decay: bool = False,
-        ess_min: Optional[float] = None,
+        ess_min: Optional[float] = 0.5,
         kernel_variance_scale: float = 1.0,
         use_last_pop_samples: bool = True,
         return_summary: bool = False,
@@ -90,10 +113,12 @@ class SMCABC(ABCBASE):
         while self.num_simulations < num_simulation_budget:
 
             pop_idx += 1
-            if qt_decay:
+            # Decay based on quantile of distances from previous pop.
+            if distance_based_decay:
                 epsilon = self._get_next_epsilon(
                     all_distances[pop_idx - 1], epsilon_decay
                 )
+            # Constant decay.
             else:
                 epsilon *= epsilon_decay
 
@@ -114,15 +139,14 @@ class SMCABC(ABCBASE):
 
             # Resample weights if ess too low.
             ess = (1 / torch.sum(torch.exp(2.0 * log_weights), dim=0)) / num_particles
-            if ess_min is not None:
-                if ess < ess_min:
-                    self.logger.info(
-                        f"ESS={ess:.2f} too low, resampling pop {pop_idx}..."
-                    )
-                    particles = self.sample_from_population_with_weights(
-                        particles, torch.exp(log_weights), num_samples=num_particles
-                    )
-                    log_weights = torch.log(1 / num_particles * ones(num_particles))
+            # Resampling of weights for low ESS only for Sisson et al. 2007.
+            if self.algorithm_variant == "B" and ess < ess_min:
+                self.logger.info(f"ESS={ess:.2f} too low, resampling pop {pop_idx}...")
+                # First resample, then set to uniform weights in in Sisson et al. 2007.
+                particles = self.sample_from_population_with_weights(
+                    particles, torch.exp(log_weights), num_samples=num_particles
+                )
+                log_weights = torch.log(1 / num_particles * ones(num_particles))
 
             self.logger.info(
                 (
@@ -296,22 +320,22 @@ class SMCABC(ABCBASE):
         return distances[qidx].item()
 
     def _calculate_new_log_weights(
-        self, new_particles: Tensor, old_particles: Tensor, log_weights: Tensor,
+        self, new_particles: Tensor, old_particles: Tensor, old_log_weights: Tensor,
     ) -> Tensor:
 
         # Prior can be batched across new particles.
         prior_log_probs = self.prior.log_prob(new_particles)
 
-        # Contstruct function to get kernel log prob for given new particle.
-        # The kernel is centered on each new particle.
+        # Contstruct function to get kernel log prob for given old particle.
+        # The kernel is centered on each old particle as in all three variants (A,B,C).
         def kernel_log_prob(new_particle):
-            return self.get_new_kernel(new_particle).log_prob(old_particles)
+            return self.get_new_kernel(old_particles).log_prob(new_particle)
 
         # We still have to loop over particles here because
         # the kernel log probs are already batched across old particles.
         log_weighted_sum = tensor(
             [
-                torch.logsumexp(log_weights + kernel_log_prob(new_particle), dim=0)
+                torch.logsumexp(old_log_weights + kernel_log_prob(new_particle), dim=0)
                 for new_particle in new_particles
             ],
             dtype=torch.float32,
@@ -379,14 +403,30 @@ class SMCABC(ABCBASE):
         )
 
         if self.kernel == "gaussian":
-            mean = torch.mean(samples, dim=0).unsqueeze(0)
+            # For variant C, Beaumont et al. 2009, the kernel variance comes from the
+            # previous population.
+            if self.algorithm_variant == "C":
+                mean = torch.mean(samples, dim=0).unsqueeze(0)
 
-            # take double the weighted sample cov as proposed in Beaumont 2009
-            population_cov = torch.matmul(samples.T, samples) / (
-                num_samples - 1
-            ) - torch.matmul(mean.T, mean)
-
-            return kernel_variance_scale * population_cov
+                # take double the weighted sample cov as proposed in Beaumont 2009
+                population_cov = torch.matmul(samples.T, samples) / (
+                    num_samples - 1
+                ) - torch.matmul(mean.T, mean)
+                return kernel_variance_scale * population_cov
+            # While for Toni et al. and Sisson et al. it comes from the parameter
+            # ranges.
+            elif self.algorithm_variant in ("A", "B"):
+                # Variance spans the range of parameters for every dimension.
+                parameter_ranges = tensor(
+                    [
+                        max(theta_column) - min(theta_column)
+                        for theta_column in samples.T
+                    ]
+                )
+                assert parameter_ranges.ndim < 2
+                return kernel_variance_scale * torch.diag(parameter_ranges)
+            else:
+                raise ValueError(f"Variant, '{self.algorithm_variant}' not supported.")
 
         elif self.kernel == "uniform":
             # Variance spans the range of parameters for every dimension.
@@ -400,6 +440,7 @@ class SMCABC(ABCBASE):
         """Return new kernel distribution for a given set of paramters."""
 
         if self.kernel == "gaussian":
+            assert self.kernel_variance.ndim == 2
             return MultivariateNormal(
                 loc=thetas, covariance_matrix=self.kernel_variance
             )

--- a/tests/abc_test.py
+++ b/tests/abc_test.py
@@ -6,7 +6,7 @@ from sbi.simulators.linear_gaussian import (
     true_posterior_linear_gaussian_mvn_prior,
 )
 
-from sbi.inference import MCABC, SMCABC
+from sbi.inference import ABC, SMC
 from torch.distributions import MultivariateNormal
 from tests.test_utils import check_c2st
 
@@ -31,9 +31,9 @@ def test_mcabc_inference_on_linear_gaussian(num_dim):
     def simulator(theta):
         return linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
-    infer = MCABC(simulator, prior, x_o, simulation_batch_size=10000)
+    infer = ABC(simulator, prior, simulation_batch_size=10000)
 
-    phat = infer(1000000, quantile=0.001)
+    phat = infer(x_o, 100000, quantile=0.01)
 
     check_c2st(phat.sample((num_samples,)), target_samples, alg="MCABC")
 
@@ -56,11 +56,10 @@ def test_smcabc_inference_on_linear_gaussian(num_dim):
     def simulator(theta):
         return linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
-    infer = SMCABC(
-        simulator, prior, x_o, simulation_batch_size=10000, algorithm_variant="C"
-    )
+    infer = SMC(simulator, prior, simulation_batch_size=10000, algorithm_variant="C")
 
     phat = infer(
+        x_o,
         num_particles=1000,
         num_initial_pop=5000,
         epsilon_decay=0.5,

--- a/tests/abc_test.py
+++ b/tests/abc_test.py
@@ -63,7 +63,7 @@ def test_smcabc_inference_on_linear_gaussian(num_dim):
         num_particles=1000,
         num_initial_pop=5000,
         epsilon_decay=0.5,
-        num_simulation_budget=30000,
+        num_simulations=30000,
         distance_based_decay=True,
     )
 

--- a/tests/abc_test.py
+++ b/tests/abc_test.py
@@ -1,5 +1,4 @@
 import pytest
-import torch
 from torch import eye, ones, zeros
 
 from sbi.simulators.linear_gaussian import (
@@ -7,15 +6,15 @@ from sbi.simulators.linear_gaussian import (
     true_posterior_linear_gaussian_mvn_prior,
 )
 
-from sbi.inference.abc.mcabc import MCABC
+from sbi.inference import MCABC, SMCABC
 from torch.distributions import MultivariateNormal
-from pyro.distributions import Empirical
 from tests.test_utils import check_c2st
 
 
 @pytest.mark.parametrize("num_dim", (1, 2))
 def test_mcabc_inference_on_linear_gaussian(num_dim):
     x_o = zeros((1, num_dim))
+    num_samples = 1000
 
     # likelihood_mean will be likelihood_shift+theta
     likelihood_shift = -1.0 * ones(num_dim)
@@ -27,7 +26,7 @@ def test_mcabc_inference_on_linear_gaussian(num_dim):
     gt_posterior = true_posterior_linear_gaussian_mvn_prior(
         x_o[0], likelihood_shift, likelihood_cov, prior_mean, prior_cov
     )
-    target_samples = gt_posterior.sample((10000,))
+    target_samples = gt_posterior.sample((num_samples,))
 
     def simulator(theta):
         return linear_gaussian(theta, likelihood_shift, likelihood_cov)
@@ -36,5 +35,35 @@ def test_mcabc_inference_on_linear_gaussian(num_dim):
 
     phat = infer(1000000, quantile=0.001)
 
-    check_c2st(phat.sample((10000,)), target_samples, alg="MCABC")
+    check_c2st(phat.sample((num_samples,)), target_samples, alg="MCABC")
 
+
+@pytest.mark.parametrize("num_dim", (1, 2))
+def test_smcabc_inference_on_linear_gaussian(num_dim):
+    x_o = zeros((1, num_dim))
+    num_samples = 1000
+    likelihood_shift = -1.0 * ones(num_dim)
+    likelihood_cov = 0.3 * eye(num_dim)
+
+    prior_mean = zeros(num_dim)
+    prior_cov = eye(num_dim)
+    prior = MultivariateNormal(loc=prior_mean, covariance_matrix=prior_cov)
+    gt_posterior = true_posterior_linear_gaussian_mvn_prior(
+        x_o[0], likelihood_shift, likelihood_cov, prior_mean, prior_cov
+    )
+    target_samples = gt_posterior.sample((num_samples,))
+
+    def simulator(theta):
+        return linear_gaussian(theta, likelihood_shift, likelihood_cov)
+
+    infer = SMCABC(simulator, prior, x_o, simulation_batch_size=10000)
+
+    phat = infer(
+        num_particles=1000,
+        num_initial_pop=5000,
+        epsilon_decay=0.5,
+        num_simulation_budget=30000,
+        qt_decay=True,
+    )
+
+    check_c2st(phat.sample((num_samples,)), target_samples, alg="SMCABC")

--- a/tests/abc_test.py
+++ b/tests/abc_test.py
@@ -1,0 +1,40 @@
+import pytest
+import torch
+from torch import eye, ones, zeros
+
+from sbi.simulators.linear_gaussian import (
+    linear_gaussian,
+    true_posterior_linear_gaussian_mvn_prior,
+)
+
+from sbi.inference.abc.mcabc import MCABC
+from torch.distributions import MultivariateNormal
+from pyro.distributions import Empirical
+from tests.test_utils import check_c2st
+
+
+@pytest.mark.parametrize("num_dim", (1, 2))
+def test_mcabc_inference_on_linear_gaussian(num_dim):
+    x_o = zeros((1, num_dim))
+
+    # likelihood_mean will be likelihood_shift+theta
+    likelihood_shift = -1.0 * ones(num_dim)
+    likelihood_cov = 0.3 * eye(num_dim)
+
+    prior_mean = zeros(num_dim)
+    prior_cov = eye(num_dim)
+    prior = MultivariateNormal(loc=prior_mean, covariance_matrix=prior_cov)
+    gt_posterior = true_posterior_linear_gaussian_mvn_prior(
+        x_o[0], likelihood_shift, likelihood_cov, prior_mean, prior_cov
+    )
+    target_samples = gt_posterior.sample((10000,))
+
+    def simulator(theta):
+        return linear_gaussian(theta, likelihood_shift, likelihood_cov)
+
+    infer = MCABC(simulator, prior, x_o, simulation_batch_size=10000)
+
+    phat = infer(1000000, quantile=0.001)
+
+    check_c2st(phat.sample((10000,)), target_samples, alg="MCABC")
+

--- a/tests/abc_test.py
+++ b/tests/abc_test.py
@@ -56,14 +56,16 @@ def test_smcabc_inference_on_linear_gaussian(num_dim):
     def simulator(theta):
         return linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
-    infer = SMCABC(simulator, prior, x_o, simulation_batch_size=10000)
+    infer = SMCABC(
+        simulator, prior, x_o, simulation_batch_size=10000, algorithm_variant="C"
+    )
 
     phat = infer(
         num_particles=1000,
         num_initial_pop=5000,
         epsilon_decay=0.5,
         num_simulation_budget=30000,
-        qt_decay=True,
+        distance_based_decay=True,
     )
 
     check_c2st(phat.sample((num_samples,)), target_samples, alg="SMCABC")


### PR DESCRIPTION
They will use a similar API as current `sbi` methods and return an empirical distribution as posterior. 

TODO: 
- [x] MCABC aka rejection ABC
- [x] SMC ABC (pmc and smc in one class with flags)
- [x] types and documentation
- [x] reviews