### PR TITLE
Update sbiutils.py

### DIFF
--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -61,6 +61,16 @@ def standardizing_transform(
     return transforms.AffineTransform(shift=-t_mean / t_std, scale=1 / t_std)
 
 
+class Standardize(nn.Module):
+    def __init__(self, mean, std):
+        super(Standardize, self).__init__()
+        self.mean = mean
+        self.std = std
+
+    def forward(self, tensor):
+        return (tensor - self.mean) / self.std
+
+
 def standardizing_net(batch_t: Tensor, min_std: float = 1e-7) -> nn.Module:
     """Builds standardizing network
 
@@ -73,15 +83,6 @@ def standardizing_net(batch_t: Tensor, min_std: float = 1e-7) -> nn.Module:
     Returns:
         Neural network module for z-scoring
     """
-
-    class Standardize(nn.Module):
-        def __init__(self, mean, std):
-            super(Standardize, self).__init__()
-            self.mean = mean
-            self.std = std
-
-        def forward(self, tensor):
-            return (tensor - self.mean) / self.std
 
     is_valid_t, *_ = handle_invalid_x(batch_t, True)
 


### PR DESCRIPTION
Hi! 
I was trying to pickle a dict that has one entry that is a list of NeuralPosteriors, and there was an error
<img width="1310" alt="Screen Shot 2020-07-07 at 10 01 40 PM" src="https://user-images.githubusercontent.com/43154947/86792847-75625b00-c09d-11ea-8aac-0a2baaf59b02.png">
It was fixed by moving the class `Standardize` outside of `standardizing_transform` in sbiutils.py.
Thanks for reviewing!