### PR TITLE
add check for density estimator arg.

### DIFF
--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -18,7 +18,12 @@ import sbi.utils as utils
 from sbi.inference import NeuralInference
 from sbi.inference.posterior import NeuralPosterior
 from sbi.types import OneOrMore, ScalarFloat
-from sbi.utils import handle_invalid_x, warn_on_invalid_x, x_shape_from_simulation
+from sbi.utils import (
+    check_estimator_arg,
+    handle_invalid_x,
+    warn_on_invalid_x,
+    x_shape_from_simulation,
+)
 
 
 class LikelihoodEstimator(NeuralInference, ABC):
@@ -70,6 +75,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
         # `_build_neural_net`. It will be called in the first round and receive
         # thetas and xs as inputs, so that they can be used for shape inference and
         # potentially for z-scoring.
+        check_estimator_arg(density_estimator)
         if isinstance(density_estimator, str):
             self._build_neural_net = utils.likelihood_nn(model=density_estimator)
         else:

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from copy import deepcopy
+from sbi.user_input.user_input_checks import check_estimator_arg
 from typing import Callable, Dict, Optional, Tuple, Union, cast
 from warnings import warn
 
@@ -20,7 +21,12 @@ import sbi.utils as utils
 from sbi.inference import NeuralInference
 from sbi.inference.posterior import NeuralPosterior
 from sbi.types import OneOrMore, ScalarFloat
-from sbi.utils import handle_invalid_x, warn_on_invalid_x, x_shape_from_simulation
+from sbi.utils import (
+    handle_invalid_x,
+    warn_on_invalid_x,
+    x_shape_from_simulation,
+    check_estimator_arg,
+)
 
 
 class PosteriorEstimator(NeuralInference, ABC):
@@ -75,6 +81,7 @@ class PosteriorEstimator(NeuralInference, ABC):
         # `_build_neural_net`. It will be called in the first round and receive
         # thetas and xs as inputs, so that they can be used for shape inference and
         # potentially for z-scoring.
+        check_estimator_arg(density_estimator)
         if isinstance(density_estimator, str):
             self._build_neural_net = utils.posterior_nn(model=density_estimator)
         else:

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -20,6 +20,7 @@ from sbi.utils import (
     handle_invalid_x,
     warn_on_invalid_x,
     x_shape_from_simulation,
+    check_estimator_arg,
 )
 from sbi.utils.torchutils import (
     ensure_theta_batched,
@@ -83,6 +84,7 @@ class RatioEstimator(NeuralInference, ABC):
         # `_build_neural_net`. It will be called in the first round and receive
         # thetas and xs as inputs, so that they can be used for shape inference and
         # potentially for z-scoring.
+        check_estimator_arg(classifier)
         if isinstance(classifier, str):
             self._build_neural_net = utils.classifier_nn(model=classifier)
         else:

--- a/sbi/user_input/user_input_checks.py
+++ b/sbi/user_input/user_input_checks.py
@@ -3,14 +3,14 @@
 
 from __future__ import annotations
 
-from typing import cast, Callable, Optional, Sequence, Tuple
 import warnings
+from typing import Callable, Optional, Sequence, Tuple, Union, cast
 
+import torch
 from numpy import ndarray
 from scipy.stats._distn_infrastructure import rv_frozen
 from scipy.stats._multivariate import multi_rv_frozen
-import torch
-from torch import Tensor, float32
+from torch import Tensor, float32, nn
 from torch.distributions import Distribution
 
 from sbi.user_input.user_input_checks_utils import (
@@ -512,3 +512,13 @@ def check_sbi_inputs(simulator: Callable, prior: Distribution) -> None:
         sim_batch_shape == num_prior_samples
     ), f"""Simulation batch shape {sim_batch_shape} must match
         num_samples={num_prior_samples}."""
+
+
+def check_estimator_arg(estimator: Union[str, Callable]) -> None:
+    """Check (density or ratio) estimator argument passed by the user."""
+    assert isinstance(estimator, str) or (
+        isinstance(estimator, Callable) and not isinstance(estimator, nn.Module)
+    ), (
+        "The passed density estimator / classifier must be a string or a function "
+        f"returning a nn.Module, but is {type(estimator)}"
+    )

--- a/sbi/utils/__init__.py
+++ b/sbi/utils/__init__.py
@@ -41,3 +41,4 @@ from sbi.utils.typechecks import (
 )
 
 from sbi.user_input.user_input_checks_utils import MultipleIndependent
+from sbi.user_input.user_input_checks import check_estimator_arg


### PR DESCRIPTION
A quick check on the `denisty_estimator` argument passed by the user. 

Passing a density estimator directly, e.g., a `nn.Module`, sounds intuitive given the name of the argument, but it results in an uninformative error. One has to pass a function returning a `nn.Module` instead. 

With this PR we add a small check on the `density_estimator` arg to give an informative error message.
