### PR TITLE
MCMC parameters to init of inference classes

### DIFF
--- a/sbi/inference/posterior.py
+++ b/sbi/inference/posterior.py
@@ -502,12 +502,12 @@ class NeuralPosterior:
         # Find init points depending on `init_strategy` if no init is set
         if self._mcmc_init_params is None:
             if init_strategy == "prior":
-                self._mcmc_init_params = self._prior.sample((num_chains,))
+                self._mcmc_init_params = self._prior.sample((num_chains,)).detach()
             elif init_strategy == "sir":
                 self.net.eval()
                 init_param_candidates = self._prior.sample(
                     (init_strategy_num_candidates,)
-                )
+                ).detach()
                 potential_function = self._get_potential_function(
                     self._prior, self.net, x, "slice_np"
                 )

--- a/sbi/inference/posterior.py
+++ b/sbi/inference/posterior.py
@@ -517,7 +517,7 @@ class NeuralPosterior:
                         for i in range(init_strategy_num_candidates)
                     ]
                 )
-                probs = np.exp(log_weights.view(-1).numpy().astype(np.float64))
+                probs = np.exp(log_weights.view(-1).detach().numpy().astype(np.float64))
                 probs[np.isnan(probs)] = 0.0
                 probs[np.isinf(probs)] = 0.0
                 probs /= probs.sum()

--- a/sbi/inference/snle/snle_a.py
+++ b/sbi/inference/snle/snle_a.py
@@ -24,6 +24,7 @@ class SNLE_A(LikelihoodEstimator):
         simulation_batch_size: int = 1,
         density_estimator: Union[str, Callable] = "maf",
         mcmc_method: str = "slice_np",
+        mcmc_parameters: Optional[Dict[str, Any]] = None,
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
         summary_writer: Optional[SummaryWriter] = None,
@@ -58,8 +59,17 @@ class SNLE_A(LikelihoodEstimator):
                 needs to return a PyTorch `nn.Module` implementing the density
                 estimator. The density estimator needs to provide the methods
                 `.log_prob` and `.sample()`.
-            mcmc_method: Specify the method for MCMC sampling, either of:
-                slice_np, slice, hmc, nuts.
+            mcmc_method: Method used for MCMC sampling, one of `slice_np`, `slice`, `hmc`, `nuts`.
+                Currently defaults to `slice_np` for a custom numpy implementation of
+                slice sampling; select `hmc`, `nuts` or `slice` for Pyro-based sampling.
+            mcmc_parameters: Dictionary overriding the default parameters for MCMC.
+                The following parameters are supported: `thin` to set the thinning
+                factor for the chain, `warmup_steps` to set the initial number of
+                samples to discard, `num_chains` for the number of chains, `init_strategy`
+                for the initialisation strategy for chains; `prior` will draw init
+                locations from prior, whereas `sir` will use Sequential-Importance-
+                Resampling using `init_strategy_num_candidates` to find init
+                locations.
             device: torch device on which to compute, e.g. gpu, cpu.
             logging_level: Minimum severity of messages to log. One of the strings
                 INFO, WARNING, DEBUG, ERROR and CRITICAL.

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -30,6 +30,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
         simulation_batch_size: int = 1,
         density_estimator: Union[str, Callable] = "maf",
         mcmc_method: str = "slice_np",
+        mcmc_parameters: Optional[Dict[str, Any]] = None,
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
         summary_writer: Optional[SummaryWriter] = None,
@@ -47,8 +48,17 @@ class LikelihoodEstimator(NeuralInference, ABC):
                 needs to return a PyTorch `nn.Module` implementing the density
                 estimator. The density estimator needs to provide the methods
                 `.log_prob` and `.sample()`.
