### PR TITLE
new property to configure NeuralPosterior instance to use MCMC sampling

### DIFF
--- a/sbi/inference/posterior.py
+++ b/sbi/inference/posterior.py
@@ -675,7 +675,7 @@ class NeuralPosterior:
         return self._sample_with_mcmc
 
     @sample_with_mcmc.setter
-    def sample_with_mcmc(self, value: bool):
+    def sample_with_mcmc(self, value: bool) -> None:
         """Set sampling method to use MCMC.
 
         Configures NeuralPosterior instance to use MCMC for sampling. See documentation of `.__init__()` for default

--- a/sbi/inference/posterior.py
+++ b/sbi/inference/posterior.py
@@ -671,6 +671,7 @@ class NeuralPosterior:
 
     @property
     def sample_with_mcmc(self) -> bool:
+        """Return 'True' if NeuralPosterior instance is configured to use MCMC in '.sample()'."""
         return self._sample_with_mcmc
 
     def __repr__(self):

--- a/sbi/inference/posterior.py
+++ b/sbi/inference/posterior.py
@@ -674,6 +674,17 @@ class NeuralPosterior:
         """Return 'True' if NeuralPosterior instance is configured to use MCMC in '.sample()'."""
         return self._sample_with_mcmc
 
+    @sample_with_mcmc.setter
+    def sample_with_mcmc(self, value: bool):
+        """Set sampling method to use MCMC.
+
+        Configures NeuralPosterior instance to use MCMC for sampling. See documentation of '.__init__()' for default
+        MCMC method. Default MCMC method and respective settings can be set upon calling '.sample()'. For details, see
+        documentation of '.sample()'.
+        """
+        self._sample_with_mcmc = value
+        self._mcmc_init_params = None
+
     def __repr__(self):
         desc = f"""NeuralPosterior(
                method_family={self._method_family},

--- a/sbi/inference/posterior.py
+++ b/sbi/inference/posterior.py
@@ -681,7 +681,13 @@ class NeuralPosterior:
         Configures NeuralPosterior instance to use MCMC for sampling. See documentation of '.__init__()' for default
         MCMC method. Default MCMC method and respective settings can be set upon calling '.sample()'. For details, see
         documentation of '.sample()'.
+
+        Raises:
+        ValueError: on attempt to turn off MCMC sampling for family of methods that do not support rejection sampling.
         """
+        if not value:
+            if self._method_family not 'snpe':
+                raise ValueError(f'{self._method_family} cannot use MCMC for sampling.')
         self._sample_with_mcmc = value
         self._mcmc_init_params = None
 

--- a/sbi/inference/posterior.py
+++ b/sbi/inference/posterior.py
@@ -671,16 +671,16 @@ class NeuralPosterior:
 
     @property
     def sample_with_mcmc(self) -> bool:
-        """Return 'True' if NeuralPosterior instance is configured to use MCMC in '.sample()'."""
+        """Return `True` if NeuralPosterior instance is configured to use MCMC in `.sample()`."""
         return self._sample_with_mcmc
 
     @sample_with_mcmc.setter
     def sample_with_mcmc(self, value: bool):
         """Set sampling method to use MCMC.
 
-        Configures NeuralPosterior instance to use MCMC for sampling. See documentation of '.__init__()' for default
-        MCMC method. Default MCMC method and respective settings can be set upon calling '.sample()'. For details, see
-        documentation of '.sample()'.
+        Configures NeuralPosterior instance to use MCMC for sampling. See documentation of `.__init__()` for default
+        MCMC method. Default MCMC method and respective settings can be set upon calling `.sample()`. For details, see
+        documentation of `.sample()`.
 
         Raises:
         ValueError: on attempt to turn off MCMC sampling for family of methods that do not support rejection sampling.

--- a/sbi/inference/posterior.py
+++ b/sbi/inference/posterior.py
@@ -686,7 +686,7 @@ class NeuralPosterior:
         ValueError: on attempt to turn off MCMC sampling for family of methods that do not support rejection sampling.
         """
         if not value:
-            if self._method_family not 'snpe':
+            if self._method_family not in 'snpe':
                 raise ValueError(f'{self._method_family} cannot use MCMC for sampling.')
         self._sample_with_mcmc = value
         self._mcmc_init_params = None

--- a/sbi/inference/posterior.py
+++ b/sbi/inference/posterior.py
@@ -669,6 +669,10 @@ class NeuralPosterior:
 
         return x_matched
 
+    @property
+    def sample_with_mcmc(self) -> bool:
+        return self._sample_with_mcmc
+
     def __repr__(self):
         desc = f"""NeuralPosterior(
                method_family={self._method_family},


### PR DESCRIPTION
I added a property getter and setter for clean change of the sampling method of NeuralPosterior instances. 

It includes a check for against somebody trying to unset sampling with mcmc on methods that only support mcmc sampling. I did this based on my understanding, that rejection sampling and mcmc sampling are the only implemented sampling 'families'. This need correction if I'm mistaken in my belief.

Tried to follow to coding conventions as close as possible ;)