### PR TITLE
Fix device kwarg

### DIFF
--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -20,7 +20,7 @@ from sbi.simulators.simutils import simulate_in_batches
 from sbi.user_input.user_input_checks import prepare_for_sbi, process_x
 from sbi.utils import get_log_root
 from sbi.utils.plot import pairplot
-from sbi.utils.torchutils import get_default_device, set_default_device
+from sbi.utils.torchutils import configure_default_device
 
 
 def infer(
@@ -105,7 +105,7 @@ class NeuralInference(ABC):
                 maps to data x at once. If None, we simulate all parameter sets at the
                 same time. If >= 1, the simulator has to process data of shape
                 (simulation_batch_size, parameter_dimension).
-            device: torch device on which to compute, e.g. `gpu` or `cpu`.
+            device: torch device on which to compute, e.g. gpu or cpu.
             logging_level: Minimum severity of messages to log. One of the strings
                "INFO", "WARNING", "DEBUG", "ERROR" and "CRITICAL".
             summary_writer: A `SummaryWriter` to control, among others, log
@@ -121,8 +121,8 @@ class NeuralInference(ABC):
             "gpu",
             "cpu",
         ), "Currently, only 'gpu' or 'cpu' are supported as devices."
-        set_default_device(device)
-        self._device = get_default_device()
+
+        self._device = configure_default_device(device)
 
         self._simulator, self._prior, self._x_shape = simulator, prior, x_shape
 

