### PR TITLE
Provide external data

### DIFF
--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -159,8 +159,8 @@ class LikelihoodEstimator(NeuralInference, ABC):
             warn_on_invalid_x(num_nans, num_infs, exclude_invalid_x)
 
             # Store (theta, x) pairs.
-            self._theta_bank.append(theta[is_valid_x])
-            self._x_bank.append(x[is_valid_x])
+            self._theta_roundwise.append(theta[is_valid_x])
+            self._x_roundwise.append(x[is_valid_x])
 
             # Fit neural likelihood to newly aggregated dataset.
             self._train(
@@ -182,8 +182,8 @@ class LikelihoodEstimator(NeuralInference, ABC):
             self._summarize(
                 round_=round_,
                 x_o=self._posterior.default_x,
-                theta_bank=self._theta_bank,
-                x_bank=self._x_bank,
+                theta_bank=self._theta_roundwise,
+                x_bank=self._x_roundwise,
             )
 
         self._posterior._num_trained_rounds = num_rounds
@@ -213,7 +213,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
         # Starting index for the training set (1 = discard round-0 samples).
         start_idx = int(discard_prior_samples and round_ > 0)
         # Get total number of training examples.
-        num_examples = sum(len(theta) for theta in self._theta_bank)
+        num_examples = sum(len(theta) for theta in self._theta_roundwise)
 
         # Select random train and validation splits from (theta, x) pairs.
         permuted_indices = torch.randperm(num_examples)
@@ -226,7 +226,8 @@ class LikelihoodEstimator(NeuralInference, ABC):
 
         # Dataset is shared for training and validation loaders.
         dataset = data.TensorDataset(
-            torch.cat(self._x_bank[start_idx:]), torch.cat(self._theta_bank[start_idx:])
+            torch.cat(self._x_roundwise[start_idx:]),
+            torch.cat(self._theta_roundwise[start_idx:]),
         )
 
         # Create neural net and validation loaders using a subset sampler.

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -123,10 +123,10 @@ class LikelihoodEstimator(NeuralInference, ABC):
             # Run simulations for the round.
             theta, x = self._run_simulations(round_, num_sims)
 
-            self._append_to_round_bank(theta, x, round_)
+            self._append_to_data_bank(theta, x, round_)
 
             # Load data from most recent round.
-            theta, x, _ = self._get_from_round_bank(round_, exclude_invalid_x, False)
+            theta, x, _ = self._get_from_data_bank(round_, exclude_invalid_x, False)
 
             # First round or if retraining from scratch:
             # Call the `self._build_neural_net` with the rounds' thetas and xs as
@@ -198,7 +198,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
 
         # Starting index for the training set (1 = discard round-0 samples).
         start_idx = int(discard_prior_samples and round_ > 0)
-        theta, x, _ = self._get_from_round_bank(start_idx, exclude_invalid_x)
+        theta, x, _ = self._get_from_data_bank(start_idx, exclude_invalid_x)
 
         # Get total number of training examples.
         num_examples = len(theta)

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -161,10 +161,10 @@ class PosteriorEstimator(NeuralInference, ABC):
 
             # Run simulations for the round.
             theta, x = self._run_simulations(round_, num_sims)
-            self._append_to_round_bank(theta, x, round_)
+            self._append_to_data_bank(theta, x, round_)
 
             # Load data from most recent round.
-            theta, x, _ = self._get_from_round_bank(round_, exclude_invalid_x, False)
+            theta, x, _ = self._get_from_data_bank(round_, exclude_invalid_x, False)
 
             # First round or if retraining from scratch:
             # Call the `self._build_neural_net` with the rounds' thetas and xs as
@@ -262,7 +262,7 @@ class PosteriorEstimator(NeuralInference, ABC):
 
         # Starting index for the training set (1 = discard round-0 samples).
         start_idx = int(discard_prior_samples and round_ > 0)
-        theta, x, prior_masks = self._get_from_round_bank(start_idx, exclude_invalid_x)
+        theta, x, prior_masks = self._get_from_data_bank(start_idx, exclude_invalid_x)
 
         # Select random neural net and validation splits from (theta, x) pairs.
         num_total_examples = len(theta)

--- a/sbi/inference/snpe/snpe_c.py
+++ b/sbi/inference/snpe/snpe_c.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Callable, Optional, Union
+from typing import Callable, Optional, Union, Tuple
 
 import torch
 from torch import Tensor, eye, nn, ones

--- a/sbi/inference/snpe/snpe_c.py
+++ b/sbi/inference/snpe/snpe_c.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Callable, Optional, Union, Tuple
+from typing import Callable, Optional, Union
 
 import torch
 from torch import Tensor, eye, nn, ones

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -170,8 +170,8 @@ class RatioEstimator(NeuralInference, ABC):
             warn_on_invalid_x(num_nans, num_infs, exclude_invalid_x)
 
             # Store (theta, x) pairs.
-            self._theta_bank.append(theta[is_valid_x])
-            self._x_bank.append(x[is_valid_x])
+            self._theta_roundwise.append(theta[is_valid_x])
+            self._x_roundwise.append(x[is_valid_x])
 
             # Fit posterior using newly aggregated data set.
             self._train(
@@ -194,8 +194,8 @@ class RatioEstimator(NeuralInference, ABC):
             self._summarize(
                 round_=round_,
                 x_o=self._posterior.default_x,
-                theta_bank=self._theta_bank,
-                x_bank=self._x_bank,
+                theta_bank=self._theta_roundwise,
+                x_bank=self._x_roundwise,
             )
 
         self._posterior._num_trained_rounds = num_rounds
@@ -228,7 +228,7 @@ class RatioEstimator(NeuralInference, ABC):
         # Starting index for the training set (1 = discard round-0 samples).
         start_idx = int(discard_prior_samples and round_ > 0)
         # Get total number of training examples.
-        num_examples = sum(len(theta) for theta in self._theta_bank)
+        num_examples = sum(len(theta) for theta in self._theta_roundwise)
 
         # Select random train and validation splits from (theta, x) pairs.
         permuted_indices = torch.randperm(num_examples)
@@ -246,7 +246,8 @@ class RatioEstimator(NeuralInference, ABC):
 
         # Dataset is shared for training and validation loaders.
         dataset = data.TensorDataset(
-            torch.cat(self._theta_bank[start_idx:]), torch.cat(self._x_bank[start_idx:])
+            torch.cat(self._theta_roundwise[start_idx:]),
+            torch.cat(self._x_roundwise[start_idx:]),
         )
 
         # Create neural net and validation loaders using a subset sampler.

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -146,7 +146,11 @@ class RatioEstimator(NeuralInference, ABC):
                 )
 
             x = self._batched_simulator(theta)
-            x_shape = x_shape_from_simulation(x)
+
+            self._append_to_round_bank(theta, x, round_)
+
+            # Load data from most recent round.
+            theta, x, _ = self._get_from_round_bank(round_, exclude_invalid_x)
 
             # First round or if retraining from scratch:
             # Call the `self._build_neural_net` with the rounds' thetas and xs as
@@ -154,6 +158,7 @@ class RatioEstimator(NeuralInference, ABC):
             # This is passed into NeuralPosterior, to create a neural posterior which
             # can `sample()` and `log_prob()`. The network is accessible via `.net`.
             if round_ == 0 or retrain_from_scratch_each_round:
+                x_shape = x_shape_from_simulation(x)
                 self._posterior = NeuralPosterior(
                     method_family=self.__class__.__name__.lower(),
                     neural_net=self._build_neural_net(theta, x),
@@ -163,15 +168,7 @@ class RatioEstimator(NeuralInference, ABC):
                     mcmc_method=self._mcmc_method,
                     get_potential_function=PotentialFunctionProvider(),
                 )
-            self._handle_x_o_wrt_amortization(x_o, x_shape, num_rounds)
-
-            # Check for NaNs in simulations.
-            is_valid_x, num_nans, num_infs = handle_invalid_x(x, exclude_invalid_x)
-            warn_on_invalid_x(num_nans, num_infs, exclude_invalid_x)
-
-            # Store (theta, x) pairs.
-            self._theta_roundwise.append(theta[is_valid_x])
-            self._x_roundwise.append(x[is_valid_x])
+                self._handle_x_o_wrt_amortization(x_o, x_shape, num_rounds)
 
             # Fit posterior using newly aggregated data set.
             self._train(
@@ -194,8 +191,8 @@ class RatioEstimator(NeuralInference, ABC):
             self._summarize(
                 round_=round_,
                 x_o=self._posterior.default_x,
-                theta_bank=self._theta_roundwise,
-                x_bank=self._x_roundwise,
+                theta_bank=theta,
+                x_bank=x,
             )
 
         self._posterior._num_trained_rounds = num_rounds
@@ -227,8 +224,11 @@ class RatioEstimator(NeuralInference, ABC):
 
         # Starting index for the training set (1 = discard round-0 samples).
         start_idx = int(discard_prior_samples and round_ > 0)
+
+        theta, x, _ = self._get_from_round_bank(start_idx)
+
         # Get total number of training examples.
-        num_examples = sum(len(theta) for theta in self._theta_roundwise)
+        num_examples = len(theta)
 
         # Select random train and validation splits from (theta, x) pairs.
         permuted_indices = torch.randperm(num_examples)

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -130,10 +130,10 @@ class RatioEstimator(NeuralInference, ABC):
             # Run simulations for the round.
             theta, x = self._run_simulations(round_, num_sims)
 
-            self._append_to_round_bank(theta, x, round_)
+            self._append_to_data_bank(theta, x, round_)
 
             # Load data from most recent round.
-            theta, x, _ = self._get_from_round_bank(round_, exclude_invalid_x, False)
+            theta, x, _ = self._get_from_data_bank(round_, exclude_invalid_x, False)
 
             # First round or if retraining from scratch:
             # Call the `self._build_neural_net` with the rounds' thetas and xs as
@@ -209,7 +209,7 @@ class RatioEstimator(NeuralInference, ABC):
 
         # Starting index for the training set (1 = discard round-0 samples).
         start_idx = int(discard_prior_samples and round_ > 0)
-        theta, x, _ = self._get_from_round_bank(start_idx, exclude_invalid_x)
+        theta, x, _ = self._get_from_data_bank(start_idx, exclude_invalid_x)
 
         # Get total number of training examples.
         num_examples = len(theta)

--- a/sbi/utils/__init__.py
+++ b/sbi/utils/__init__.py
@@ -13,6 +13,7 @@ from sbi.utils.sbiutils import (
     warn_on_invalid_x,
     x_shape_from_simulation,
     get_data_after_round,
+    mask_sims_from_prior,
 )
 from sbi.utils.torchutils import (
     BoxUniform,

--- a/sbi/utils/__init__.py
+++ b/sbi/utils/__init__.py
@@ -12,6 +12,7 @@ from sbi.utils.sbiutils import (
     handle_invalid_x,
     warn_on_invalid_x,
     x_shape_from_simulation,
+    get_data_after_round,
 )
 from sbi.utils.torchutils import (
     BoxUniform,

--- a/sbi/utils/__init__.py
+++ b/sbi/utils/__init__.py
@@ -12,7 +12,7 @@ from sbi.utils.sbiutils import (
     handle_invalid_x,
     warn_on_invalid_x,
     x_shape_from_simulation,
-    get_data_after_round,
+    get_data_since_round,
     mask_sims_from_prior,
 )
 from sbi.utils.torchutils import (

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Sequence, Tuple
 import torch
 import torch.nn as nn
 from pyknos.nflows import transforms
-from torch import Tensor, as_tensor, ones
+from torch import Tensor, as_tensor, ones, zeros
 from tqdm.auto import tqdm
 
 
@@ -233,3 +233,17 @@ def get_data_after_round(
             counting from 0.
     """
     return torch.cat([t for t, r in zip(data, data_round_index) if r >= starting_round])
+
+
+def mask_sims_from_prior(round_: int, num_simulations: int) -> Tensor:
+    """Returns Tensor True where simulated from prior parameters.
+
+    Args:
+        round_: Current training round, starting at 0.
+        num_simulations: Actually performed simulations. This number can be below
+            the one fixed for the round if leakage correction through sampling is
+            active and `patience` is not enough to reach it.
+    """
+
+    prior_mask_values = ones if round_ == 0 else zeros
+    return prior_mask_values((num_simulations, 1), dtype=torch.bool)

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -2,12 +2,12 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 import logging
-from typing import Tuple, Dict, Sequence, Any
+from typing import Any, Dict, List, Sequence, Tuple
 
-from pyknos.nflows import transforms
 import torch
-from torch import Tensor, as_tensor, ones
 import torch.nn as nn
+from pyknos.nflows import transforms
+from torch import Tensor, as_tensor, ones
 from tqdm.auto import tqdm
 
 
@@ -216,3 +216,20 @@ def warn_on_invalid_x(num_nans: int, num_infs: int, exclude_invalid_x: bool) -> 
                 f"Found {num_nans} NaN simulations and {num_infs} Inf simulations. "
                 "Training might fail. Consider setting `exclude_invalid_x=True`."
             )
+
+
+def get_data_after_round(
+    data: List, data_round_index: List, starting_round: int
+) -> Tensor:
+    """
+    Returns tensor with all data coming from a round >= `starting_round`.
+
+    Args:
+        data: Each list entry contains a set of data (either parameters, simulation
+            outputs, or prior masks).
+        data_round_index: List with same length as data, each entry is an integer that
+            indicates which round the data is from.
+        starting_round: From which round onwards to return the data. We start
+            counting from 0.
+    """
+    return torch.cat([t for t, r in zip(data, data_round_index) if r >= starting_round])

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -218,8 +218,8 @@ def warn_on_invalid_x(num_nans: int, num_infs: int, exclude_invalid_x: bool) -> 
             )
 
 
-def get_data_after_round(
-    data: List, data_round_index: List, starting_round: int
+def get_data_since_round(
+    data: List, data_round_indices: List, starting_round_index: int
 ) -> Tensor:
     """
     Returns tensor with all data coming from a round >= `starting_round`.
@@ -227,12 +227,14 @@ def get_data_after_round(
     Args:
         data: Each list entry contains a set of data (either parameters, simulation
             outputs, or prior masks).
-        data_round_index: List with same length as data, each entry is an integer that
+        data_round_indices: List with same length as data, each entry is an integer that
             indicates which round the data is from.
-        starting_round: From which round onwards to return the data. We start
+        starting_round_index: From which round onwards to return the data. We start
             counting from 0.
     """
-    return torch.cat([t for t, r in zip(data, data_round_index) if r >= starting_round])
+    return torch.cat(
+        [t for t, r in zip(data, data_round_indices) if r >= starting_round_index]
+    )
 
 
 def mask_sims_from_prior(round_: int, num_simulations: int) -> Tensor:

--- a/tests/linearGaussian_snle_test.py
+++ b/tests/linearGaussian_snle_test.py
@@ -105,17 +105,14 @@ def test_c2st_snl_on_linearGaussian_different_dims(set_seed):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize(
-    "num_dim, num_simulations", ((1, 0), (1, 1000), (2, 0), (2, 1000)),
-)
-def test_c2st_snle_external_data_on_linearGaussian(
-    num_dim: int, num_simulations: int, set_seed
-):
+def test_c2st_snle_external_data_on_linearGaussian(set_seed):
     """Test whether SNPE C infers well a simple example with available ground truth.
 
     Args:
         set_seed: fixture for manual seeding
     """
+
+    num_dim = 2
 
     device = "cpu"
     configure_default_device(device)
@@ -150,9 +147,7 @@ def test_c2st_snle_external_data_on_linearGaussian(
     infer.provide_presimulated(external_theta, external_x)
 
     posterior = infer(
-        num_rounds=1,
-        num_simulations_per_round=num_simulations,
-        training_batch_size=100,
+        num_rounds=1, num_simulations_per_round=1000, training_batch_size=100,
     ).set_default_x(x_o)
     samples = posterior.sample((num_samples,))
 

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -171,6 +171,61 @@ def test_c2st_snpe_on_linearGaussian_different_dims(set_seed):
     check_c2st(samples, target_samples, alg="snpe_c")
 
 
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "num_dim, num_simulations", ((1, 0), (1, 1000), (2, 0), (2, 1000)),
+)
+def test_c2st_snpe_external_data_on_linearGaussian(num_dim: int, num_simulations: int):
+    """Test whether SNPE C infers well a simple example with available ground truth.
+
+    Args:
+        set_seed: fixture for manual seeding
+    """
+
+    device = "cpu"
+    configure_default_device(device)
+    x_o = zeros(1, num_dim)
+    num_samples = 1000
+
+    # likelihood_mean will be likelihood_shift+theta
+    likelihood_shift = -1.0 * ones(num_dim)
+    likelihood_cov = 0.3 * eye(num_dim)
+
+    prior_mean = zeros(num_dim)
+    prior_cov = eye(num_dim)
+    prior = MultivariateNormal(loc=prior_mean, covariance_matrix=prior_cov)
+    gt_posterior = true_posterior_linear_gaussian_mvn_prior(
+        x_o[0], likelihood_shift, likelihood_cov, prior_mean, prior_cov
+    )
+    target_samples = gt_posterior.sample((num_samples,))
+
+    def simulator(theta):
+        return linear_gaussian(theta, likelihood_shift, likelihood_cov)
+
+    infer = SNPE_C(
+        *prepare_for_sbi(simulator, prior),
+        simulation_batch_size=1000,
+        show_progress_bars=False,
+        sample_with_mcmc=False,
+        device=device,
+    )
+
+    external_theta = prior.sample((1000,))
+    external_x = simulator(external_theta)
+
+    infer.provide_presimulated(external_theta, external_x)
+
+    posterior = infer(
+        num_rounds=1,
+        num_simulations_per_round=num_simulations,
+        training_batch_size=100,
+    ).set_default_x(x_o)
+    samples = posterior.sample((num_samples,))
+
+    # Compute the c2st and assert it is near chance level of 0.5.
+    check_c2st(samples, target_samples, alg="snpe_c")
+
+
 # Test multi-round SNPE.
 @pytest.mark.slow
 @pytest.mark.parametrize(

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -172,17 +172,14 @@ def test_c2st_snpe_on_linearGaussian_different_dims(set_seed):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize(
-    "num_dim, num_simulations", ((1, 0), (1, 1000), (2, 0), (2, 1000)),
-)
-def test_c2st_snpe_external_data_on_linearGaussian(
-    num_dim: int, num_simulations: int, set_seed
-):
+def test_c2st_snpe_external_data_on_linearGaussian(set_seed):
     """Test whether SNPE C infers well a simple example with available ground truth.
 
     Args:
         set_seed: fixture for manual seeding
     """
+
+    num_dim = 2
 
     device = "cpu"
     configure_default_device(device)
@@ -218,9 +215,7 @@ def test_c2st_snpe_external_data_on_linearGaussian(
     infer.provide_presimulated(external_theta, external_x)
 
     posterior = infer(
-        num_rounds=1,
-        num_simulations_per_round=num_simulations,
-        training_batch_size=100,
+        num_rounds=1, num_simulations_per_round=1000, training_batch_size=100,
     ).set_default_x(x_o)
     samples = posterior.sample((num_samples,))
 

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -175,7 +175,9 @@ def test_c2st_snpe_on_linearGaussian_different_dims(set_seed):
 @pytest.mark.parametrize(
     "num_dim, num_simulations", ((1, 0), (1, 1000), (2, 0), (2, 1000)),
 )
-def test_c2st_snpe_external_data_on_linearGaussian(num_dim: int, num_simulations: int):
+def test_c2st_snpe_external_data_on_linearGaussian(
+    num_dim: int, num_simulations: int, set_seed
+):
     """Test whether SNPE C infers well a simple example with available ground truth.
 
     Args:

--- a/tests/linearGaussian_snre_test.py
+++ b/tests/linearGaussian_snre_test.py
@@ -108,17 +108,13 @@ def test_c2st_sre_on_linearGaussian_different_dims(set_seed):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize(
-    "num_dim, num_simulations", ((1, 0), (1, 1000), (2, 0), (2, 1000)),
-)
-def test_c2st_snle_external_data_on_linearGaussian(
-    num_dim: int, num_simulations: int, set_seed
-):
+def test_c2st_sre_external_data_on_linearGaussian(set_seed):
     """Test whether SNPE C infers well a simple example with available ground truth.
 
     Args:
         set_seed: fixture for manual seeding
     """
+    num_dim = 2
 
     device = "cpu"
     configure_default_device(device)
@@ -153,9 +149,7 @@ def test_c2st_snle_external_data_on_linearGaussian(
     infer.provide_presimulated(external_theta, external_x)
 
     posterior = infer(
-        num_rounds=1,
-        num_simulations_per_round=num_simulations,
-        training_batch_size=100,
+        num_rounds=1, num_simulations_per_round=1000, training_batch_size=100,
     ).set_default_x(x_o)
     samples = posterior.sample((num_samples,))
 

--- a/tests/linearGaussian_snre_test.py
+++ b/tests/linearGaussian_snre_test.py
@@ -109,6 +109,62 @@ def test_c2st_sre_on_linearGaussian_different_dims(set_seed):
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
+    "num_dim, num_simulations", ((1, 0), (1, 1000), (2, 0), (2, 1000)),
+)
+def test_c2st_snle_external_data_on_linearGaussian(
+    num_dim: int, num_simulations: int, set_seed
+):
+    """Test whether SNPE C infers well a simple example with available ground truth.
+
+    Args:
+        set_seed: fixture for manual seeding
+    """
+
+    device = "cpu"
+    configure_default_device(device)
+    x_o = zeros(1, num_dim)
+    num_samples = 1000
+
+    # likelihood_mean will be likelihood_shift+theta
+    likelihood_shift = -1.0 * ones(num_dim)
+    likelihood_cov = 0.3 * eye(num_dim)
+
+    prior_mean = zeros(num_dim)
+    prior_cov = eye(num_dim)
+    prior = MultivariateNormal(loc=prior_mean, covariance_matrix=prior_cov)
+    gt_posterior = true_posterior_linear_gaussian_mvn_prior(
+        x_o[0], likelihood_shift, likelihood_cov, prior_mean, prior_cov
+    )
+    target_samples = gt_posterior.sample((num_samples,))
+
+    def simulator(theta):
+        return linear_gaussian(theta, likelihood_shift, likelihood_cov)
+
+    infer = SRE(
+        *prepare_for_sbi(simulator, prior),
+        simulation_batch_size=1000,
+        show_progress_bars=False,
+        device=device,
+    )
+
+    external_theta = prior.sample((1000,))
+    external_x = simulator(external_theta)
+
+    infer.provide_presimulated(external_theta, external_x)
+
+    posterior = infer(
+        num_rounds=1,
+        num_simulations_per_round=num_simulations,
+        training_batch_size=100,
+    ).set_default_x(x_o)
+    samples = posterior.sample((num_samples,))
+
+    # Compute the c2st and assert it is near chance level of 0.5.
+    check_c2st(samples, target_samples, alg="snpe_c")
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize(
     "num_dim, prior_str, method_str",
     (
         (2, "gaussian", "sre"),


### PR DESCRIPTION
# Goal
We should support users that provide external data. Importantly, this should also be possible in multiple round inference (e.g. the user could run simulations on the cluster and inference on another computer), see #163 

# API suggestion
For single round:
```
infer = SNPE(simulator, prior)
posterior = infer(num_round=1, num_simulations=0, external_data=(theta,x))
```
For multi-round, one can then do the following (not sure if I will implement this in this PR, but this would be the idea):
```
posterior_r2 = infer.continue(num_rounds=1, num_simulations=0, external_data=(theta2, x2), simulations_from_prior=False)
```
Here, the `simulations_from_prior` argument tells the inference algorithm whether the new simulations came from the latest posterior or from the prior. E.g. SNPE-B needs this information to use the correct importance weights. `num_simulations` indicates the number of simulations _after_ `external_data` is exceeded.

# Implementation
At the beginning of inference, we wrap the simulator to return `external_data` until it runs out of it (at which point it falls back onto simulating).

### Why not let the user do the wrapping themselves (and then just provide it as simulator)?
a) I think it's unintuitive that the `simulator` does not actually simulate
b) after each round, the user would need to define a new "simulator" - which will do the same simulations, but would have different `external_data`. I find this not very elegant.
c) For the docs, it might be helpful to have an argument called `external_data`. It makes it easy for the user to figure out how to provide external data. If we made it a decorator, I fear that we would have to write a dedicated tutorial which shows how to do this.

### Why wrap it at all and not just set `theta_bank=external_theta_data` and `x_bank=external_x_data`?
This works just fine for the core functionality, but for many advanced features (e.g. handling NaN, z-scoring, retrain_from_scratch,...) it requires extra care, making things unnecessarily complicated).

# Disadvantages / concerns
- we add an additional argument to `__call__()`
- any more concerns?