-            mcmc_method: Specify the method for MCMC sampling, either of:
-                slice_np, slice, hmc, nuts.
+            mcmc_method: Method used for MCMC sampling, one of `slice_np`, `slice`, `hmc`, `nuts`.
+                Currently defaults to `slice_np` for a custom numpy implementation of
+                slice sampling; select `hmc`, `nuts` or `slice` for Pyro-based sampling.
+            mcmc_parameters: Dictionary overriding the default parameters for MCMC.
+                The following parameters are supported: `thin` to set the thinning
+                factor for the chain, `warmup_steps` to set the initial number of
+                samples to discard, `num_chains` for the number of chains, `init_strategy`
+                for the initialisation strategy for chains; `prior` will draw init
+                locations from prior, whereas `sir` will use Sequential-Importance-
+                Resampling using `init_strategy_num_candidates` to find init
+                locations.
 
         See docstring of `NeuralInference` class for all other arguments.
         """
@@ -78,6 +88,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
         self._posterior = None
         self._sample_with_mcmc = True
         self._mcmc_method = mcmc_method
+        self._mcmc_parameters = mcmc_parameters
 
         # SNLE-specific summary_writer fields.
         self._summary.update({"mcmc_times": []})  # type: ignore
@@ -142,6 +153,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
                     x_shape=x_shape,
                     sample_with_mcmc=self._sample_with_mcmc,
                     mcmc_method=self._mcmc_method,
+                    mcmc_parameters=self._mcmc_parameters,
                     get_potential_function=PotentialFunctionProvider(),
                 )
                 self._handle_x_o_wrt_amortization(x_o, x_shape, num_rounds)

--- a/sbi/inference/snpe/snpe_c.py
+++ b/sbi/inference/snpe/snpe_c.py
@@ -22,7 +22,7 @@ class SNPE_C(PosteriorEstimator):
         prior,
         num_workers: int = 1,
         simulation_batch_size: int = 1,
-        density_estimator: Union[str, nn.Module] = "maf",
+        density_estimator: Union[str, Callable] = "maf",
         sample_with_mcmc: bool = False,
         mcmc_method: str = "slice_np",
         mcmc_parameters: Optional[Dict[str, Any]] = None,

--- a/sbi/inference/snpe/snpe_c.py
+++ b/sbi/inference/snpe/snpe_c.py
@@ -25,6 +25,7 @@ class SNPE_C(PosteriorEstimator):
         density_estimator: Union[str, nn.Module] = "maf",
         sample_with_mcmc: bool = False,
         mcmc_method: str = "slice_np",
+        mcmc_parameters: Optional[Dict[str, Any]] = None,
         use_combined_loss: bool = False,
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
@@ -61,8 +62,17 @@ class SNPE_C(PosteriorEstimator):
                 `.log_prob` and `.sample()`.
             sample_with_mcmc: Whether to sample with MCMC. MCMC can be used to deal
                 with high leakage.
-            mcmc_method: If MCMC sampling is used, specify the method here: either of
-                slice_np, slice, hmc, nuts.
+            mcmc_method: Method used for MCMC sampling, one of `slice_np`, `slice`, `hmc`, `nuts`.
+                Currently defaults to `slice_np` for a custom numpy implementation of
+                slice sampling; select `hmc`, `nuts` or `slice` for Pyro-based sampling.
+            mcmc_parameters: Dictionary overriding the default parameters for MCMC.
+                The following parameters are supported: `thin` to set the thinning
+                factor for the chain, `warmup_steps` to set the initial number of
+                samples to discard, `num_chains` for the number of chains, `init_strategy`
+                for the initialisation strategy for chains; `prior` will draw init
+                locations from prior, whereas `sir` will use Sequential-Importance-
+                Resampling using `init_strategy_num_candidates` to find init
+                locations.
             use_combined_loss: Whether to train the neural net also on prior samples
                 using maximum likelihood in addition to training it on all samples using
                 atomic loss. The extra MLE loss helps prevent density leaking with

--- a/sbi/inference/snre/snre_a.py
+++ b/sbi/inference/snre/snre_a.py
@@ -21,6 +21,7 @@ class SNRE_A(RatioEstimator):
         simulation_batch_size: int = 1,
         classifier: Union[str, Callable] = "resnet",
         mcmc_method: str = "slice_np",
+        mcmc_parameters: Optional[Dict[str, Any]] = None,
         device: str = "cpu",
         logging_level: Union[int, str] = "warning",
         summary_writer: Optional[SummaryWriter] = None,
@@ -53,8 +54,17 @@ class SNRE_A(RatioEstimator):
                 first batch of simulations (theta, x), which can thus be used for shape
                 inference and potentially for z-scoring. It needs to return a PyTorch
                 `nn.Module` implementing the classifier.
-            mcmc_method: Specify the method for MCMC sampling, either of:
-                slice_np, slice, hmc, nuts.
+            mcmc_method: Method used for MCMC sampling, one of `slice_np`, `slice`, `hmc`, `nuts`.
+                Currently defaults to `slice_np` for a custom numpy implementation of
+                slice sampling; select `hmc`, `nuts` or `slice` for Pyro-based sampling.
+            mcmc_parameters: Dictionary overriding the default parameters for MCMC.
+                The following parameters are supported: `thin` to set the thinning
+                factor for the chain, `warmup_steps` to set the initial number of
+                samples to discard, `num_chains` for the number of chains, `init_strategy`
+                for the initialisation strategy for chains; `prior` will draw init
+                locations from prior, whereas `sir` will use Sequential-Importance-
+                Resampling using `init_strategy_num_candidates` to find init
+                locations.
             device: torch device on which to compute, e.g. gpu, cpu.
             logging_level: Minimum severity of messages to log. One of the strings
                 INFO, WARNING, DEBUG, ERROR and CRITICAL.

--- a/sbi/inference/snre/snre_b.py
+++ b/sbi/inference/snre/snre_b.py
@@ -21,6 +21,7 @@ class SNRE_B(RatioEstimator):
         simulation_batch_size: int = 1,
         classifier: Union[str, Callable] = "resnet",
         mcmc_method: str = "slice_np",
+        mcmc_parameters: Optional[Dict[str, Any]] = None,
         device: str = "cpu",
         logging_level: Union[int, str] = "warning",
         summary_writer: Optional[SummaryWriter] = None,
@@ -53,8 +54,17 @@ class SNRE_B(RatioEstimator):
                 first batch of simulations (theta, x), which can thus be used for shape
                 inference and potentially for z-scoring. It needs to return a PyTorch
                 `nn.Module` implementing the classifier.
-            mcmc_method: Specify the method for MCMC sampling, either of:
-                slice_np, slice, hmc, nuts.
+            mcmc_method: Method used for MCMC sampling, one of `slice_np`, `slice`, `hmc`, `nuts`.
+                Currently defaults to `slice_np` for a custom numpy implementation of
+                slice sampling; select `hmc`, `nuts` or `slice` for Pyro-based sampling.
+            mcmc_parameters: Dictionary overriding the default parameters for MCMC.
+                The following parameters are supported: `thin` to set the thinning
+                factor for the chain, `warmup_steps` to set the initial number of
+                samples to discard, `num_chains` for the number of chains, `init_strategy`
+                for the initialisation strategy for chains; `prior` will draw init
+                locations from prior, whereas `sir` will use Sequential-Importance-
+                Resampling using `init_strategy_num_candidates` to find init
+                locations.
             device: torch device on which to compute, e.g. gpu, cpu.
             logging_level: Minimum severity of messages to log. One of the strings
                 INFO, WARNING, DEBUG, ERROR and CRITICAL.


### PR DESCRIPTION
This PR:
- adds `mcmc_parameters` to init methods of inference methods
- fixes a bug in which `log_weights` were not detached from graph when using `sir` init strategy for MCMC 

Will merge upon one review and release as `v0.10.1`.