--- a/sbi/inference/posterior.py
+++ b/sbi/inference/posterior.py
@@ -25,9 +25,6 @@ from sbi.utils.torchutils import (
 from sbi.user_input.user_input_checks import process_x
 
 
-NEG_INF = torch.tensor(float("-inf"), dtype=torch.float32)
-
-
 class NeuralPosterior:
     r"""Posterior $p(\theta|x)$ with `log_prob()` and `sample()` methods.<br/><br/>
     All inference methods in sbi train a neural network which is then used to obtain
@@ -213,7 +210,12 @@ class NeuralPosterior:
 
         # Force probability to be zero outside prior support.
         is_prior_finite = torch.isfinite(self._prior.log_prob(theta))
-        masked_log_prob = torch.where(is_prior_finite, unnorm_log_prob, NEG_INF)
+
+        masked_log_prob = torch.where(
+            is_prior_finite,
+            unnorm_log_prob,
+            torch.tensor(float("-inf"), dtype=torch.float32),
+        )
 
         log_factor = (
             log(self.leakage_correction(x=batched_first_of_batch(x)))

--- a/sbi/inference/snle/snle_a.py
+++ b/sbi/inference/snle/snle_a.py
@@ -75,7 +75,7 @@ class SNLE_A(LikelihoodEstimator):
         num_rounds: int,
         num_simulations_per_round: OneOrMore[int],
         x_o: Optional[Tensor] = None,
-        batch_size: int = 50,
+        training_batch_size: int = 50,
         learning_rate: float = 5e-4,
         validation_fraction: float = 0.1,
         stop_after_epochs: int = 20,
@@ -102,7 +102,7 @@ class SNLE_A(LikelihoodEstimator):
                 sampling so that the simulator is run with parameters that are likely
                 for that `x_o`, i.e. they are sampled from the posterior obtained in the
                 previous round $p(\theta|x_o)$.
-            batch_size: Training batch size.
+            training_batch_size: Training batch size.
             learning_rate: Learning rate for Adam optimizer.
             validation_fraction: The fraction of data to use for validation.
             stop_after_epochs: The number of epochs to wait for improvement on the

--- a/sbi/inference/snle/snle_a.py
+++ b/sbi/inference/snle/snle_a.py
@@ -10,7 +10,6 @@ from torch.utils.tensorboard import SummaryWriter
 
 from sbi.inference.posterior import NeuralPosterior
 from sbi.inference.snle.snle_base import LikelihoodEstimator
-from sbi.utils.torchutils import get_default_device
 from sbi.types import OneOrMore
 from sbi.utils import del_entries
 
@@ -25,7 +24,7 @@ class SNLE_A(LikelihoodEstimator):
         simulation_batch_size: int = 1,
         density_estimator: Union[str, nn.Module] = "maf",
         mcmc_method: str = "slice_np",
-        device: Union[torch.device, str] = get_default_device(),
+        device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
         summary_writer: Optional[SummaryWriter] = None,
         show_progress_bars: bool = True,
@@ -57,7 +56,7 @@ class SNLE_A(LikelihoodEstimator):
                 configured network of the provided type (one of nsf, maf, mdn, made).
             mcmc_method: If MCMC sampling is used, specify the method here: either of
                 slice_np, slice, hmc, nuts.
-            device: torch device on which to compute, e.g. cuda, cpu.
+            device: torch device on which to compute, e.g. gpu, cpu.
             logging_level: Minimum severity of messages to log. One of the strings
                 INFO, WARNING, DEBUG, ERROR and CRITICAL.
             summary_writer: A `SummaryWriter` to control, among others, log

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -19,7 +19,6 @@ from sbi.inference.posterior import NeuralPosterior
 from sbi.types import OneOrMore, ScalarFloat
 import sbi.utils as utils
 from sbi.utils import handle_invalid_x, warn_on_invalid_x
-from sbi.utils.torchutils import get_default_device
 
 
 class LikelihoodEstimator(NeuralInference, ABC):
@@ -32,7 +31,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
         simulation_batch_size: int = 1,
         density_estimator: Union[str, nn.Module] = "maf",
         mcmc_method: str = "slice_np",
-        device: Union[torch.device, str] = get_default_device(),
+        device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
         summary_writer: Optional[SummaryWriter] = None,
         show_progress_bars: bool = True,
@@ -64,7 +63,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
                 configured network of the provided type (one of nsf, maf, mdn, made).
             mcmc_method: If MCMC sampling is used, specify the method here: either of
                 slice_np, slice, hmc, nuts.
-            device: torch device on which to compute, e.g. cuda, cpu.
+            device: torch device on which to compute, e.g. gpu, cpu.
             logging_level: Minimum severity of messages to log. One of the strings
                 INFO, WARNING, DEBUG, ERROR and CRITICAL.
             summary_writer: A `SummaryWriter` to control, among others, log

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -115,7 +115,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
         num_rounds: int,
         num_simulations_per_round: OneOrMore[int],
         x_o: Optional[Tensor] = None,
-        batch_size: int = 50,
+        training_batch_size: int = 50,
         learning_rate: float = 5e-4,
         validation_fraction: float = 0.1,
         stop_after_epochs: int = 20,
@@ -177,7 +177,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
             # Fit neural likelihood to newly aggregated dataset.
             self._train(
                 round_=round_,
-                batch_size=batch_size,
+                training_batch_size=training_batch_size,
                 learning_rate=learning_rate,
                 validation_fraction=validation_fraction,
                 stop_after_epochs=stop_after_epochs,
@@ -205,7 +205,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
     def _train(
         self,
         round_: int,
-        batch_size: int,
+        training_batch_size: int,
         learning_rate: float,
         validation_fraction: float,
         stop_after_epochs: int,
@@ -246,13 +246,13 @@ class LikelihoodEstimator(NeuralInference, ABC):
         # Create neural net and validation loaders using a subset sampler.
         train_loader = data.DataLoader(
             dataset,
-            batch_size=min(batch_size, num_training_examples),
+            batch_size=min(training_batch_size, num_training_examples),
             drop_last=True,
             sampler=SubsetRandomSampler(train_indices),
         )
         val_loader = data.DataLoader(
             dataset,
-            batch_size=min(batch_size, num_validation_examples),
+            batch_size=min(training_batch_size, num_validation_examples),
             shuffle=False,
             drop_last=False,
             sampler=SubsetRandomSampler(val_indices),

--- a/sbi/inference/snpe/snpe_a.py
+++ b/sbi/inference/snpe/snpe_a.py
@@ -9,7 +9,6 @@ from torch import nn
 from torch.utils.tensorboard import SummaryWriter
 
 from sbi.inference.snpe.snpe_base import PosteriorEstimator
-from sbi.utils.torchutils import get_default_device
 
 
 class SNPE_A(PosteriorEstimator):
@@ -25,7 +24,7 @@ class SNPE_A(PosteriorEstimator):
         z_score_x: bool = True,
         z_score_min_std: float = 1e-7,
         exclude_invalid_x: bool = True,
-        device: Union[torch.device, str] = get_default_device(),
+        device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
         summary_writer: Optional[SummaryWriter] = None,
         show_progress_bars: bool = True,

--- a/sbi/inference/snpe/snpe_b.py
+++ b/sbi/inference/snpe/snpe_b.py
@@ -9,7 +9,6 @@ from torch import Tensor, nn
 from torch.utils.tensorboard import SummaryWriter
 
 from sbi.inference.snpe.snpe_base import PosteriorEstimator
-from sbi.utils.torchutils import get_default_device
 
 
 class SNPE_B(PosteriorEstimator):
@@ -27,7 +26,7 @@ class SNPE_B(PosteriorEstimator):
         retrain_from_scratch_each_round: bool = False,
         discard_prior_samples: bool = False,
         exclude_invalid_x: bool = True,
-        device: Union[torch.device, str] = get_default_device(),
+        device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
         summary_writer: Optional[SummaryWriter] = None,
         show_progress_bars: bool = True,

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -91,7 +91,7 @@ class PosteriorEstimator(NeuralInference, ABC):
         num_rounds: int,
         num_simulations_per_round: OneOrMore[int],
         x_o: Optional[Tensor] = None,
-        batch_size: int = 50,
+        training_batch_size: int = 50,
         learning_rate: float = 5e-4,
         validation_fraction: float = 0.1,
         stop_after_epochs: int = 20,
@@ -121,7 +121,7 @@ class PosteriorEstimator(NeuralInference, ABC):
                 sampling so that the simulator is run with parameters that are likely
                 for that `x_o`, i.e. they are sampled from the posterior obtained in the
                 previous round $p(\theta|x_o)$.
-            batch_size: Training batch size.
+            training_batch_size: Training batch size.
             learning_rate: Learning rate for Adam optimizer.
             validation_fraction: The fraction of data to use for validation.
             stop_after_epochs: The number of epochs to wait for improvement on the
@@ -198,7 +198,7 @@ class PosteriorEstimator(NeuralInference, ABC):
             # Fit posterior using newly aggregated data set.
             self._train(
                 round_=round_,
-                batch_size=batch_size,
+                training_batch_size=training_batch_size,
                 learning_rate=learning_rate,
                 validation_fraction=validation_fraction,
                 stop_after_epochs=stop_after_epochs,
@@ -314,7 +314,7 @@ class PosteriorEstimator(NeuralInference, ABC):
     def _train(
         self,
         round_: int,
-        batch_size: int,
+        training_batch_size: int,
         learning_rate: float,
         validation_fraction: float,
         stop_after_epochs: int,
@@ -356,13 +356,13 @@ class PosteriorEstimator(NeuralInference, ABC):
         # Create neural net and validation loaders using a subset sampler.
         train_loader = data.DataLoader(
             dataset,
-            batch_size=min(batch_size, num_training_examples),
+            batch_size=min(training_batch_size, num_training_examples),
             drop_last=True,
             sampler=SubsetRandomSampler(train_indices),
         )
         val_loader = data.DataLoader(
             dataset,
-            batch_size=min(batch_size, num_validation_examples),
+            batch_size=min(training_batch_size, num_validation_examples),
             shuffle=False,
             drop_last=True,
             sampler=SubsetRandomSampler(val_indices),

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -20,7 +20,6 @@ from sbi.inference.posterior import NeuralPosterior
 from sbi.types import OneOrMore, ScalarFloat
 import sbi.utils as utils
 from sbi.utils import Standardize, handle_invalid_x, warn_on_invalid_x
-from sbi.utils.torchutils import get_default_device
 
 
 class PosteriorEstimator(NeuralInference, ABC):
@@ -34,7 +33,7 @@ class PosteriorEstimator(NeuralInference, ABC):
         density_estimator: Union[str, nn.Module] = "maf",
         sample_with_mcmc: bool = False,
         mcmc_method: str = "slice_np",
-        device: Union[torch.device, str] = get_default_device(),
+        device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
         summary_writer: Optional[SummaryWriter] = None,
         show_progress_bars: bool = True,

--- a/sbi/inference/snpe/snpe_c.py
+++ b/sbi/inference/snpe/snpe_c.py
@@ -88,7 +88,7 @@ class SNPE_C(PosteriorEstimator):
         num_simulations_per_round: OneOrMore[int],
         x_o: Optional[Tensor] = None,
         num_atoms: int = 10,
-        batch_size: int = 50,
+        training_batch_size: int = 50,
         learning_rate: float = 5e-4,
         validation_fraction: float = 0.1,
         stop_after_epochs: int = 20,
@@ -119,7 +119,7 @@ class SNPE_C(PosteriorEstimator):
                 for that `x_o`, i.e. they are sampled from the posterior obtained in the
                 previous round $p(\theta|x_o)$.
             num_atoms: Number of atoms to use for classification.
-            batch_size: Training batch size.
+            training_batch_size: Training batch size.
             learning_rate: Learning rate for Adam optimizer.
             validation_fraction: The fraction of data to use for validation.
             stop_after_epochs: The number of epochs to wait for improvement on the

--- a/sbi/inference/snpe/snpe_c.py
+++ b/sbi/inference/snpe/snpe_c.py
@@ -27,7 +27,7 @@ class SNPE_C(PosteriorEstimator):
         sample_with_mcmc: bool = False,
         mcmc_method: str = "slice_np",
         use_combined_loss: bool = False,
-        device: Union[torch.device, str] = get_default_device(),
+        device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
         summary_writer: Optional[SummaryWriter] = None,
         show_progress_bars: bool = True,
@@ -64,7 +64,7 @@ class SNPE_C(PosteriorEstimator):
                 using maximum likelihood in addition to training it on all samples using
                 atomic loss. The extra MLE loss helps prevent density leaking with
                 bounded priors.
-            device: torch device on which to compute, e.g. cuda, cpu.
+            device: torch device on which to compute, e.g. gpu, cpu.
             logging_level: Minimum severity of messages to log. One of the strings
                 INFO, WARNING, DEBUG, ERROR and CRITICAL.
             summary_writer: A `SummaryWriter` to control, among others, log

--- a/sbi/inference/snpe/snpe_c.py
+++ b/sbi/inference/snpe/snpe_c.py
@@ -12,7 +12,6 @@ from sbi.inference.posterior import NeuralPosterior
 from sbi.inference.snpe.snpe_base import PosteriorEstimator
 from sbi.types import OneOrMore
 from sbi.utils import clamp_and_warn, del_entries, repeat_rows
-from sbi.utils.torchutils import get_default_device
 
 
 class SNPE_C(PosteriorEstimator):

--- a/sbi/inference/snre/snre_a.py
+++ b/sbi/inference/snre/snre_a.py
@@ -10,7 +10,6 @@ from torch.utils.tensorboard import SummaryWriter
 from sbi.inference.posterior import NeuralPosterior
 from sbi.inference.snre.snre_base import RatioEstimator
 from sbi.utils import del_entries
-from sbi.utils.torchutils import get_default_device
 
 
 class SNRE_A(RatioEstimator):
@@ -24,7 +23,7 @@ class SNRE_A(RatioEstimator):
         embedding_net: nn.Module = nn.Identity(),
         classifier: Union[str, nn.Module] = "resnet",
         mcmc_method: str = "slice_np",
-        device: Union[torch.device, str] = get_default_device(),
+        device: str = "cpu",
         logging_level: Union[int, str] = "warning",
         summary_writer: Optional[SummaryWriter] = None,
         show_progress_bars: bool = True,
@@ -56,7 +55,7 @@ class SNRE_A(RatioEstimator):
                 use a pre-configured neural network.
             mcmc_method: If MCMC sampling is used, specify the method here: either of
                 slice_np, slice, hmc, nuts.
-            device: torch device on which to compute, e.g. cuda, cpu.
+            device: torch device on which to compute, e.g. gpu, cpu.
             logging_level: Minimum severity of messages to log. One of the strings
                 INFO, WARNING, DEBUG, ERROR and CRITICAL.
             summary_writer: A `SummaryWriter` to control, among others, log

--- a/sbi/inference/snre/snre_a.py
+++ b/sbi/inference/snre/snre_a.py
@@ -74,7 +74,7 @@ class SNRE_A(RatioEstimator):
         num_rounds: int,
         num_simulations_per_round: OneOrMore[int],
         x_o: Optional[Tensor] = None,
-        batch_size: int = 50,
+        training_batch_size: int = 50,
         learning_rate: float = 5e-4,
         validation_fraction: float = 0.1,
         stop_after_epochs: int = 20,
@@ -101,7 +101,7 @@ class SNRE_A(RatioEstimator):
                 sampling so that the simulator is run with parameters that are likely
                 for that `x_o`, i.e. they are sampled from the posterior obtained in the
                 previous round $p(\theta|x_o)$.
-            batch_size: Training batch size.
+            training_batch_size: Training batch size.
             learning_rate: Learning rate for Adam optimizer.
             validation_fraction: The fraction of data to use for validation.
             stop_after_epochs: The number of epochs to wait for improvement on the

--- a/sbi/inference/snre/snre_b.py
+++ b/sbi/inference/snre/snre_b.py
@@ -75,7 +75,7 @@ class SNRE_B(RatioEstimator):
         num_simulations_per_round: OneOrMore[int],
         x_o: Optional[Tensor] = None,
         num_atoms: int = 10,
-        batch_size: int = 50,
+        training_batch_size: int = 50,
         learning_rate: float = 5e-4,
         validation_fraction: float = 0.1,
         stop_after_epochs: int = 20,
@@ -102,7 +102,7 @@ class SNRE_B(RatioEstimator):
                 sampling so that the simulator is run with parameters that are likely
                 for that `x_o`, i.e. they are sampled from the posterior obtained in the
                 previous round $p(\theta|x_o)$.
-            batch_size: Training batch size.
+            training_batch_size: Training batch size.
             learning_rate: Learning rate for Adam optimizer.
             validation_fraction: The fraction of data to use for validation.
             stop_after_epochs: The number of epochs to wait for improvement on the

--- a/sbi/inference/snre/snre_b.py
+++ b/sbi/inference/snre/snre_b.py
@@ -9,7 +9,6 @@ from torch.utils.tensorboard import SummaryWriter
 from sbi.inference.posterior import NeuralPosterior
 from sbi.types import OneOrMore
 from sbi.inference.snre.snre_base import RatioEstimator
-from sbi.utils.torchutils import get_default_device
 from sbi.utils import del_entries
 
 
@@ -24,7 +23,7 @@ class SNRE_B(RatioEstimator):
         embedding_net: nn.Module = nn.Identity(),
         classifier: Union[str, nn.Module] = "resnet",
         mcmc_method: str = "slice_np",
-        device: Union[torch.device, str] = get_default_device(),
+        device: str = "cpu",
         logging_level: Union[int, str] = "warning",
         summary_writer: Optional[SummaryWriter] = None,
         show_progress_bars: bool = True,
@@ -56,7 +55,7 @@ class SNRE_B(RatioEstimator):
                 use a pre-configured neural network.
             mcmc_method: If MCMC sampling is used, specify the method here: either of
                 slice_np, slice, hmc, nuts.
-            device: torch device on which to compute, e.g. cuda, cpu.
+            device: torch device on which to compute, e.g. gpu, cpu.
             logging_level: Minimum severity of messages to log. One of the strings
                 INFO, WARNING, DEBUG, ERROR and CRITICAL.
             summary_writer: A `SummaryWriter` to control, among others, log

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -104,7 +104,7 @@ class RatioEstimator(NeuralInference, ABC):
         num_simulations_per_round: OneOrMore[int],
         x_o: Optional[Tensor] = None,
         num_atoms: int = 10,
-        batch_size: int = 50,
+        training_batch_size: int = 50,
         learning_rate: float = 5e-4,
         validation_fraction: float = 0.1,
         stop_after_epochs: int = 20,
@@ -169,7 +169,7 @@ class RatioEstimator(NeuralInference, ABC):
             self._train(
                 round_=round_,
                 num_atoms=num_atoms,
-                batch_size=batch_size,
+                training_batch_size=training_batch_size,
                 learning_rate=learning_rate,
                 validation_fraction=validation_fraction,
                 stop_after_epochs=stop_after_epochs,
@@ -199,7 +199,7 @@ class RatioEstimator(NeuralInference, ABC):
         self,
         round_: int,
         num_atoms: int,
-        batch_size: int,
+        training_batch_size: int,
         learning_rate: float,
         validation_fraction: float,
         stop_after_epochs: int,
@@ -233,7 +233,7 @@ class RatioEstimator(NeuralInference, ABC):
             permuted_indices[num_training_examples:],
         )
 
-        clipped_batch_size = min(batch_size, num_validation_examples)
+        clipped_batch_size = min(training_batch_size, num_validation_examples)
 
         # num_atoms = theta.shape[0]
         clamp_and_warn("num_atoms", num_atoms, min_val=2, max_val=clipped_batch_size)

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -282,8 +282,12 @@ class RatioEstimator(NeuralInference, ABC):
 
             # Train for a single epoch.
             self._posterior.net.train()
-            for theta_batch, x_batch in train_loader:
+            for batch in train_loader:
                 optimizer.zero_grad()
+                theta_batch, x_batch = (
+                    batch[0].to(self._device),
+                    batch[1].to(self._device),
+                )
                 loss = self._loss(theta_batch, x_batch, num_atoms)
                 loss.backward()
                 if clip_max_norm is not None:
@@ -298,7 +302,11 @@ class RatioEstimator(NeuralInference, ABC):
             self._posterior.net.eval()
             log_prob_sum = 0
             with torch.no_grad():
-                for theta_batch, x_batch in val_loader:
+                for batch in val_loader:
+                    theta_batch, x_batch = (
+                        batch[0].to(self._device),
+                        batch[1].to(self._device),
+                    )
                     log_prob = self._loss(theta_batch, x_batch, num_atoms)
                     log_prob_sum -= log_prob.sum().item()
                 self._val_log_prob = log_prob_sum / num_validation_examples

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -19,7 +19,6 @@ from sbi.utils import clamp_and_warn
 from sbi.utils import handle_invalid_x, warn_on_invalid_x
 import sbi.utils as utils
 from sbi.utils.torchutils import ensure_theta_batched, ensure_x_batched
-from sbi.utils.torchutils import get_default_device
 
 
 class RatioEstimator(NeuralInference, ABC):
@@ -33,7 +32,7 @@ class RatioEstimator(NeuralInference, ABC):
         embedding_net: nn.Module = nn.Identity(),
         classifier: Union[str, nn.Module] = "resnet",
         mcmc_method: str = "slice_np",
-        device: Union[torch.device, str] = get_default_device(),
+        device: str = "cpu",
         logging_level: Union[int, str] = "warning",
         summary_writer: Optional[SummaryWriter] = None,
         show_progress_bars: bool = True,

--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 import torch
-from torch import Tensor, float32
+from torch import Tensor, float32, device
 from torch.distributions import Independent, Uniform
 from typing import Union
 import warnings
@@ -14,8 +14,8 @@ import sbi.utils as utils
 from sbi.types import Array, OneOrMore, ScalarFloat
 
 
-def set_default_device(device: str) -> None:
-    """Set the default device to `cpu` or `gpu`."""
+def configure_default_device(device: str) -> device:
+    """Set and return the default device to cpu or gpu."""
 
     if device == "cpu":
         torch.set_default_tensor_type("torch.FloatTensor")
@@ -23,19 +23,13 @@ def set_default_device(device: str) -> None:
         warnings.warn(
             """Gpu was selected as device, the default tensor type will be set to cuda.
             Note that currently we do not expect computation speed improvements by
-            moving computation to the GPU. This is partially because the regime we are
-            working in (neural networks are not very broad, nor deep; batch sizes are
-            rather small) is not the regime we would expect GPUs to give a big speed
-            up. We are working on a better solution and recommend to use device='cpu'
-            for now."""
+            moving computation to the GPU. We are working on a better solution and
+            recommend to use device='cpu' for now."""
         )
         torch.set_default_tensor_type("torch.cuda.FloatTensor")
     else:
         raise ValueError(f"Device '{device}' not supported, use 'cpu' or 'gpu'.")
 
