### PR TITLE
Z-scoring for all algorithms, refactor neural network creation

### DIFF
--- a/docs/docs/tutorial/markdown_files/03_flexible_interface.md
+++ b/docs/docs/tutorial/markdown_files/03_flexible_interface.md
@@ -47,12 +47,11 @@ In the advanced mode, you have to ensure that your simulator and prior adhere th
 simulator, prior, x_shape = prepare_for_sbi(linear_gaussian, prior)
 ```
 
-You can then use the `prior` and `x_shape` object to specify a custom density estimator. Since we use S*N*PE, we specifiy a neural network targeting the *posterior* (hence the call to `posterior_nn()`). In this example, we will create a neural spline flow (`'nsf'`) with `60` hidden units and `3` transform layers:
+You can specify a custom density estimator. Since we use S*N*PE, we specifiy a neural network targeting the *posterior* (hence the call to `posterior_nn()`). In this example, we will create a neural spline flow (`'nsf'`) with `60` hidden units and `3` transform layers:
 
 
 ```python
-my_density_estimator = posterior_nn('nsf', prior, x_shape, hidden_features=60, 
-                                    flow_num_transforms=3)
+my_density_estimator = posterior_nn('nsf', hidden_features=60, num_transforms=3)
 ```
 
 We will use `SNPE` with a `simulation_batch_size=10`, i.e. `10` simulations will be passed to the simulator which will then handle the simulations in a vectorized way (note that your simulator has to support this in order to use this feature):

--- a/docs/docs/tutorial/notebooks/03_flexible_interface.ipynb
+++ b/docs/docs/tutorial/notebooks/03_flexible_interface.ipynb
@@ -94,7 +94,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can then use the `prior` and `x_shape` object to specify a custom density estimator. Since we use S*N*PE, we specifiy a neural network targeting the *posterior* (hence the call to `posterior_nn()`). In this example, we will create a neural spline flow (`'nsf'`) with `60` hidden units and `3` transform layers:"
+    "You can specify a custom density estimator. Since we use S*N*PE, we specifiy a neural network targeting the *posterior* (hence the call to `posterior_nn()`). In this example, we will create a neural spline flow (`'nsf'`) with `60` hidden units and `3` transform layers:"
    ]
   },
   {
@@ -103,8 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "my_density_estimator = posterior_nn('nsf', prior, x_shape, hidden_features=60, \n",
-    "                                    flow_num_transforms=3)"
+    "my_density_estimator = posterior_nn('nsf', hidden_features=60, num_transforms=3)"
    ]
   },
   {

--- a/sbi/inference/posterior.py
+++ b/sbi/inference/posterior.py
@@ -243,7 +243,7 @@ class NeuralPosterior:
             )
         return self._log_prob_ratio_estimator(theta, x)
 
-    def _log_prob_snle_a(self, theta: Tensor, x: Tensor) -> Tensor:
+    def _log_prob_snle(self, theta: Tensor, x: Tensor) -> Tensor:
         warn(
             "The log probability from SNL is only correct up to a normalizing constant."
         )

--- a/sbi/inference/posterior.py
+++ b/sbi/inference/posterior.py
@@ -83,7 +83,7 @@ class NeuralPosterior:
         self._get_potential_function = get_potential_function
         self._x_shape = x_shape
 
-        if method_family in ("snpe", "snle_a", "snre_a", "snre_b"):
+        if method_family in ("snpe", "snle", "snre_a", "snre_b"):
             self._method_family = method_family
         else:
             raise ValueError("Method family unsupported.")

--- a/sbi/inference/snle/snle_a.py
+++ b/sbi/inference/snle/snle_a.py
@@ -60,7 +60,7 @@ class SNLE_A(LikelihoodEstimator):
                 needs to return a PyTorch `nn.Module` implementing the density
                 estimator. The density estimator needs to provide the methods
                 `.log_prob` and `.sample()`.
-            mcmc_method: Specify the method for MCMC sampling, either either of:
+            mcmc_method: Specify the method for MCMC sampling, either of:
                 slice_np, slice, hmc, nuts.
             device: torch device on which to compute, e.g. gpu, cpu.
             logging_level: Minimum severity of messages to log. One of the strings

--- a/sbi/inference/snle/snle_a.py
+++ b/sbi/inference/snle/snle_a.py
@@ -2,10 +2,11 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 from __future__ import annotations
+
 from typing import Callable, Optional, Union
 
 import torch
-from torch import Tensor, nn
+from torch import Tensor
 from torch.utils.tensorboard import SummaryWriter
 
 from sbi.inference.posterior import NeuralPosterior
@@ -22,7 +23,7 @@ class SNLE_A(LikelihoodEstimator):
         x_shape: Optional[torch.Size] = None,
         num_workers: int = 1,
         simulation_batch_size: int = 1,
-        density_estimator: Union[str, nn.Module] = "maf",
+        density_estimator: Union[str, Callable] = "maf",
         mcmc_method: str = "slice_np",
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
@@ -51,10 +52,15 @@ class SNLE_A(LikelihoodEstimator):
                 maps to data x at once. If None, we simulate all parameter sets at the
                 same time. If >= 1, the simulator has to process data of shape
                 (simulation_batch_size, parameter_dimension).
-            density_estimator: Either a string or a density estimation neural network
-                that can `.log_prob()` and `.sample()`. If it is a string, use a pre-
-                configured network of the provided type (one of nsf, maf, mdn, made).
-            mcmc_method: If MCMC sampling is used, specify the method here: either of
+            density_estimator: If it is a string, use a pre-configured network of the
+                provided type (one of nsf, maf, mdn, made). Alternatively, a function
+                that builds a custom neural network can be provided. The function will
+                be called with the first batch of simulations (theta, x), which can
+                thus be used for shape inference and potentially for z-scoring. It
+                needs to return a PyTorch `nn.Module` implementing the density
+                estimator. The density estimator needs to provide the methods
+                `.log_prob` and `.sample()`.
+            mcmc_method: Specify the method for MCMC sampling, either either of:
                 slice_np, slice, hmc, nuts.
             device: torch device on which to compute, e.g. gpu, cpu.
             logging_level: Minimum severity of messages to log. One of the strings

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -48,7 +48,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
                 needs to return a PyTorch `nn.Module` implementing the density
                 estimator. The density estimator needs to provide the methods
                 `.log_prob` and `.sample()`.
-            mcmc_method: Specify the method for MCMC sampling, either either of:
+            mcmc_method: Specify the method for MCMC sampling, either of:
                 slice_np, slice, hmc, nuts.
 
         See docstring of `NeuralInference` class for all other arguments.
@@ -67,7 +67,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
             show_round_summary=show_round_summary,
         )
 
-        # As detailed in the docstring, density estimator is either a string or
+        # As detailed in the docstring, `density_estimator` is either a string or
         # a callable. The function creating the neural network is attached to
         # `_build_neural_net`. It will be called in the first round and receive
         # thetas and xs as inputs, so that they can be used for shape inference and
@@ -147,7 +147,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
                     mcmc_method=self._mcmc_method,
                     get_potential_function=PotentialFunctionProvider(),
                 )
-                self._handle_x_o_wrt_amortization(x_o, num_rounds)
+            self._handle_x_o_wrt_amortization(x_o, num_rounds)
 
             # Check for NaNs in simulations.
             is_valid_x, num_nans, num_infs = handle_invalid_x(x, exclude_invalid_x)

--- a/sbi/inference/snpe/snpe_a.py
+++ b/sbi/inference/snpe/snpe_a.py
@@ -2,6 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 from __future__ import annotations
+
 from typing import Callable, Optional, Union
 
 import torch
@@ -19,10 +20,8 @@ class SNPE_A(PosteriorEstimator):
         x_shape: Optional[torch.Size] = None,
         num_workers: int = 1,
         simulation_batch_size: int = 1,
-        density_estimator: Union[str, nn.Module] = "mdn",
+        density_estimator: Union[str, Callable] = "mdn",
         calibration_kernel: Optional[Callable] = None,
-        z_score_x: bool = True,
-        z_score_min_std: float = 1e-7,
         exclude_invalid_x: bool = True,
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",

--- a/sbi/inference/snpe/snpe_b.py
+++ b/sbi/inference/snpe/snpe_b.py
@@ -2,6 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 from __future__ import annotations
+
 from typing import Callable, Optional, Union
 
 import torch
@@ -19,9 +20,7 @@ class SNPE_B(PosteriorEstimator):
         x_shape: Optional[torch.Size] = None,
         num_workers: int = 1,
         simulation_batch_size: Optional[int] = 1,
-        density_estimator: Union[str, nn.Module] = "mdn",
-        z_score_x: bool = True,
-        z_score_min_std: float = 1e-7,
+        density_estimator: Union[str, Callable] = "mdn",
         calibration_kernel: Optional[Callable] = None,
         retrain_from_scratch_each_round: bool = False,
         discard_prior_samples: bool = False,
@@ -51,8 +50,6 @@ class SNPE_B(PosteriorEstimator):
             num_workers=num_workers,
             simulation_batch_size=simulation_batch_size,
             density_estimator=density_estimator,
-            z_score_x=z_score_x,
-            z_score_min_std=z_score_min_std,
             calibration_kernel=calibration_kernel,
             retrain_from_scratch_each_round=retrain_from_scratch_each_round,
             discard_prior_samples=discard_prior_samples,

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -72,7 +72,7 @@ class PosteriorEstimator(NeuralInference, ABC):
             show_round_summary=show_round_summary,
         )
 
-        # As detailed in the docstring, density estimator is either a string or
+        # As detailed in the docstring, `density_estimator` is either a string or
         # a callable. The function creating the neural network is attached to
         # `_build_neural_net`. It will be called in the first round and receive
         # thetas and xs as inputs, so that they can be used for shape inference and
@@ -177,7 +177,7 @@ class PosteriorEstimator(NeuralInference, ABC):
                     mcmc_method=self._mcmc_method,
                     get_potential_function=PotentialFunctionProvider(),
                 )
-                self._handle_x_o_wrt_amortization(x_o, num_rounds)
+            self._handle_x_o_wrt_amortization(x_o, num_rounds)
 
             # Check for NaNs in simulations.
             is_valid_x, num_nans, num_infs = handle_invalid_x(x, exclude_invalid_x)

--- a/sbi/inference/snre/snre_a.py
+++ b/sbi/inference/snre/snre_a.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-from typing import Optional, Callable, Union
-from sbi.types import OneOrMore
+from typing import Callable, Optional, Union
 
 import torch
-from torch import nn, ones, Tensor
+from torch import Tensor, nn, ones
 from torch.utils.tensorboard import SummaryWriter
 
 from sbi.inference.posterior import NeuralPosterior
 from sbi.inference.snre.snre_base import RatioEstimator
+from sbi.types import OneOrMore
 from sbi.utils import del_entries
 
 
@@ -20,8 +20,7 @@ class SNRE_A(RatioEstimator):
         x_shape: Optional[torch.Size] = None,
         num_workers: int = 1,
         simulation_batch_size: int = 1,
-        embedding_net: nn.Module = nn.Identity(),
-        classifier: Union[str, nn.Module] = "resnet",
+        classifier: Union[str, Callable] = "resnet",
         mcmc_method: str = "slice_np",
         device: str = "cpu",
         logging_level: Union[int, str] = "warning",
@@ -49,11 +48,14 @@ class SNRE_A(RatioEstimator):
                 maps to data x at once. If None, we simulate all parameter sets at the
                 same time. If >= 1, the simulator has to process data of shape
                 (simulation_batch_size, parameter_dimension).
-            embedding_net: Can be used to encode observations $x$. Currently not
-                implemented.
-            classifier: Classifier trained to approximate likelihood rations. If str,
-                use a pre-configured neural network.
-            mcmc_method: If MCMC sampling is used, specify the method here: either of
+            classifier: Classifier trained to approximate likelihood rations. If it is
+                a string, use a pre-configured network of the provided type (one of
+                linear, mlp, resnet). Alternatively, a function that builds a custom
+                neural network can be provided. The function will be called with the
+                first batch of simulations (theta, x), which can thus be used for shape
+                inference and potentially for z-scoring. It needs to return a PyTorch
+                `nn.Module` implementing the classifier.
+            mcmc_method: Specify the method for MCMC sampling, either either of:
                 slice_np, slice, hmc, nuts.
             device: torch device on which to compute, e.g. gpu, cpu.
             logging_level: Minimum severity of messages to log. One of the strings

--- a/sbi/inference/snre/snre_a.py
+++ b/sbi/inference/snre/snre_a.py
@@ -48,14 +48,14 @@ class SNRE_A(RatioEstimator):
                 maps to data x at once. If None, we simulate all parameter sets at the
                 same time. If >= 1, the simulator has to process data of shape
                 (simulation_batch_size, parameter_dimension).
-            classifier: Classifier trained to approximate likelihood rations. If it is
+            classifier: Classifier trained to approximate likelihood ratios. If it is
                 a string, use a pre-configured network of the provided type (one of
                 linear, mlp, resnet). Alternatively, a function that builds a custom
                 neural network can be provided. The function will be called with the
                 first batch of simulations (theta, x), which can thus be used for shape
                 inference and potentially for z-scoring. It needs to return a PyTorch
                 `nn.Module` implementing the classifier.
-            mcmc_method: Specify the method for MCMC sampling, either either of:
+            mcmc_method: Specify the method for MCMC sampling, either of:
                 slice_np, slice, hmc, nuts.
             device: torch device on which to compute, e.g. gpu, cpu.
             logging_level: Minimum severity of messages to log. One of the strings

--- a/sbi/inference/snre/snre_b.py
+++ b/sbi/inference/snre/snre_b.py
@@ -48,14 +48,14 @@ class SNRE_B(RatioEstimator):
                 maps to data x at once. If None, we simulate all parameter sets at the
                 same time. If >= 1, the simulator has to process data of shape
                 (simulation_batch_size, parameter_dimension).
-            classifier: Classifier trained to approximate likelihood rations. If it is
+            classifier: Classifier trained to approximate likelihood ratios. If it is
                 a string, use a pre-configured network of the provided type (one of
                 linear, mlp, resnet). Alternatively, a function that builds a custom
                 neural network can be provided. The function will be called with the
                 first batch of simulations (theta, x), which can thus be used for shape
                 inference and potentially for z-scoring. It needs to return a PyTorch
                 `nn.Module` implementing the classifier.
-            mcmc_method: Specify the method for MCMC sampling, either either of:
+            mcmc_method: Specify the method for MCMC sampling, either of:
                 slice_np, slice, hmc, nuts.
             device: torch device on which to compute, e.g. gpu, cpu.
             logging_level: Minimum severity of messages to log. One of the strings

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -50,14 +50,14 @@ class RatioEstimator(NeuralInference, ABC):
           even when training only one round.
 
         Args:
-            classifier: Classifier trained to approximate likelihood rations. If it is
+            classifier: Classifier trained to approximate likelihood ratios. If it is
                 a string, use a pre-configured network of the provided type (one of
                 linear, mlp, resnet). Alternatively, a function that builds a custom
                 neural network can be provided. The function will be called with the
                 first batch of simulations (theta, x), which can thus be used for shape
                 inference and potentially for z-scoring. It needs to return a PyTorch
                 `nn.Module` implementing the classifier.
-            mcmc_method: Specify the method for MCMC sampling, either either of:
+            mcmc_method: Specify the method for MCMC sampling, either of:
                 slice_np, slice, hmc, nuts.
 
         See docstring of `NeuralInference` class for all other arguments.
@@ -76,7 +76,7 @@ class RatioEstimator(NeuralInference, ABC):
             show_round_summary=show_round_summary,
         )
 
-        # As detailed in the docstring, density estimator is either a string or
+        # As detailed in the docstring, `density_estimator` is either a string or
         # a callable. The function creating the neural network is attached to
         # `_build_neural_net`. It will be called in the first round and receive
         # thetas and xs as inputs, so that they can be used for shape inference and
@@ -158,7 +158,7 @@ class RatioEstimator(NeuralInference, ABC):
                     mcmc_method=self._mcmc_method,
                     get_potential_function=PotentialFunctionProvider(),
                 )
-                self._handle_x_o_wrt_amortization(x_o, num_rounds)
+            self._handle_x_o_wrt_amortization(x_o, num_rounds)
 
             # Check for NaNs in simulations.
             is_valid_x, num_nans, num_infs = handle_invalid_x(x, exclude_invalid_x)

--- a/sbi/neural_nets/classifier.py
+++ b/sbi/neural_nets/classifier.py
@@ -16,7 +16,9 @@ def build_input_layer(
     z_score_x: bool = True,
     z_score_y: bool = True,
 ) -> nn.Module:
-    """Builds input layer for classifers that optionally z-scores
+    """Builds input layer for classifiers that optionally z-scores
+
+    In SNRE, the classifier will receive batches of thetas and xs.
 
     Args:
         batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring
@@ -39,25 +41,26 @@ def build_input_layer(
         embedding_net_y = nn.Identity()
 
     class StandardizeInputs(nn.Module):
-        def __init__(self, embedding_net_x, embedding_net_y):
+        def __init__(self, embedding_net_x, embedding_net_y, dim_x, dim_y):
             super().__init__()
             self.embedding_net_x = embedding_net_x
             self.embedding_net_y = embedding_net_y
+            self.dim_x = dim_x
+            self.dim_y = dim_y
 
         def forward(self, t):
-            numel = t[0].numel()
             out = torch.cat(
                 [
-                    self.embedding_net_x(t[:, : numel // 2]),
-                    self.embedding_net_y(t[:, numel // 2 :]),
+                    self.embedding_net_x(t[:, : self.dim_x]),
+                    self.embedding_net_y(t[:, self.dim_x : self.dim_x + self.dim_y]),
                 ],
                 dim=1,
             )
             return out
 
-    input_layer = StandardizeInputs(embedding_net_x, embedding_net_y)
-
-    # xxx
+    input_layer = StandardizeInputs(
+        embedding_net_x, embedding_net_y, dim_x=batch_x.shape[1], dim_y=batch_y.shape[1]
+    )
 
     return input_layer
 
@@ -68,7 +71,9 @@ def build_linear_classifier(
     z_score_x: bool = True,
     z_score_y: bool = True,
 ) -> nn.Module:
-    """Builds linear classifier for SNRE
+    """Builds linear classifier
+
+    In SNRE, the classifier will receive batches of thetas and xs.
 
     Args:
         batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring
@@ -98,7 +103,9 @@ def build_mlp_classifier(
     z_score_y: bool = True,
     hidden_features: int = 50,
 ) -> nn.Module:
-    """Builds MLP classifier for SNRE
+    """Builds MLP classifier
+
+    In SNRE, the classifier will receive batches of thetas and xs.
 
     Args:
         batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring
@@ -137,7 +144,9 @@ def build_resnet_classifier(
     z_score_y: bool = True,
     hidden_features: int = 50,
 ) -> nn.Module:
-    """Builds ResNet classifier for SNRE
+    """Builds ResNet classifier
+
+    In SNRE, the classifier will receive batches of thetas and xs.
 
     Args:
         batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring

--- a/sbi/neural_nets/classifier.py
+++ b/sbi/neural_nets/classifier.py
@@ -1,0 +1,170 @@
+# This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
+# under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+import torch
+from pyknos.nflows.nn import nets
+from torch import Tensor, nn, relu
+
+from sbi.utils.sbiutils import standardizing_net
+
+
+def build_input_layer(
+    batch_x: Tensor = None,
+    batch_y: Tensor = None,
+    z_score_x: bool = True,
+    z_score_y: bool = True,
+) -> nn.Module:
+    """Builds input layer for classifers that optionally z-scores
+
+    Args:
+        batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring
+        batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring
+        z_score_x: Whether to z-score xs passing into the network
+        z_score_y: Whether to z-score ys passing into the network
+        hidden_features: Number of hidden features
+
+    Returns:
+        Input layer that optionally z-scores
+    """
+    if z_score_x:
+        embedding_net_x = standardizing_net(batch_x)
+    else:
+        embedding_net_x = nn.Identity()
+
+    if z_score_y:
+        embedding_net_y = standardizing_net(batch_y)
+    else:
+        embedding_net_y = nn.Identity()
+
+    class StandardizeInputs(nn.Module):
+        def __init__(self, embedding_net_x, embedding_net_y):
+            super().__init__()
+            self.embedding_net_x = embedding_net_x
+            self.embedding_net_y = embedding_net_y
+
+        def forward(self, t):
+            numel = t[0].numel()
+            out = torch.cat(
+                [
+                    self.embedding_net_x(t[:, : numel // 2]),
+                    self.embedding_net_y(t[:, numel // 2 :]),
+                ],
+                dim=1,
+            )
+            return out
+
+    input_layer = StandardizeInputs(embedding_net_x, embedding_net_y)
+
+    # xxx
+
+    return input_layer
+
+
+def build_linear_classifier(
+    batch_x: Tensor = None,
+    batch_y: Tensor = None,
+    z_score_x: bool = True,
+    z_score_y: bool = True,
+) -> nn.Module:
+    """Builds linear classifier for SNRE
+
+    Args:
+        batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring
+        batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring
+        z_score_x: Whether to z-score xs passing into the network
+        z_score_y: Whether to z-score ys passing into the network
+
+    Returns:
+        Neural network
+    """
+    x_numel = batch_x[0].numel()
+    y_numel = batch_y[0].numel()
+
+    neural_net = nn.Linear(x_numel + y_numel, 1)
+
+    input_layer = build_input_layer(batch_x, batch_y, z_score_x, z_score_y)
+
+    neural_net = nn.Sequential(input_layer, neural_net)
+
+    return neural_net
+
+
+def build_mlp_classifier(
+    batch_x: Tensor = None,
+    batch_y: Tensor = None,
+    z_score_x: bool = True,
+    z_score_y: bool = True,
+    hidden_features: int = 50,
+) -> nn.Module:
+    """Builds MLP classifier for SNRE
+
+    Args:
+        batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring
+        batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring
+        z_score_x: Whether to z-score xs passing into the network
+        z_score_y: Whether to z-score ys passing into the network
+        hidden_features: Number of hidden features
+
+    Returns:
+        Neural network
+    """
+    x_numel = batch_x[0].numel()
+    y_numel = batch_y[0].numel()
+
+    neural_net = nn.Sequential(
+        nn.Linear(x_numel + y_numel, hidden_features),
+        nn.BatchNorm1d(hidden_features),
+        nn.ReLU(),
+        nn.Linear(hidden_features, hidden_features),
+        nn.BatchNorm1d(hidden_features),
+        nn.ReLU(),
+        nn.Linear(hidden_features, 1),
+    )
+
+    input_layer = build_input_layer(batch_x, batch_y, z_score_x, z_score_y)
+
+    neural_net = nn.Sequential(input_layer, neural_net)
+
+    return neural_net
+
+
+def build_resnet_classifier(
+    batch_x: Tensor = None,
+    batch_y: Tensor = None,
+    z_score_x: bool = True,
+    z_score_y: bool = True,
+    hidden_features: int = 50,
+) -> nn.Module:
+    """Builds ResNet classifier for SNRE
+
+    Args:
+        batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring
+        batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring
+        z_score_x: Whether to z-score xs passing into the network
+        z_score_y: Whether to z-score ys passing into the network
+        hidden_features: Number of hidden features
+
+    Returns:
+        Neural network
+    """
+    x_numel = batch_x[0].numel()
+    y_numel = batch_y[0].numel()
+
+    neural_net = nets.ResidualNet(
+        in_features=x_numel + y_numel,
+        out_features=1,
+        hidden_features=hidden_features,
+        context_features=None,
+        num_blocks=2,
+        activation=relu,
+        dropout_probability=0.0,
+        use_batch_norm=False,
+    )
+
+    input_layer = build_input_layer(batch_x, batch_y, z_score_x, z_score_y)
+
+    neural_net = nn.Sequential(input_layer, neural_net)
+
+    return neural_net

--- a/sbi/neural_nets/flow.py
+++ b/sbi/neural_nets/flow.py
@@ -1,0 +1,209 @@
+# This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
+# under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from warnings import warn
+
+from pyknos.nflows import distributions as distributions_
+from pyknos.nflows import flows, transforms
+from pyknos.nflows.nn import nets
+from torch import Tensor, nn, relu, tanh
+
+from sbi.utils.sbiutils import standardizing_net, standardizing_transform
+from sbi.utils.torchutils import create_alternating_binary_mask
+
+
+def build_made(
+    batch_x: Tensor = None,
+    batch_y: Tensor = None,
+    z_score_x: bool = True,
+    z_score_y: bool = True,
+    hidden_features: int = 50,
+    num_blocks: int = 5,
+    num_mixture_components: int = 10,
+) -> nn.Module:
+    """Builds MADE p(x|y)
+
+    Args:
+        batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring
+        batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring
+        z_score_x: Whether to z-score xs passing into the network
+        z_score_y: Whether to z-score ys passing into the network
+        hidden_features: Number of hidden features
+        num_blocks: Number of MADE blocks
+        num_mixture_components: Number of mixture components
+
+    Returns:
+        Neural network
+    """
+    x_numel = batch_x[0].numel()
+    y_numel = batch_y[0].numel()
+
+    if x_numel == 1:
+        warn(f"In one-dimensional output space, this flow is limited to Gaussians")
+
+    transform = transforms.IdentityTransform()
+    distribution = distributions_.MADEMoG(
+        features=x_numel,
+        hidden_features=hidden_features,
+        context_features=y_numel,
+        num_blocks=num_blocks,
+        num_mixture_components=num_mixture_components,
+        use_residual_blocks=True,
+        random_mask=False,
+        activation=relu,
+        dropout_probability=0.0,
+        use_batch_norm=False,
+        custom_initialization=True,
+    )
+
+    if z_score_x:
+        transform_zx = standardizing_transform(batch_x)
+        transform = transforms.CompositeTransform([transform_zx, transform])
+
+    if z_score_y:
+        embedding_net = standardizing_net(batch_y)
+    else:
+        embedding_net = nn.Identity()
+
+    distribution = distributions_.StandardNormal((x_numel,))
+    neural_net = flows.Flow(transform, distribution, embedding_net)
+
+    return neural_net
+
+
+def build_maf(
+    batch_x: Tensor = None,
+    batch_y: Tensor = None,
+    z_score_x: bool = True,
+    z_score_y: bool = True,
+    hidden_features: int = 50,
+    num_transforms: int = 5,
+) -> nn.Module:
+    """Builds MAF p(x|y)
+
+    Args:
+        batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring
+        batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring
+        z_score_x: Whether to z-score xs passing into the network
+        z_score_y: Whether to z-score ys passing into the network
+        hidden_features: Number of hidden features
+        num_transforms: Number of transforms
+
+    Returns:
+        Neural network
+    """
+    x_numel = batch_x[0].numel()
+    y_numel = batch_y[0].numel()
+
+    if x_numel == 1:
+        warn(f"In one-dimensional output space, this flow is limited to Gaussians")
+
+    transform = transforms.CompositeTransform(
+        [
+            transforms.CompositeTransform(
+                [
+                    transforms.MaskedAffineAutoregressiveTransform(
+                        features=x_numel,
+                        hidden_features=hidden_features,
+                        context_features=y_numel,
+                        num_blocks=2,
+                        use_residual_blocks=False,
+                        random_mask=False,
+                        activation=tanh,
+                        dropout_probability=0.0,
+                        use_batch_norm=True,
+                    ),
+                    transforms.RandomPermutation(features=x_numel),
+                ]
+            )
+            for _ in range(num_transforms)
+        ]
+    )
+
+    if z_score_x:
+        transform_zx = standardizing_transform(batch_x)
+        transform = transforms.CompositeTransform([transform_zx, transform])
+
+    if z_score_y:
+        embedding_net = standardizing_net(batch_y)
+    else:
+        embedding_net = nn.Identity()
+
+    distribution = distributions_.StandardNormal((x_numel,))
+    neural_net = flows.Flow(transform, distribution, embedding_net)
+
+    return neural_net
+
+
+def build_nsf(
+    batch_x: Tensor = None,
+    batch_y: Tensor = None,
+    z_score_x: bool = True,
+    z_score_y: bool = True,
+    hidden_features: int = 50,
+    num_transforms: int = 5,
+) -> nn.Module:
+    """Builds NSF p(x|y)
+
+    Args:
+        batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring
+        batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring
+        z_score_x: Whether to z-score xs passing into the network
+        z_score_y: Whether to z-score ys passing into the network
+        hidden_features: Number of hidden features
+        num_transforms: Number of transforms
+
+    Returns:
+        Neural network
+    """
+    x_numel = batch_x[0].numel()
+    y_numel = batch_y[0].numel()
+
+    if x_numel == 1:
+        raise NotImplementedError
+
+    transform = transforms.CompositeTransform(
+        [
+            transforms.CompositeTransform(
+                [
+                    transforms.PiecewiseRationalQuadraticCouplingTransform(
+                        mask=create_alternating_binary_mask(
+                            features=x_numel, even=(i % 2 == 0)
+                        ),
+                        transform_net_create_fn=lambda in_features, out_features: nets.ResidualNet(
+                            in_features=in_features,
+                            out_features=out_features,
+                            hidden_features=hidden_features,
+                            context_features=y_numel,
+                            num_blocks=2,
+                            activation=relu,
+                            dropout_probability=0.0,
+                            use_batch_norm=False,
+                        ),
+                        num_bins=10,
+                        tails="linear",
+                        tail_bound=3.0,
+                        apply_unconditional_transform=False,
+                    ),
+                    transforms.LULinear(x_numel, identity_init=True),
+                ]
+            )
+            for i in range(num_transforms)
+        ]
+    )
+
+    if z_score_x:
+        transform_zx = standardizing_transform(batch_x)
+        transform = transforms.CompositeTransform([transform_zx, transform])
+
+    if z_score_y:
+        embedding_net = standardizing_net(batch_y)
+    else:
+        embedding_net = nn.Identity()
+
+    distribution = distributions_.StandardNormal((x_numel,))
+    neural_net = flows.Flow(transform, distribution, embedding_net)
+
+    return neural_net

--- a/sbi/neural_nets/flow.py
+++ b/sbi/neural_nets/flow.py
@@ -22,20 +22,22 @@ def build_made(
     hidden_features: int = 50,
     num_blocks: int = 5,
     num_mixture_components: int = 10,
+    embedding_net: nn.Module = nn.Identity(),
 ) -> nn.Module:
-    """Builds MADE p(x|y)
+    """Builds MADE p(x|y).
 
     Args:
-        batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring
-        batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring
-        z_score_x: Whether to z-score xs passing into the network
-        z_score_y: Whether to z-score ys passing into the network
-        hidden_features: Number of hidden features
-        num_blocks: Number of MADE blocks
-        num_mixture_components: Number of mixture components
+        batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring.
+        batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring.
+        z_score_x: Whether to z-score xs passing into the network.
+        z_score_y: Whether to z-score ys passing into the network.
+        hidden_features: Number of hidden features.
+        num_blocks: Number of MADE blocks.
+        num_mixture_components: Number of mixture components.
+        embedding_net: Optional embedding network for y.
 
     Returns:
-        Neural network
+        Neural network.
     """
     x_numel = batch_x[0].numel()
     y_numel = batch_y[0].numel()
@@ -63,9 +65,7 @@ def build_made(
         transform = transforms.CompositeTransform([transform_zx, transform])
 
     if z_score_y:
-        embedding_net = standardizing_net(batch_y)
-    else:
-        embedding_net = nn.Identity()
+        embedding_net = nn.Sequential(standardizing_net(batch_y), embedding_net)
 
     distribution = distributions_.StandardNormal((x_numel,))
     neural_net = flows.Flow(transform, distribution, embedding_net)
@@ -80,19 +80,21 @@ def build_maf(
     z_score_y: bool = True,
     hidden_features: int = 50,
     num_transforms: int = 5,
+    embedding_net: nn.Module = nn.Identity(),
 ) -> nn.Module:
-    """Builds MAF p(x|y)
+    """Builds MAF p(x|y).
 
     Args:
-        batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring
-        batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring
-        z_score_x: Whether to z-score xs passing into the network
-        z_score_y: Whether to z-score ys passing into the network
-        hidden_features: Number of hidden features
-        num_transforms: Number of transforms
+        batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring.
+        batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring.
+        z_score_x: Whether to z-score xs passing into the network.
+        z_score_y: Whether to z-score ys passing into the network.
+        hidden_features: Number of hidden features.
+        num_transforms: Number of transforms.
+        embedding_net: Optional embedding network for y.
 
     Returns:
-        Neural network
+        Neural network.
     """
     x_numel = batch_x[0].numel()
     y_numel = batch_y[0].numel()
@@ -127,9 +129,7 @@ def build_maf(
         transform = transforms.CompositeTransform([transform_zx, transform])
 
     if z_score_y:
-        embedding_net = standardizing_net(batch_y)
-    else:
-        embedding_net = nn.Identity()
+        embedding_net = nn.Sequential(standardizing_net(batch_y), embedding_net)
 
     distribution = distributions_.StandardNormal((x_numel,))
     neural_net = flows.Flow(transform, distribution, embedding_net)
@@ -144,19 +144,21 @@ def build_nsf(
     z_score_y: bool = True,
     hidden_features: int = 50,
     num_transforms: int = 5,
+    embedding_net: nn.Module = nn.Identity(),
 ) -> nn.Module:
-    """Builds NSF p(x|y)
+    """Builds NSF p(x|y).
 
     Args:
-        batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring
-        batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring
-        z_score_x: Whether to z-score xs passing into the network
-        z_score_y: Whether to z-score ys passing into the network
-        hidden_features: Number of hidden features
-        num_transforms: Number of transforms
+        batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring.
+        batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring.
+        z_score_x: Whether to z-score xs passing into the network.
+        z_score_y: Whether to z-score ys passing into the network.
+        hidden_features: Number of hidden features.
+        num_transforms: Number of transforms.
+        embedding_net: Optional embedding network for y.
 
     Returns:
-        Neural network
+        Neural network.
     """
     x_numel = batch_x[0].numel()
     y_numel = batch_y[0].numel()
@@ -199,9 +201,7 @@ def build_nsf(
         transform = transforms.CompositeTransform([transform_zx, transform])
 
     if z_score_y:
-        embedding_net = standardizing_net(batch_y)
-    else:
-        embedding_net = nn.Identity()
+        embedding_net = nn.Sequential(standardizing_net(batch_y), embedding_net)
 
     distribution = distributions_.StandardNormal((x_numel,))
     neural_net = flows.Flow(transform, distribution, embedding_net)

--- a/sbi/neural_nets/mdn.py
+++ b/sbi/neural_nets/mdn.py
@@ -1,0 +1,65 @@
+# This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
+# under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from pyknos.mdn.mdn import MultivariateGaussianMDN
+from torch import Tensor, nn
+
+from sbi.utils.sbiutils import standardizing_net
+
+
+def build_mdn(
+    batch_x: Tensor = None,
+    batch_y: Tensor = None,
+    z_score_x: bool = True,
+    z_score_y: bool = True,
+    hidden_features: int = 50,
+    num_components: int = 10,
+) -> nn.Module:
+    """Builds MDN p(x|y)
+
+    Args:
+        batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring
+        batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring
+        z_score_x: Whether to z-score xs passing into the network
+        z_score_y: Whether to z-score ys passing into the network
+        hidden_features: Number of hidden features
+        num_components: Number of components
+
+    Returns:
+        Neural network
+    """
+    x_numel = batch_x[0].numel()
+    y_numel = batch_y[0].numel()
+
+    neural_net = MultivariateGaussianMDN(
+        features=x_numel,
+        context_features=y_numel,
+        hidden_features=hidden_features,
+        hidden_net=nn.Sequential(
+            nn.Linear(y_numel, hidden_features),
+            nn.ReLU(),
+            nn.Dropout(p=0.0),
+            nn.Linear(hidden_features, hidden_features),
+            nn.ReLU(),
+            nn.Linear(hidden_features, hidden_features),
+            nn.ReLU(),
+        ),
+        num_components=num_components,
+        custom_initialization=True,
+    )
+
+    if z_score_x:
+        embedding_net_x = standardizing_net(batch_x)
+    else:
+        embedding_net_x = nn.Identity()
+
+    if z_score_y:
+        embedding_net_y = standardizing_net(batch_y)
+    else:
+        embedding_net_y = nn.Identity()
+
+    neural_net = nn.Sequential(embedding_net_y, neural_net, embedding_net_x)
+
+    return neural_net

--- a/sbi/neural_nets/mdn.py
+++ b/sbi/neural_nets/mdn.py
@@ -16,19 +16,21 @@ def build_mdn(
     z_score_y: bool = True,
     hidden_features: int = 50,
     num_components: int = 10,
+    embedding_net: nn.Module = nn.Identity(),
 ) -> nn.Module:
-    """Builds MDN p(x|y)
+    """Builds MDN p(x|y).
 
     Args:
-        batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring
-        batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring
-        z_score_x: Whether to z-score xs passing into the network
-        z_score_y: Whether to z-score ys passing into the network
-        hidden_features: Number of hidden features
-        num_components: Number of components
+        batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring.
+        batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring.
+        z_score_x: Whether to z-score xs passing into the network.
+        z_score_y: Whether to z-score ys passing into the network.
+        hidden_features: Number of hidden features.
+        num_components: Number of components.
+        embedding_net: Optional embedding network for y.
 
     Returns:
-        Neural network
+        Neural network.
     """
     x_numel = batch_x[0].numel()
     y_numel = batch_y[0].numel()
@@ -56,9 +58,9 @@ def build_mdn(
         embedding_net_x = nn.Identity()
 
     if z_score_y:
-        embedding_net_y = standardizing_net(batch_y)
+        embedding_net_y = nn.Sequential(standardizing_net(batch_y), embedding_net)
     else:
-        embedding_net_y = nn.Identity()
+        embedding_net_y = embedding_net
 
     neural_net = nn.Sequential(embedding_net_y, neural_net, embedding_net_x)
 

--- a/sbi/utils/__init__.py
+++ b/sbi/utils/__init__.py
@@ -4,7 +4,8 @@ from sbi.utils.get_nn_models import posterior_nn
 from sbi.utils.io import get_data_root, get_log_root, get_project_root
 from sbi.utils.plot import pairplot
 from sbi.utils.sbiutils import (
-    Standardize,
+    standardizing_transform,
+    standardizing_net,
     sample_posterior_within_prior,
     del_entries,
     clamp_and_warn,

--- a/sbi/utils/get_nn_models.py
+++ b/sbi/utils/get_nn_models.py
@@ -3,389 +3,60 @@
 
 from __future__ import annotations
 
-from typing import Optional
-from warnings import warn
-
-import torch
-from pyknos.mdn.mdn import MultivariateGaussianMDN
-from pyknos.nflows import distributions as distributions_
-from pyknos.nflows import flows, transforms
-from pyknos.nflows.nn import nets
-from pyknos.nflows.nn.nde import MixtureOfGaussiansMADE
-from torch import nn, Tensor, float32, relu, tanh
-
-import sbi.utils as utils
-from sbi.utils.torchutils import create_alternating_binary_mask
+from typing import Any, Callable
+from sbi.neural_nets.flow import build_made, build_maf, build_nsf
+from sbi.neural_nets.mdn import build_mdn
+from sbi.neural_nets.classifier import (
+    build_linear_classifier,
+    build_mlp_classifier,
+    build_resnet_classifier,
+)
 
 
-def posterior_nn(
-    model: str,
-    prior,
-    x_o_shape: torch.Size,
-    embedding: nn.Module = nn.Identity(),
-    hidden_features: int = 50,
-    mdn_num_components: int = 20,
-    made_num_mixture_components: int = 10,
-    made_num_blocks: int = 4,
-    flow_num_transforms: int = 5,
-) -> nn.Module:
-    """Neural posterior density estimator
+def classifier_nn(model: str, **kwargs: Any) -> Callable:
+    def build_fn(batch_theta, batch_x):
+        if model == "linear":
+            return build_linear_classifier(
+                batch_x=batch_x, batch_y=batch_theta, **kwargs
+            )
+        if model == "mlp":
+            return build_mlp_classifier(batch_x=batch_x, batch_y=batch_theta, **kwargs)
+        if model == "resnet":
+            return build_resnet_classifier(
+                batch_x=batch_x, batch_y=batch_theta, **kwargs
+            )
+            raise NotImplementedError
 
-    Args:
-        model: Model, one of maf / mdn / made / nsf
-        prior: Prior distribution.
-        x_o_shape: Shape of a single observation. Used as input size to the NN.
-        embedding: Embedding network
-        hidden_features: For all, number of hidden features
-        mdn_num_components: For MDNs only, number of components
-        made_num_mixture_components: For MADEs only, number of mixture components
-        made_num_blocks: For MADEs only, number of blocks
-        flow_num_transforms: For flows only, number of transforms
-
-    Returns:
-        Neural network
-    """
-
-    # We need these asserts because mean and std can be defined outside, prior to user
-    # input checks.
-    prior_mean = prior.mean
-    prior_std = prior.stddev
-    assert (
-        prior_mean.dtype == float32
-    ), f"Prior mean must have dtype float32, is {prior_mean.dtype}."
-    assert (
-        prior_std.dtype == float32
-    ), f"Prior std must have dtype float32, is {prior_std.dtype}."
-
-    standardizing_transform = transforms.AffineTransform(
-        shift=-prior_mean / prior_std, scale=1 / prior_std
-    )
-
-    theta_numel = prior_mean.numel()
-    x_o_numel = x_o_shape.numel()
-
-    if theta_numel == 1:
-        _check_1d_flow_limitations(model, "parameter")
-
-    if model == "mdn":
-        neural_net = MultivariateGaussianMDN(
-            features=theta_numel,
-            context_features=x_o_numel,
-            hidden_features=hidden_features,
-            hidden_net=nn.Sequential(
-                nn.Linear(x_o_numel, hidden_features),
-                nn.ReLU(),
-                nn.Dropout(p=0.0),
-                nn.Linear(hidden_features, hidden_features),
-                nn.ReLU(),
-                nn.Linear(hidden_features, hidden_features),
-                nn.ReLU(),
-            ),
-            num_components=mdn_num_components,
-            custom_initialization=True,
-        )
-
-    elif model == "made":
-        transform = standardizing_transform
-        distribution = distributions_.MADEMoG(
-            features=theta_numel,
-            hidden_features=hidden_features,
-            context_features=x_o_numel,
-            num_blocks=made_num_blocks,
-            num_mixture_components=made_num_mixture_components,
-            use_residual_blocks=True,
-            random_mask=False,
-            activation=relu,
-            dropout_probability=0.0,
-            use_batch_norm=False,
-            custom_initialization=True,
-        )
-        neural_net = flows.Flow(transform, distribution, embedding)
-
-    elif model == "maf":
-        transform = transforms.CompositeTransform(
-            [
-                transforms.CompositeTransform(
-                    [
-                        transforms.MaskedAffineAutoregressiveTransform(
-                            features=theta_numel,
-                            hidden_features=hidden_features,
-                            context_features=x_o_numel,
-                            num_blocks=2,
-                            use_residual_blocks=False,
-                            random_mask=False,
-                            activation=tanh,
-                            dropout_probability=0.0,
-                            use_batch_norm=True,
-                        ),
-                        transforms.RandomPermutation(features=theta_numel),
-                    ]
-                )
-                for _ in range(flow_num_transforms)
-            ]
-        )
-
-        transform = transforms.CompositeTransform([standardizing_transform, transform,])
-
-        distribution = distributions_.StandardNormal((theta_numel,))
-        neural_net = flows.Flow(transform, distribution, embedding)
-
-    elif model == "nsf":
-        transform = transforms.CompositeTransform(
-            [
-                transforms.CompositeTransform(
-                    [
-                        transforms.PiecewiseRationalQuadraticCouplingTransform(
-                            mask=create_alternating_binary_mask(
-                                features=theta_numel, even=(i % 2 == 0)
-                            ),
-                            transform_net_create_fn=lambda in_features, out_features: nets.ResidualNet(
-                                in_features=in_features,
-                                out_features=out_features,
-                                hidden_features=hidden_features,
-                                context_features=x_o_numel,
-                                num_blocks=2,
-                                activation=relu,
-                                dropout_probability=0.0,
-                                use_batch_norm=False,
-                            ),
-                            num_bins=10,
-                            tails="linear",
-                            tail_bound=3.0,
-                            apply_unconditional_transform=False,
-                        ),
-                        transforms.LULinear(theta_numel, identity_init=True),
-                    ]
-                )
-                for i in range(flow_num_transforms)
-            ]
-        )
-
-        transform = transforms.CompositeTransform([standardizing_transform, transform,])
-
-        distribution = distributions_.StandardNormal((theta_numel,))
-        neural_net = flows.Flow(transform, distribution, embedding)
-
-    else:
-        raise ValueError
-
-    return neural_net
+    return build_fn
 
 
-def likelihood_nn(
-    model: str,
-    theta_shape: torch.Size,
-    x_o_shape: torch.Size,
-    embedding: Optional[nn.Module] = None,
-    hidden_features: int = 50,
-    mdn_num_components: int = 20,
-    made_num_mixture_components: int = 10,
-    made_num_blocks: int = 4,
-    flow_num_transforms: int = 5,
-) -> nn.Module:
-    """Neural likelihood density estimator
+def likelihood_nn(model: str, **kwargs: Any) -> Callable:
+    def build_fn(batch_theta, batch_x):
+        if model == "mdn":
+            return build_mdn(batch_x=batch_x, batch_y=batch_theta, **kwargs)
+        if model == "made":
+            return build_made(batch_x=batch_x, batch_y=batch_theta, **kwargs)
+        if model == "maf":
+            return build_maf(batch_x=batch_x, batch_y=batch_theta, **kwargs)
+        elif model == "nsf":
+            return build_nsf(batch_x=batch_x, batch_y=batch_theta, **kwargs)
+        else:
+            raise NotImplementedError
 
-    Args:
-        model: Model, one of maf / mdn / made / nsf
-        theta_shape: event shape of the prior, number of parameters.
-        x_o_shape: number of elements in a single data point.
-        embedding: Embedding network
-        hidden_features: For all, number of hidden features
-        mdn_num_components: For MDNs only, number of components
-        made_num_mixture_components: For MADEs only, number of mixture components
-        made_num_blocks: For MADEs only, number of blocks
-        flow_num_transforms: For flows only, number of transforms
-
-    Returns:
-        Neural network
-    """
-
-    theta_numel = theta_shape.numel()
-    x_o_numel = x_o_shape.numel()
-
-    if x_o_numel == 1:
-        _check_1d_flow_limitations(model, "data")
-
-    if model == "mdn":
-        neural_net = MultivariateGaussianMDN(
-            features=x_o_numel,
-            context_features=theta_numel,
-            hidden_features=hidden_features,
-            hidden_net=nn.Sequential(
-                nn.Linear(theta_numel, hidden_features),
-                nn.BatchNorm1d(hidden_features),
-                nn.ReLU(),
-                nn.Dropout(p=0.0),
-                nn.Linear(hidden_features, hidden_features),
-                nn.BatchNorm1d(hidden_features),
-                nn.ReLU(),
-                nn.Linear(hidden_features, hidden_features),
-                nn.BatchNorm1d(hidden_features),
-                nn.ReLU(),
-            ),
-            num_components=mdn_num_components,
-            custom_initialization=True,
-        )
-
-    elif model == "made":
-        neural_net = MixtureOfGaussiansMADE(
-            features=x_o_numel,
-            hidden_features=hidden_features,
-            context_features=theta_numel,
-            num_blocks=made_num_blocks,
-            num_mixture_components=made_num_mixture_components,
-            use_residual_blocks=True,
-            random_mask=False,
-            activation=relu,
-            use_batch_norm=True,
-            dropout_probability=0.0,
-            custom_initialization=True,
-        )
-
-    elif model == "maf":
-        transform = transforms.CompositeTransform(
-            [
-                transforms.CompositeTransform(
-                    [
-                        transforms.MaskedAffineAutoregressiveTransform(
-                            features=x_o_numel,
-                            hidden_features=hidden_features,
-                            context_features=theta_numel,
-                            num_blocks=2,
-                            use_residual_blocks=False,
-                            random_mask=False,
-                            activation=tanh,
-                            dropout_probability=0.0,
-                            use_batch_norm=True,
-                        ),
-                        transforms.RandomPermutation(features=x_o_numel),
-                    ]
-                )
-                for _ in range(flow_num_transforms)
-            ]
-        )
-        distribution = distributions_.StandardNormal((x_o_numel,))
-        neural_net = flows.Flow(transform, distribution, embedding)
-
-    elif model == "nsf":
-        transform = transforms.CompositeTransform(
-            [
-                transforms.CompositeTransform(
-                    [
-                        transforms.PiecewiseRationalQuadraticCouplingTransform(
-                            mask=create_alternating_binary_mask(
-                                features=x_o_numel, even=(i % 2 == 0)
-                            ),
-                            transform_net_create_fn=lambda in_features, out_features: nets.ResidualNet(
-                                in_features=in_features,
-                                out_features=out_features,
-                                hidden_features=hidden_features,
-                                context_features=theta_numel,
-                                num_blocks=2,
-                                activation=relu,
-                                dropout_probability=0.0,
-                                use_batch_norm=False,
-                            ),
-                            num_bins=10,
-                            tails="linear",
-                            tail_bound=3.0,
-                            apply_unconditional_transform=False,
-                        ),
-                        transforms.LULinear(x_o_numel, identity_init=True),
-                    ]
-                )
-                for i in range(flow_num_transforms)
-            ]
-        )
-        distribution = distributions_.StandardNormal((x_o_numel,))
-        neural_net = flows.Flow(transform, distribution)
-
-    else:
-        raise ValueError
-
-    return neural_net
+    return build_fn
 
 
-def classifier_nn(
-    model: str,
-    theta_shape: torch.Size,
-    x_o_shape: torch.Size,
-    hidden_features: int = 50,
-) -> nn.Module:
-    """Neural classifier
+def posterior_nn(model: str, **kwargs: Any) -> Callable:
+    def build_fn(batch_theta, batch_x):
+        if model == "mdn":
+            return build_mdn(batch_x=batch_theta, batch_y=batch_x, **kwargs)
+        if model == "made":
+            return build_made(batch_x=batch_theta, batch_y=batch_x, **kwargs)
+        if model == "maf":
+            return build_maf(batch_x=batch_theta, batch_y=batch_x, **kwargs)
+        elif model == "nsf":
+            return build_nsf(batch_x=batch_theta, batch_y=batch_x, **kwargs)
+        else:
+            raise NotImplementedError
 
-    Args:
-        model: Model, one of linear / mlp / resnet
-        theta_shape: event shape of the prior, number of parameters.
-        x_o_shape: number of elements in a single data point.
-        hidden_features: For all, number of hidden features
-
-    Returns:
-        Neural network
-    """
-
-    theta_numel = theta_shape.numel()
-    x_o_numel = x_o_shape.numel()
-
-    if model == "linear":
-        neural_net = nn.Linear(theta_numel + x_o_numel, 1)
-
-    elif model == "mlp":
-        neural_net = nn.Sequential(
-            nn.Linear(theta_numel + x_o_numel, hidden_features),
-            nn.BatchNorm1d(hidden_features),
-            nn.ReLU(),
-            nn.Linear(hidden_features, hidden_features),
-            nn.BatchNorm1d(hidden_features),
-            nn.ReLU(),
-            nn.Linear(hidden_features, 1),
-        )
-
-    elif model == "resnet":
-        neural_net = nets.ResidualNet(
-            in_features=theta_numel + x_o_numel,
-            out_features=1,
-            hidden_features=hidden_features,
-            context_features=None,
-            num_blocks=2,
-            activation=relu,
-            dropout_probability=0.0,
-            use_batch_norm=False,
-        )
-
-    else:
-        raise ValueError(f"'model' must be one of ['linear', 'mlp', 'resnet'].")
-
-    return neural_net
-
-
-def _check_1d_flow_limitations(model: str, output_space: str) -> None:
-    """
-    Gives a warning or error due to limitations of flows in 1D.
-
-    For MAFs and MADEs this gives a warning, since MAFs and MADEs are inherently limited
-        to Gaussian densities in 1D. For NSFs this raises an error due to implementation
-        issues in 1D.
-
-    Args:
-        model: The used density estimator, one of ['maf'|'mdn'|'made'|'nsf'].
-        output_space: Either of ['parameter'|'data']. Is used to add to the
-            message whether the output of the density estimator is the parameter space
-            theta (which is the case for SNPE) or the data space x (which is the case
-            for SNLE).
-    """
-
-    if model == "maf" or model == "made":
-        warn(
-            f"In one-dimensional {output_space} spaces, {model.upper()}s are"
-            " limited to a Gaussian density. Consider setting"
-            ' `density_estimator="mdn"` instead.'
-        )
-    elif model == "nsf":
-        raise NotImplementedError(
-            f"NSFs are not implemented for one-dimensional {output_space}"
-            ' spaces. Please set `density_estimator="mdn"` instead.'
-        )
-    else:
-        # all other density estimators are fine
-        pass
+    return build_fn

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -33,12 +33,12 @@ def clamp_and_warn(name: str, value: float, min_val: float, max_val: float) -> f
 
 
 def standardizing_transform(
-    batch_t: Tensor, min_std: float = 1e-7
+    batch_t: Tensor, min_std: float = 1e-14
 ) -> transforms.AffineTransform:
     """Builds standardizing transform
 
     Args:
-        batch_t: Batched tensor from which mean and std deviation (across 
+        batch_t: Batched tensor from which mean and std deviation (across
             first dimension) are computed.
         min_std:  Minimum value of the standard deviation to use when z-scoring to
             avoid division by zero.
@@ -60,7 +60,7 @@ def standardizing_net(batch_t: Tensor, min_std: float = 1e-7) -> nn.Module:
     """Builds standardizing network
 
     Args:
-        batch_t: Batched tensor from which mean and std deviation (across 
+        batch_t: Batched tensor from which mean and std deviation (across
             first dimension) are computed.
         min_std:  Minimum value of the standard deviation to use when z-scoring to
             avoid division by zero.

--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -305,7 +305,7 @@ def atleast_2d_float32_tensor(arr: Union[Tensor, np.ndarray]) -> Tensor:
     return atleast_2d(torch.as_tensor(arr, dtype=float32))
 
 
-def batched_first_of_batch(t: Tensor):
+def batched_first_of_batch(t: Tensor) -> Tensor:
     """
     Takes in a tensor of shape (N, M) and outputs tensor of shape (1,M).
     """


### PR DESCRIPTION
Big refactor in order to address https://github.com/mackelab/sbi/issues/216. Help with this big PR is highly appreciated. It's not thoroughly tested yet (some tests might still fail), but the PR is ready for a first round of feedback

Core changes:
- Z-scoring of both, theta and x, now possible for all methods
- Delayed neural network creation till training data from round 0 is available
- Training data is passed to a function that builds the neural network. This way, shape inference and z-scoring can be handled inside the builder function
- Introduced a new module, `sbi.neural_nets` holding network builder functions
- No longer storing a deep copy of the initial posterior but calling the build function again if retrain from scratch is requested

Open questions:
- Please have a look at the new logic and comment. Do you see any potential problems down the road?
- At the moment, `x_shape` is a user facing argument in inference methods. We could also infer that from the first set of simulations, addressing https://github.com/mackelab/sbi/issues/255 and https://github.com/mackelab/sbi/issues/254. Before doing that, I wondered if there are scenarios where we can or should not infer this automatically

Related issues:
- https://github.com/mackelab/sbi/issues/216
- https://github.com/mackelab/sbi/issues/217
- https://github.com/mackelab/sbi/issues/195
- https://github.com/mackelab/sbi/issues/162
- https://github.com/mackelab/sbi/issues/255
- https://github.com/mackelab/sbi/issues/254