### PR TITLE
Add missing type imports + make compatible for Python 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ See below for the available methods of inference, `SNPE`, `SNRE` and `SNLE`.
 
 ## Installation
 
-`sbi` requires Python 3.7 or higher. It can be installed using `pip`:
+`sbi` requires Python 3.6 or higher. It can be installed using `pip`:
 ```commandline
 $ pip install sbi
 ```
@@ -35,8 +35,8 @@ We recommend to use a [`conda`](https://docs.conda.io/en/latest/miniconda.html) 
 environment ([Miniconda installation instructions](https://docs.conda.io/en/latest/miniconda.html])). If `conda` is installed on the system, an environment for
 installing `sbi` can be created as follows:
 ```commandline
-# Create an environment for sbi (indicate Python 3.7 or higher); activate it
-$ conda create -n sbi_env python=3.7 && conda activate sbi_env
+# Create an environment for sbi (indicate Python 3.6 or higher); activate it
+$ conda create -n sbi_env python=3.6 && conda activate sbi_env
 ```
 
 To test the installation, drop into a python prompt and run

--- a/sbi/inference/__init__.py
+++ b/sbi/inference/__init__.py
@@ -1,4 +1,4 @@
-from typing import List, Type  # noqa: F401
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
 from sbi.inference.base import NeuralInference, infer  # noqa: F401
 from sbi.user_input.user_input_checks import prepare_for_sbi
 

--- a/sbi/inference/__init__.py
+++ b/sbi/inference/__init__.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
 from sbi.inference.base import NeuralInference, infer  # noqa: F401
 from sbi.user_input.user_input_checks import prepare_for_sbi
 

--- a/sbi/inference/abc/abc_base.py
+++ b/sbi/inference/abc/abc_base.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 
 from abc import ABC
 from typing import Callable, Union

--- a/sbi/inference/abc/abc_base.py
+++ b/sbi/inference/abc/abc_base.py
@@ -1,6 +1,6 @@
 
 from abc import ABC
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
 
 import torch
 from torch import Tensor

--- a/sbi/inference/abc/abc_base.py
+++ b/sbi/inference/abc/abc_base.py
@@ -1,6 +1,6 @@
 
 from abc import ABC
-from typing import Callable, Union
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
 
 import torch
 from torch import Tensor

--- a/sbi/inference/abc/mcabc.py
+++ b/sbi/inference/abc/mcabc.py
@@ -1,5 +1,5 @@
 
-from typing import Callable, Optional, Tuple, Union
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
 
 import torch
 from numpy import ndarray

--- a/sbi/inference/abc/mcabc.py
+++ b/sbi/inference/abc/mcabc.py
@@ -1,5 +1,5 @@
 
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
 
 import torch
 from numpy import ndarray

--- a/sbi/inference/abc/mcabc.py
+++ b/sbi/inference/abc/mcabc.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 
 from typing import Callable, Optional, Tuple, Union
 

--- a/sbi/inference/abc/smcabc.py
+++ b/sbi/inference/abc/smcabc.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 
 import logging
 from typing import Callable, Optional, Tuple, Union

--- a/sbi/inference/abc/smcabc.py
+++ b/sbi/inference/abc/smcabc.py
@@ -1,6 +1,6 @@
 
 import logging
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
 
 import torch
 from numpy import ndarray

--- a/sbi/inference/abc/smcabc.py
+++ b/sbi/inference/abc/smcabc.py
@@ -1,6 +1,6 @@
 
 import logging
-from typing import Callable, Optional, Tuple, Union
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
 
 import torch
 from numpy import ndarray

--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -1,8 +1,6 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
-from __future__ import annotations
-
 from abc import ABC
 from copy import deepcopy
 from datetime import datetime

--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -5,7 +5,7 @@ from abc import ABC
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
 from warnings import warn
 
 import torch

--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -5,7 +5,7 @@ from abc import ABC
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Tuple, Union, cast
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast
 from warnings import warn
 
 import torch

--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -5,7 +5,7 @@ from abc import ABC
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
 from warnings import warn
 
 import torch

--- a/sbi/inference/posterior.py
+++ b/sbi/inference/posterior.py
@@ -2,7 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
 from warnings import warn
 
 import numpy as np

--- a/sbi/inference/posterior.py
+++ b/sbi/inference/posterior.py
@@ -1,7 +1,6 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
-from __future__ import annotations
 
 from typing import Callable, Optional
 from warnings import warn

--- a/sbi/inference/posterior.py
+++ b/sbi/inference/posterior.py
@@ -13,7 +13,7 @@ from torch import Tensor, log
 from torch import multiprocessing as mp
 from torch import nn
 
-import sbi.utils as utils
+from sbi import utils as utils
 from sbi.mcmc import Slice, SliceSampler
 from sbi.types import Array, Shape
 from sbi.user_input.user_input_checks import process_x

--- a/sbi/inference/posterior.py
+++ b/sbi/inference/posterior.py
@@ -2,7 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 
-from typing import Callable, Optional
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast
 from warnings import warn
 
 import numpy as np

--- a/sbi/inference/posterior.py
+++ b/sbi/inference/posterior.py
@@ -2,7 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
 from warnings import warn
 
 import numpy as np

--- a/sbi/inference/snle/snle_a.py
+++ b/sbi/inference/snle/snle_a.py
@@ -1,7 +1,6 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
-from __future__ import annotations
 
 from typing import Callable, Optional, Union
 

--- a/sbi/inference/snle/snle_a.py
+++ b/sbi/inference/snle/snle_a.py
@@ -2,7 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
 
 import torch
 from torch import Tensor

--- a/sbi/inference/snle/snle_a.py
+++ b/sbi/inference/snle/snle_a.py
@@ -2,7 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 
-from typing import Callable, Optional, Union
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast
 
 import torch
 from torch import Tensor

--- a/sbi/inference/snle/snle_a.py
+++ b/sbi/inference/snle/snle_a.py
@@ -2,7 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
 
 import torch
 from torch import Tensor

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -13,7 +13,7 @@ from torch.utils import data
 from torch.utils.data.sampler import SubsetRandomSampler
 from torch.utils.tensorboard import SummaryWriter
 
-import sbi.utils as utils
+from sbi import utils as utils
 from sbi.inference import NeuralInference
 from sbi.inference.posterior import NeuralPosterior
 from sbi.types import OneOrMore, ScalarFloat

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -3,7 +3,7 @@
 
 
 from abc import ABC
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
 
 import numpy as np
 import torch

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -1,7 +1,6 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
-from __future__ import annotations
 
 from abc import ABC
 from typing import Callable, Dict, Optional, Union

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -3,7 +3,7 @@
 
 
 from abc import ABC
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
 
 import numpy as np
 import torch

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -3,7 +3,7 @@
 
 
 from abc import ABC
-from typing import Callable, Dict, Optional, Union
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast
 
 import numpy as np
 import torch

--- a/sbi/inference/snpe/snpe_a.py
+++ b/sbi/inference/snpe/snpe_a.py
@@ -1,7 +1,6 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
-from __future__ import annotations
 
 from typing import Callable, Optional, Union
 

--- a/sbi/inference/snpe/snpe_a.py
+++ b/sbi/inference/snpe/snpe_a.py
@@ -2,7 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
 
 import torch
 from torch import nn

--- a/sbi/inference/snpe/snpe_a.py
+++ b/sbi/inference/snpe/snpe_a.py
@@ -2,7 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 
-from typing import Callable, Optional, Union
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
 
 import torch
 from torch import nn

--- a/sbi/inference/snpe/snpe_b.py
+++ b/sbi/inference/snpe/snpe_b.py
@@ -1,7 +1,6 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
-from __future__ import annotations
 
 from typing import Callable, Optional, Union
 

--- a/sbi/inference/snpe/snpe_b.py
+++ b/sbi/inference/snpe/snpe_b.py
@@ -2,7 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 
-from typing import Callable, Optional, Union
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
 
 import torch
 from torch import Tensor, nn

--- a/sbi/inference/snpe/snpe_b.py
+++ b/sbi/inference/snpe/snpe_b.py
@@ -2,7 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
 
 import torch
 from torch import Tensor, nn

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -1,7 +1,6 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
-from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from copy import deepcopy

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -5,7 +5,7 @@
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from sbi.user_input.user_input_checks import check_estimator_arg
-from typing import Callable, Dict, Optional, Tuple, Union, cast
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast
 from warnings import warn
 
 import numpy as np

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -5,7 +5,7 @@
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from sbi.user_input.user_input_checks import check_estimator_arg
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
 from warnings import warn
 
 import numpy as np

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -16,7 +16,7 @@ from torch.utils import data
 from torch.utils.data.sampler import SubsetRandomSampler
 from torch.utils.tensorboard import SummaryWriter
 
-import sbi.utils as utils
+from sbi import utils as utils
 from sbi.inference import NeuralInference
 from sbi.inference.posterior import NeuralPosterior
 from sbi.types import OneOrMore, ScalarFloat

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -5,7 +5,7 @@
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from sbi.user_input.user_input_checks import check_estimator_arg
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
 from warnings import warn
 
 import numpy as np

--- a/sbi/inference/snpe/snpe_c.py
+++ b/sbi/inference/snpe/snpe_c.py
@@ -1,7 +1,6 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
-from __future__ import annotations
 
 from typing import Callable, Optional, Union
 

--- a/sbi/inference/snpe/snpe_c.py
+++ b/sbi/inference/snpe/snpe_c.py
@@ -2,7 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
 
 import torch
 from torch import Tensor, eye, nn, ones

--- a/sbi/inference/snpe/snpe_c.py
+++ b/sbi/inference/snpe/snpe_c.py
@@ -2,7 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 
-from typing import Callable, Optional, Union
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
 
 import torch
 from torch import Tensor, eye, nn, ones

--- a/sbi/inference/snre/snre_a.py
+++ b/sbi/inference/snre/snre_a.py
@@ -1,5 +1,5 @@
 
-from typing import Callable, Optional, Union
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union
 
 import torch
 from torch import Tensor, nn, ones

--- a/sbi/inference/snre/snre_a.py
+++ b/sbi/inference/snre/snre_a.py
@@ -1,5 +1,5 @@
 
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
 
 import torch
 from torch import Tensor, nn, ones

--- a/sbi/inference/snre/snre_a.py
+++ b/sbi/inference/snre/snre_a.py
@@ -1,5 +1,5 @@
 
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
 
 import torch
 from torch import Tensor, nn, ones

--- a/sbi/inference/snre/snre_a.py
+++ b/sbi/inference/snre/snre_a.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 
 from typing import Callable, Optional, Union
 

--- a/sbi/inference/snre/snre_b.py
+++ b/sbi/inference/snre/snre_b.py
@@ -1,5 +1,5 @@
 
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
 
 import torch
 from torch import Tensor

--- a/sbi/inference/snre/snre_b.py
+++ b/sbi/inference/snre/snre_b.py
@@ -1,5 +1,5 @@
 
-from typing import Callable, Optional, Union
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union
 
 import torch
 from torch import Tensor

--- a/sbi/inference/snre/snre_b.py
+++ b/sbi/inference/snre/snre_b.py
@@ -1,5 +1,5 @@
 
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
 
 import torch
 from torch import Tensor

--- a/sbi/inference/snre/snre_b.py
+++ b/sbi/inference/snre/snre_b.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 
 from typing import Callable, Optional, Union
 

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -1,6 +1,6 @@
 
 from abc import ABC, abstractmethod
-from typing import Callable, Dict, Optional, Union
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
 
 import numpy as np
 import torch

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -10,7 +10,7 @@ from torch.utils import data
 from torch.utils.data.sampler import SubsetRandomSampler
 from torch.utils.tensorboard import SummaryWriter
 
-import sbi.utils as utils
+from sbi import utils as utils
 from sbi.inference.base import NeuralInference
 from sbi.inference.posterior import NeuralPosterior
 from sbi.types import OneOrMore, ScalarFloat

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from typing import Callable, Dict, Optional, Union

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -1,6 +1,6 @@
 
 from abc import ABC, abstractmethod
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
 
 import numpy as np
 import torch

--- a/sbi/neural_nets/classifier.py
+++ b/sbi/neural_nets/classifier.py
@@ -1,7 +1,6 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
-from __future__ import annotations
 
 import torch
 from pyknos.nflows.nn import nets

--- a/sbi/neural_nets/flow.py
+++ b/sbi/neural_nets/flow.py
@@ -1,7 +1,6 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
-from __future__ import annotations
 
 from warnings import warn
 

--- a/sbi/neural_nets/mdn.py
+++ b/sbi/neural_nets/mdn.py
@@ -1,7 +1,6 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
-from __future__ import annotations
 
 from pyknos.mdn.mdn import MultivariateGaussianMDN
 from pyknos.nflows import flows, transforms

--- a/sbi/simulators/linear_gaussian.py
+++ b/sbi/simulators/linear_gaussian.py
@@ -1,7 +1,6 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
-from __future__ import annotations
 
 from typing import Union, Tuple
 

--- a/sbi/simulators/linear_gaussian.py
+++ b/sbi/simulators/linear_gaussian.py
@@ -2,7 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
 
 import torch
 from torch import Tensor

--- a/sbi/simulators/linear_gaussian.py
+++ b/sbi/simulators/linear_gaussian.py
@@ -2,7 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 
-from typing import Union, Tuple
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
 
 import torch
 from torch import Tensor

--- a/sbi/simulators/simutils.py
+++ b/sbi/simulators/simutils.py
@@ -2,7 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 
-from typing import Callable
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
 
 import torch
 from torch import Tensor

--- a/sbi/simulators/simutils.py
+++ b/sbi/simulators/simutils.py
@@ -1,7 +1,6 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
-from __future__ import annotations
 
 from typing import Callable
 

--- a/sbi/simulators/simutils.py
+++ b/sbi/simulators/simutils.py
@@ -2,7 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
 
 import torch
 from torch import Tensor

--- a/sbi/types.py
+++ b/sbi/types.py
@@ -2,7 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
 import numpy as np
 import torch
 

--- a/sbi/types.py
+++ b/sbi/types.py
@@ -1,7 +1,6 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
-from __future__ import annotations
 
 from typing import Sequence, Union, Tuple, TypeVar
 import numpy as np

--- a/sbi/types.py
+++ b/sbi/types.py
@@ -2,7 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 
-from typing import Sequence, Union, Tuple, TypeVar
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
 import numpy as np
 import torch
 

--- a/sbi/user_input/user_input_checks.py
+++ b/sbi/user_input/user_input_checks.py
@@ -1,7 +1,6 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
-from __future__ import annotations
 
 import warnings
 from typing import Callable, Optional, Sequence, Tuple, Union, cast

--- a/sbi/user_input/user_input_checks.py
+++ b/sbi/user_input/user_input_checks.py
@@ -3,7 +3,7 @@
 
 
 import warnings
-from typing import Callable, Optional, Sequence, Tuple, Union, cast
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
 
 import torch
 from numpy import ndarray

--- a/sbi/user_input/user_input_checks.py
+++ b/sbi/user_input/user_input_checks.py
@@ -3,7 +3,7 @@
 
 
 import warnings
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
 
 import torch
 from numpy import ndarray

--- a/sbi/user_input/user_input_checks_utils.py
+++ b/sbi/user_input/user_input_checks_utils.py
@@ -1,7 +1,6 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
-from __future__ import annotations
 
 import warnings
 from typing import Optional, Sequence, Union

--- a/sbi/user_input/user_input_checks_utils.py
+++ b/sbi/user_input/user_input_checks_utils.py
@@ -3,7 +3,7 @@
 
 
 import warnings
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
 
 import torch
 from scipy.stats._distn_infrastructure import rv_frozen

--- a/sbi/user_input/user_input_checks_utils.py
+++ b/sbi/user_input/user_input_checks_utils.py
@@ -170,7 +170,7 @@ class MultipleIndependent(Distribution):
 
     def __init__(
         self, dists: Sequence[Distribution], validate_args=None,
-    ) -> MultipleIndependent:
+    ):
         self._check_distributions(dists)
 
         self.dists = dists

--- a/sbi/user_input/user_input_checks_utils.py
+++ b/sbi/user_input/user_input_checks_utils.py
@@ -3,7 +3,7 @@
 
 
 import warnings
-from typing import Optional, Sequence, Union
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
 
 import torch
 from scipy.stats._distn_infrastructure import rv_frozen

--- a/sbi/utils/get_nn_models.py
+++ b/sbi/utils/get_nn_models.py
@@ -2,7 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 
-from typing import Any, Callable
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
 from sbi.neural_nets.flow import build_made, build_maf, build_nsf
 from sbi.neural_nets.mdn import build_mdn
 from sbi.neural_nets.classifier import (

--- a/sbi/utils/get_nn_models.py
+++ b/sbi/utils/get_nn_models.py
@@ -1,7 +1,6 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
-from __future__ import annotations
 
 from typing import Any, Callable
 from sbi.neural_nets.flow import build_made, build_maf, build_nsf

--- a/sbi/utils/get_nn_models.py
+++ b/sbi/utils/get_nn_models.py
@@ -2,7 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
 from sbi.neural_nets.flow import build_made, build_maf, build_nsf
 from sbi.neural_nets.mdn import build_mdn
 from sbi.neural_nets.classifier import (

--- a/sbi/utils/metrics.py
+++ b/sbi/utils/metrics.py
@@ -4,7 +4,7 @@
 import numpy as np
 import torch
 
-from typing import Optional
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
 from torch import Tensor
 
 from sklearn.model_selection import KFold, cross_val_score

--- a/sbi/utils/metrics.py
+++ b/sbi/utils/metrics.py
@@ -4,7 +4,7 @@
 import numpy as np
 import torch
 
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
 from torch import Tensor
 
 from sklearn.model_selection import KFold, cross_val_score

--- a/sbi/utils/plot.py
+++ b/sbi/utils/plot.py
@@ -7,7 +7,7 @@ from typing import Optional, Tuple, Union, List
 
 import torch
 import matplotlib as mpl
-import matplotlib.pyplot as plt
+from matplotlib import pyplot as plt
 import numpy as np
 import six
 from scipy.stats import gaussian_kde

--- a/sbi/utils/plot.py
+++ b/sbi/utils/plot.py
@@ -3,7 +3,7 @@
 
 import collections
 import inspect
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
 
 import torch
 import matplotlib as mpl

--- a/sbi/utils/plot.py
+++ b/sbi/utils/plot.py
@@ -3,7 +3,7 @@
 
 import collections
 import inspect
-from typing import Optional, Tuple, Union, List
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
 
 import torch
 import matplotlib as mpl

--- a/sbi/utils/pyroutils.py
+++ b/sbi/utils/pyroutils.py
@@ -1,7 +1,7 @@
 from typing import Callable, Any
 
-import pyro.distributions as dist
-import pyro.poutine as poutine
+from pyro import distributions as dist
+from pyro import poutine as poutine
 from torch.distributions import biject_to
 
 

--- a/sbi/utils/pyroutils.py
+++ b/sbi/utils/pyroutils.py
@@ -1,4 +1,4 @@
-from typing import Callable, Any
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
 
 from pyro import distributions as dist
 from pyro import poutine as poutine

--- a/sbi/utils/pyroutils.py
+++ b/sbi/utils/pyroutils.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
 
 from pyro import distributions as dist
 from pyro import poutine as poutine

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -2,7 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 import logging
-from typing import Any, Dict, List, Sequence, Tuple
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
 
 import torch
 from torch import nn as nn

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any, Dict, List, Sequence, Tuple
 
 import torch
-import torch.nn as nn
+from torch import nn as nn
 from pyknos.nflows import transforms
 from torch import Tensor, as_tensor, ones, zeros
 from tqdm.auto import tqdm

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -2,7 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 import logging
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
 
 import torch
 from torch import nn as nn

--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -7,7 +7,7 @@ import numpy as np
 import torch
 from torch import Tensor, float32, device
 from torch.distributions import Independent, Uniform
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
 import warnings
 
 from sbi import utils as utils

--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -7,7 +7,7 @@ import numpy as np
 import torch
 from torch import Tensor, float32, device
 from torch.distributions import Independent, Uniform
-from typing import Union
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
 import warnings
 
 from sbi import utils as utils

--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -10,7 +10,7 @@ from torch.distributions import Independent, Uniform
 from typing import Union
 import warnings
 
-import sbi.utils as utils
+from sbi import utils as utils
 from sbi.types import Array, OneOrMore, ScalarFloat
 
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ REQUIRED = [
     "pillow",
     "pyro-ppl",
     "pyknos==0.11",
+    "nflows @ git+https://github.com/bayesiains/nflows.git@84dc0298d99cc3bee9650a1501ef6aa578558080#egg=nflows",
     "scipy",
     "tensorboard",
     "torch>=1.5.1",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ REQUIRED = [
     "pillow",
     "pyro-ppl",
     "pyknos==0.11",
-    "nflows @ git+https://github.com/bayesiains/nflows.git@84dc0298d99cc3bee9650a1501ef6aa578558080#egg=nflows",
+    "nflows==0.12", #Remove once pyknos is updated to 0.12
     "scipy",
     "tensorboard",
     "torch>=1.5.1",

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ DESCRIPTION = "Simulation-based inference."
 URL = "https://github.com/mackelab/sbi"
 EMAIL = "sbi@mackelab.org"
 AUTHOR = "Álvaro Tejero-Cantero, Jakob H. Macke, Jan-Matthis Lückmann, Conor M. Durkan, Michael Deistler, Jan Bölts"
-REQUIRES_PYTHON = ">=3.7.0"
+REQUIRES_PYTHON = ">=3.6.0"
 
 REQUIRED = [
     "joblib",

--- a/tests/inference_with_NaN_simulator_test.py
+++ b/tests/inference_with_NaN_simulator_test.py
@@ -8,7 +8,7 @@ import torch
 from sbi.inference import SNPE_C, SRE, SNL, prepare_for_sbi
 from torch import zeros, ones, eye
 
-import sbi.utils as utils
+from sbi import utils as utils
 
 from sbi.simulators.linear_gaussian import (
     samples_true_posterior_linear_gaussian_uniform_prior,

--- a/tests/linearGaussian_snle_test.py
+++ b/tests/linearGaussian_snle_test.py
@@ -7,7 +7,7 @@ import pytest
 from torch import eye, ones, zeros
 from torch.distributions import MultivariateNormal
 
-import sbi.utils as utils
+from sbi import utils as utils
 from sbi.inference import SNL, prepare_for_sbi
 from sbi.simulators.linear_gaussian import (
     diagonal_linear_gaussian,

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -8,7 +8,7 @@ import pytest
 from torch import eye, ones, zeros
 from torch.distributions import MultivariateNormal
 
-import sbi.utils as utils
+from sbi import utils as utils
 from sbi.inference import SNPE_B, SNPE_C, prepare_for_sbi
 from sbi.simulators.linear_gaussian import (
     linear_gaussian,

--- a/tests/linearGaussian_snre_test.py
+++ b/tests/linearGaussian_snre_test.py
@@ -7,7 +7,7 @@ import pytest
 from torch import eye, ones, zeros
 from torch.distributions import MultivariateNormal
 
-import sbi.utils as utils
+from sbi import utils as utils
 from sbi.inference import AALR, SRE, prepare_for_sbi
 from sbi.simulators.linear_gaussian import (
     diagonal_linear_gaussian,

--- a/tests/mcmc_slice_pyro/test_slice.py
+++ b/tests/mcmc_slice_pyro/test_slice.py
@@ -6,9 +6,9 @@ import os
 from collections import namedtuple
 
 import pyro
-import pyro.distributions as dist
-import pyro.optim as optim
-import pyro.poutine as poutine
+from pyro import distributions as dist
+from pyro import optim as optim
+from pyro import poutine as poutine
 import pytest
 import torch
 from pyro.contrib.conjugate.infer import (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Union, Tuple
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
 
 import torch
 from torch import Tensor

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
 
 import torch
 from torch import Tensor

--- a/tests/torchutils_test.py
+++ b/tests/torchutils_test.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import numpy as np
 import torch
-import torch.distributions as distributions
+from torch import distributions as distributions
 import torchtestcase
 
 from sbi.utils import torchutils

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 from sbi.utils.get_nn_models import posterior_nn
 
-from typing import Callable
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
 
 import pytest
 import torch

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 from sbi.utils.get_nn_models import posterior_nn
 
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List
+from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
 
 import pytest
 import torch


### PR DESCRIPTION
This is a work in progress PR.

I'm interested in hearing your comments. I performed some simple changes throughout the codebase to make it compatible for Python 3.6. The reason 3.6 would be of special interest is because the popular ML platform "[Google Colaboratory](https://colab.research.google.com/)" (used for freely demonstrating and sharing work requiring GPUs + a complex build environment) is exclusively on Python 3.6. 

Changes include:

- Removed all `from __future__ import annotations` statements.
- Fixed all statements like `import sbi.utils as utils` to `from sbi import utils as utils`, since the first is incompatible with 3.6.
- Also fixed this with `nflows` by changing nflows version from v0.11 to git commit https://github.com/bayesiains/nflows/commit/84dc0298d99cc3bee9650a1501ef6aa578558080 in `setup.py` (so it installs from git rather than from pypi). From a skim through the commit history, no major changes were added from v0.11 to this commit. 
- Imported common types for all files which use type-checking. Many files used types which were not directly imported, so I just added all the common types to all files. 