-
-def get_default_device():
-    """Returns default device by creating a tensor for testing."""
     return torch.ones((1,)).device
 
 

--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -8,9 +8,30 @@ import torch
 from torch import Tensor, float32
 from torch.distributions import Independent, Uniform
 from typing import Union
+import warnings
 
 import sbi.utils as utils
 from sbi.types import Array, OneOrMore, ScalarFloat
+
+
+def set_default_device(device: str) -> None:
+    """Set the default device to `cpu` or `gpu`."""
+
+    if device == "cpu":
+        torch.set_default_tensor_type("torch.FloatTensor")
+    elif device == "gpu":
+        warnings.warn(
+            """Gpu was selected as device, the default tensor type will be set to cuda.
+            Note that currently we do not expect computation speed improvements by
+            moving computation to the GPU. This is partially because the regime we are
+            working in (neural networks are not very broad, nor deep; batch sizes are
+            rather small) is not the regime we would expect GPUs to give a big speed
+            up. We are working on a better solution and recommend to use device='cpu'
+            for now."""
+        )
+        torch.set_default_tensor_type("torch.cuda.FloatTensor")
+    else:
+        raise ValueError(f"Device '{device}' not supported, use 'cpu' or 'gpu'.")
 
 
 def get_default_device():

--- a/tests/linearGaussian_snle_test.py
+++ b/tests/linearGaussian_snle_test.py
@@ -18,7 +18,7 @@ from sbi.simulators.linear_gaussian import (
     true_posterior_linear_gaussian_mvn_prior,
 )
 from tests.test_utils import check_c2st, get_prob_outside_uniform_prior
-from sbi.utils.torchutils import set_default_device
+from sbi.utils.torchutils import configure_default_device
 
 
 @pytest.mark.parametrize("num_dim", (1, 3))
@@ -61,7 +61,7 @@ def test_c2st_snl_on_linearGaussian_different_dims(set_seed):
     """
 
     device = "cpu"
-    set_default_device(device)
+    configure_default_device(device)
     theta_dim = 3
     x_dim = 2
     discard_dims = theta_dim - x_dim
@@ -98,7 +98,7 @@ def test_c2st_snl_on_linearGaussian_different_dims(set_seed):
         device=device,
     )
 
-    posterior = infer(num_rounds=1, num_simulations_per_round=4000)  # type: ignore
+    posterior = infer(num_rounds=1, num_simulations_per_round=5000)  # type: ignore
     samples = posterior.sample((num_samples,), x=x_o, thin=3)
 
     # Compute the c2st and assert it is near chance level of 0.5.

--- a/tests/linearGaussian_snle_test.py
+++ b/tests/linearGaussian_snle_test.py
@@ -18,6 +18,7 @@ from sbi.simulators.linear_gaussian import (
     true_posterior_linear_gaussian_mvn_prior,
 )
 from tests.test_utils import check_c2st, get_prob_outside_uniform_prior
+from sbi.utils.torchutils import set_default_device
 
 
 @pytest.mark.parametrize("num_dim", (1, 3))
@@ -59,6 +60,8 @@ def test_c2st_snl_on_linearGaussian_different_dims(set_seed):
         set_seed: fixture for manual seeding
     """
 
+    device = "cpu"
+    set_default_device(device)
     theta_dim = 3
     x_dim = 2
     discard_dims = theta_dim - x_dim
@@ -92,6 +95,7 @@ def test_c2st_snl_on_linearGaussian_different_dims(set_seed):
         simulation_batch_size=50,
         mcmc_method="slice_np",
         show_progress_bars=False,
+        device=device,
     )
 
     posterior = infer(num_rounds=1, num_simulations_per_round=4000)  # type: ignore

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -2,7 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 from __future__ import annotations
-from sbi.utils.torchutils import set_default_device
+from sbi.utils.torchutils import configure_default_device
 
 import pytest
 from torch import eye, ones, zeros
@@ -37,7 +37,7 @@ def test_c2st_snpe_on_linearGaussian(
     """
 
     device = "cpu"
-    set_default_device(device)
+    configure_default_device(device)
     x_o = zeros(1, num_dim)
     num_samples = 1000
 

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -71,7 +71,7 @@ def test_c2st_snpe_on_linearGaussian(
     )
 
     posterior = infer(
-        num_rounds=1, num_simulations_per_round=2000, batch_size=100
+        num_rounds=1, num_simulations_per_round=2000, training_batch_size=100
     ).set_default_x(x_o)
     samples = posterior.sample((num_samples,))
 

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -2,9 +2,9 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 from __future__ import annotations
+from sbi.utils.torchutils import set_default_device
 
 import pytest
-import torch
 from torch import eye, ones, zeros
 from torch.distributions import MultivariateNormal
 
@@ -36,6 +36,8 @@ def test_c2st_snpe_on_linearGaussian(
         set_seed: fixture for manual seeding
     """
 
+    device = "cpu"
+    set_default_device(device)
     x_o = zeros(1, num_dim)
     num_samples = 1000
 
@@ -62,12 +64,15 @@ def test_c2st_snpe_on_linearGaussian(
 
     infer = SNPE_C(
         *prepare_for_sbi(simulator, prior),
-        simulation_batch_size=10,
+        simulation_batch_size=1000,
         show_progress_bars=False,
         sample_with_mcmc=False,
+        device=device,
     )
 
-    posterior = infer(num_rounds=1, num_simulations_per_round=2000).set_default_x(x_o)
+    posterior = infer(
+        num_rounds=1, num_simulations_per_round=2000, batch_size=100
+    ).set_default_x(x_o)
     samples = posterior.sample((num_samples,))
 
     # Compute the c2st and assert it is near chance level of 0.5.

--- a/tests/linearGaussian_snre_test.py
+++ b/tests/linearGaussian_snre_test.py
@@ -22,7 +22,7 @@ from tests.test_utils import (
     get_dkl_gaussian_prior,
     get_prob_outside_uniform_prior,
 )
-from sbi.utils.torchutils import set_default_device
+from sbi.utils.torchutils import configure_default_device
 
 
 @pytest.mark.parametrize("num_dim", (1, 3))
@@ -62,7 +62,7 @@ def test_c2st_sre_on_linearGaussian_different_dims(set_seed):
     """
 
     device = "cpu"
-    set_default_device(device)
+    configure_default_device(device)
     theta_dim = 3
     x_dim = 2
     discard_dims = theta_dim - x_dim

--- a/tests/linearGaussian_snre_test.py
+++ b/tests/linearGaussian_snre_test.py
@@ -22,6 +22,7 @@ from tests.test_utils import (
     get_dkl_gaussian_prior,
     get_prob_outside_uniform_prior,
 )
+from sbi.utils.torchutils import set_default_device
 
 
 @pytest.mark.parametrize("num_dim", (1, 3))
@@ -60,6 +61,8 @@ def test_c2st_sre_on_linearGaussian_different_dims(set_seed):
         set_seed: fixture for manual seeding
     """
 
+    device = "cpu"
+    set_default_device(device)
     theta_dim = 3
     x_dim = 2
     discard_dims = theta_dim - x_dim
@@ -95,9 +98,10 @@ def test_c2st_sre_on_linearGaussian_different_dims(set_seed):
         classifier="resnet",
         simulation_batch_size=50,
         show_progress_bars=False,
+        device=device,
     )
 
-    posterior = infer(num_rounds=1, num_simulations_per_round=1000)
+    posterior = infer(num_rounds=1, num_simulations_per_round=5000)
     samples = posterior.sample((num_samples,), x=x_o, thin=3)
 
     # Compute the c2st and assert it is near chance level of 0.5.


### PR DESCRIPTION
- accept only string "cpu" or "gpu" as device `kwarg`, "cpu" as default.
- depending of device string set device globally via torch default tensor type
- raise warning when "gpu" is used.
- rename `batch_size` in train methdos to `training_batch_size` to avoid confusion with `simulation_batch_size` and `batch_size` used in more general contexts.
- add missing usage of `device` in `SNRE`

closes #251 
relates to #257 