### PR TITLE
Subclassing posterior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.11.2
+- Subclassed Posterior (#282)
+
+
 # v0.11.1
 - Bug fix for log_prob() in SNRE (#280)
 

--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -34,9 +34,17 @@
     rendering:
       show_root_heading: true
 
-## Posterior
+## Posteriors
 
-::: sbi.inference.posterior.NeuralPosterior
+::: sbi.inference.posteriors.snpe_posterior.SNPE_Posterior
+    rendering:
+      show_root_heading: true
+      
+::: sbi.inference.posteriors.snle_posterior.SNLE_Posterior
+    rendering:
+      show_root_heading: true
+      
+::: sbi.inference.posteriors.snre_posterior.SNRE_Posterior
     rendering:
       show_root_heading: true
 

--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -13,40 +13,64 @@
 ::: sbi.inference.snpe.snpe_c.SNPE_C
     rendering:
       show_root_heading: true
+    selection:
+      filters: [ "!^_", "^__", "!^__class__" ]
+      inherited_members: true
 
 ::: sbi.inference.snle.snle_a.SNLE_A
     rendering:
       show_root_heading: true
+    selection:
+      filters: [ "!^_", "^__", "!^__class__" ]
+      inherited_members: true
 
 ::: sbi.inference.snre.snre_a.SNRE_A
     rendering:
       show_root_heading: true
+    selection:
+      filters: [ "!^_", "^__", "!^__class__" ]
+      inherited_members: true
 
 ::: sbi.inference.snre.snre_b.SNRE_B
     rendering:
       show_root_heading: true
+    selection:
+      filters: [ "!^_", "^__", "!^__class__" ]
+      inherited_members: true
 
 ::: sbi.inference.abc.mcabc.MCABC
     rendering:
       show_root_heading: true
+    selection:
+      filters: [ "!^_", "^__", "!^__class__" ]
+      inherited_members: true
 
 ::: sbi.inference.abc.smcabc.SMCABC
     rendering:
       show_root_heading: true
+    selection:
+      filters: [ "!^_", "^__", "!^__class__" ]
+      inherited_members: true
 
 ## Posteriors
 
 ::: sbi.inference.posteriors.snpe_posterior.SNPE_Posterior
     rendering:
       show_root_heading: true
+    selection:
+      inherited_members: true
       
 ::: sbi.inference.posteriors.snle_posterior.SNLE_Posterior
     rendering:
       show_root_heading: true
+    selection:
+      inherited_members: true
       
 ::: sbi.inference.posteriors.snre_posterior.SNRE_Posterior
     rendering:
       show_root_heading: true
+    selection:
+      inherited_members: true
 
 ## Models
 

--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -171,7 +171,7 @@ class NeuralInference(ABC):
             theta: Parameter sets used to generate presimulated data.
             x: Simulation outputs of presimulated data.
             from_round: Which round the data was simulated from. `from_round=0` means
-                that the data came from the first round.
+                that the data came from the first round, i.e. the prior.
         """
         self._append_to_data_bank(theta, x, from_round)
 

--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -13,7 +13,7 @@ from torch import Tensor
 from torch.utils.tensorboard import SummaryWriter
 
 import sbi.inference
-from sbi.inference.posteriors.posterior import NeuralPosterior
+from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.simulators.simutils import simulate_in_batches
 from sbi.user_input.user_input_checks import prepare_for_sbi
 from sbi.utils import (

--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -5,18 +5,7 @@ from abc import ABC
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 from warnings import warn
 
 import torch
@@ -24,7 +13,7 @@ from torch import Tensor
 from torch.utils.tensorboard import SummaryWriter
 
 import sbi.inference
-from sbi.inference.posterior import NeuralPosterior
+from sbi.inference.posteriors.posterior import NeuralPosterior
 from sbi.simulators.simutils import simulate_in_batches
 from sbi.user_input.user_input_checks import prepare_for_sbi
 from sbi.utils import (

--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -213,9 +213,6 @@ class NeuralPosterior:
             often as there were batch elements in $\theta$ orginally.
         """
 
-        # TODO Train exited here, entered after sampling?
-        self.net.eval()
-
         theta = ensure_theta_batched(torch.as_tensor(theta))
 
         # Select and check x to condition on.

--- a/sbi/inference/posteriors/snle_posterior.py
+++ b/sbi/inference/posteriors/snle_posterior.py
@@ -89,6 +89,10 @@ class SNLE_Posterior(NeuralPosterior):
             `(len(θ),)`-shaped log-probability $\log(p(x|\theta) \cdot p(\theta))$.
 
         """
+
+        # TODO Train exited here, entered after sampling?
+        self.net.eval()
+
         theta, x = self._prepare_theta_and_x_for_log_prob_(theta, x)
 
         warn(

--- a/sbi/inference/posteriors/snle_posterior.py
+++ b/sbi/inference/posteriors/snle_posterior.py
@@ -1,0 +1,156 @@
+# This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
+# under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
+
+from copy import deepcopy
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+)
+from warnings import warn
+
+import numpy as np
+import torch
+from pyro.infer.mcmc import HMC, NUTS
+from pyro.infer.mcmc.api import MCMC
+from torch import Tensor, log
+from torch import multiprocessing as mp
+from torch import nn
+
+from sbi import utils as utils
+from sbi.inference.posteriors.posterior import NeuralPosterior
+from sbi.mcmc import Slice, SliceSampler
+from sbi.types import Array, Shape
+from sbi.user_input.user_input_checks import process_x
+from sbi.utils import del_entries
+from sbi.utils.torchutils import (
+    atleast_2d_float32_tensor,
+    batched_first_of_batch,
+    ensure_theta_batched,
+)
+
+
+class SnlePosterior(NeuralPosterior):
+    r"""Posterior $p(\theta|x)$ with `log_prob()` and `sample()` methods.<br/><br/>
+    All inference methods in sbi train a neural network which is then used to obtain
+    the posterior distribution. The `NeuralPosterior` class wraps the trained network
+    such that one can directly evaluate the log probability and draw samples from the
+    posterior. The neural network itself can be accessed via the `.net` attribute.
+    <br/><br/>
+    Specifically, this class offers the following functionality:<br/>
+    - Correction of leakage (applicable only to SNPE): If the prior is bounded, the
+      posterior resulting from SNPE can generate samples that lie outside of the prior
+      support (i.e. the posterior leaks). This class rejects these samples or,
+      alternatively, allows to sample from the posterior with MCMC. It also corrects the
+      calculation of the log probability such that it compensates for the leakage.<br/>
+    - Posterior inference from likelihood (SNL) and likelihood ratio (SRE): SNL and SRE
+      learn to approximate the likelihood and likelihood ratio, which in turn can be
+      used to generate samples from the posterior. This class provides the needed MCMC
+      methods to sample from the posterior and to evaluate the log probability.
+
+    """
+
+    def __init__(
+        self,
+        method_family: str,
+        neural_net: nn.Module,
+        prior,
+        x_shape: torch.Size,
+        mcmc_method: str = "slice_np",
+        mcmc_parameters: Optional[Dict[str, Any]] = None,
+        get_potential_function: Optional[Callable] = None,
+    ):
+        """
+        Args:
+            method_family: One of snpe, snl, snre_a or snre_b.
+            neural_net: A classifier for SNRE, a density estimator for SNPE and SNL.
+            prior: Prior distribution with `.log_prob()` and `.sample()`.
+            x_shape: Shape of a single simulator output.
+            mcmc_method: Method used for MCMC sampling, one of `slice_np`, `slice`, `hmc`, `nuts`.
+                Currently defaults to `slice_np` for a custom numpy implementation of
+                slice sampling; select `hmc`, `nuts` or `slice` for Pyro-based sampling.
+            mcmc_parameters: Dictionary overriding the default parameters for MCMC.
+                The following parameters are supported: `thin` to set the thinning
+                factor for the chain, `warmup_steps` to set the initial number of
+                samples to discard, `num_chains` for the number of chains, `init_strategy`
+                for the initialisation strategy for chains; `prior` will draw init
+                locations from prior, whereas `sir` will use Sequential-Importance-
+                Resampling using `init_strategy_num_candidates` to find init
+                locations.
+            get_potential_function: Callable that returns the potential function used
+                for MCMC sampling.
+        """
+        kwargs = del_entries(locals(), entries=("self", "__class__"))
+        super().__init__(**kwargs)
+
+    def _log_prob_snle(self, theta: Tensor, x: Tensor) -> Tensor:
+        warn(
+            "The log probability from SNL is only correct up to a normalizing constant."
+        )
+        return self.net.log_prob(x, theta) + self._prior.log_prob(theta)
+
+    def sample(
+        self,
+        sample_shape: Shape = torch.Size(),
+        x: Optional[Tensor] = None,
+        show_progress_bars: bool = True,
+        sample_with_mcmc: Optional[bool] = None,
+        mcmc_method: Optional[str] = None,
+        mcmc_parameters: Optional[Dict[str, Any]] = None,
+    ) -> Tensor:
+        r"""
+        Return samples from posterior distribution $p(\theta|x)$.
+
+        Samples are obtained either with rejection sampling or MCMC. SNPE can use
+        rejection sampling and MCMC (which can help to deal with strong leakage). SNL
+        and SRE are restricted to sampling with MCMC.
+
+        Args:
+            sample_shape: Desired shape of samples that are drawn from posterior. If
+                sample_shape is multidimensional we simply draw `sample_shape.numel()`
+                samples and then reshape into the desired shape.
+            x: Conditioning context for posterior $p(\theta|x)$. If not provided,
+                fall back onto `x_o` if previously provided for multiround training, or
+                to a set default (see `set_default_x()` method).
+            show_progress_bars: Whether to show sampling progress monitor.
+            sample_with_mcmc: Optional parameter to override `self.sample_with_mcmc`.
+            mcmc_method: Optional parameter to override `self.mcmc_method`.
+            mcmc_parameters: Dictionary overriding the default parameters for MCMC.
+                The following parameters are supported: `thin` to set the thinning
+                factor for the chain, `warmup_steps` to set the initial number of
+                samples to discard, `num_chains` for the number of chains, `init_strategy`
+                for the initialisation strategy for chains; `prior` will draw init
+                locations from prior, whereas `sir` will use Sequential-Importance-
+                Resampling using `init_strategy_num_candidates` to find init
+                locations.
+
+        Returns:
+            Samples from posterior.
+        """
+
+        x = atleast_2d_float32_tensor(self._x_else_default_x(x))
+        self._ensure_single_x(x)
+        self._ensure_x_consistent_with_default_x(x)
+        num_samples = torch.Size(sample_shape).numel()
+
+        mcmc_method = mcmc_method if mcmc_method is not None else self.mcmc_method
+        mcmc_parameters = (
+            mcmc_parameters if mcmc_parameters is not None else self.mcmc_parameters
+        )
+
+        samples = self._sample_posterior_mcmc(
+            x=x,
+            num_samples=num_samples,
+            show_progress_bars=show_progress_bars,
+            mcmc_method=mcmc_method,
+            **mcmc_parameters,
+        )
+
+        return samples.reshape((*sample_shape, -1))

--- a/sbi/inference/posteriors/snpe_posterior.py
+++ b/sbi/inference/posteriors/snpe_posterior.py
@@ -1,0 +1,268 @@
+# This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
+# under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
+
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+)
+
+import torch
+from torch import Tensor, log, nn
+
+from sbi import utils as utils
+from sbi.inference.posteriors.posterior import NeuralPosterior
+from sbi.types import Shape
+from sbi.utils import del_entries
+from sbi.utils.torchutils import atleast_2d_float32_tensor, batched_first_of_batch
+
+
+class SnpePosterior(NeuralPosterior):
+    r"""Posterior $p(\theta|x)$ with `log_prob()` and `sample()` methods.<br/><br/>
+    All inference methods in sbi train a neural network which is then used to obtain
+    the posterior distribution. The `NeuralPosterior` class wraps the trained network
+    such that one can directly evaluate the log probability and draw samples from the
+    posterior. The neural network itself can be accessed via the `.net` attribute.
+    <br/><br/>
+    Specifically, this class offers the following functionality:<br/>
+    - Correction of leakage (applicable only to SNPE): If the prior is bounded, the
+      posterior resulting from SNPE can generate samples that lie outside of the prior
+      support (i.e. the posterior leaks). This class rejects these samples or,
+      alternatively, allows to sample from the posterior with MCMC. It also corrects the
+      calculation of the log probability such that it compensates for the leakage.<br/>
+    - Posterior inference from likelihood (SNL) and likelihood ratio (SRE): SNL and SRE
+      learn to approximate the likelihood and likelihood ratio, which in turn can be
+      used to generate samples from the posterior. This class provides the needed MCMC
+      methods to sample from the posterior and to evaluate the log probability.
+
+    """
+
+    def __init__(
+        self,
+        method_family: str,
+        neural_net: nn.Module,
+        prior,
+        x_shape: torch.Size,
+        sample_with_mcmc: bool = True,
+        mcmc_method: str = "slice_np",
+        mcmc_parameters: Optional[Dict[str, Any]] = None,
+        get_potential_function: Optional[Callable] = None,
+    ):
+        """
+        Args:
+            method_family: One of snpe, snl, snre_a or snre_b.
+            neural_net: A classifier for SNRE, a density estimator for SNPE and SNL.
+            prior: Prior distribution with `.log_prob()` and `.sample()`.
+            x_shape: Shape of a single simulator output.
+            sample_with_mcmc: Whether to sample with MCMC. Will always be `True` for SRE
+                and SNL, but can also be set to `True` for SNPE if MCMC is preferred to
+                deal with leakage over rejection sampling.
+            mcmc_method: Method used for MCMC sampling, one of `slice_np`, `slice`,
+                `hmc`, `nuts`. Currently defaults to `slice_np` for a custom numpy
+                implementation of slice sampling; select `hmc`, `nuts` or `slice` for
+                Pyro-based sampling.
+            mcmc_parameters: Dictionary overriding the default parameters for MCMC.
+                The following parameters are supported: `thin` to set the thinning
+                factor for the chain, `warmup_steps` to set the initial number of
+                samples to discard, `num_chains` for the number of chains, `init_strategy`
+                for the initialisation strategy for chains; `prior` will draw init
+                locations from prior, whereas `sir` will use Sequential-Importance-
+                Resampling using `init_strategy_num_candidates` to find init
+                locations.
+            get_potential_function: Callable that returns the potential function used
+                for MCMC sampling.
+        """
+
+        kwargs = del_entries(
+            locals(), entries=("self", "__class__", "sample_with_mcmc")
+        )
+        super().__init__(**kwargs)
+
+        self.set_sample_with_mcmc(sample_with_mcmc)
+
+    @property
+    def sample_with_mcmc(self) -> bool:
+        """
+        Return `True` if NeuralPosterior instance should use MCMC in `.sample()`.
+        """
+        return self._sample_with_mcmc
+
+    @sample_with_mcmc.setter
+    def sample_with_mcmc(self, value: bool) -> None:
+        """See `set_sample_with_mcmc`."""
+        self.set_sample_with_mcmc(value)
+
+    def set_sample_with_mcmc(self, use_mcmc: bool) -> "NeuralPosterior":
+        """Turns MCMC sampling on or off and returns `NeuralPosterior`.
+
+        Args:
+            use_mcmc: Flag to set whether or not MCMC sampling is used.
+
+        Returns:
+            `NeuralPosterior` for chainable calls.
+
+        Raises:
+            `ValueError` on attempt to turn off MCMC sampling for family of methods
+            that do not support rejection sampling.
+        """
+        if not use_mcmc:
+            if self._method_family not in ["snpe"]:
+                raise ValueError(f"{self._method_family} cannot use MCMC for sampling.")
+        self._sample_with_mcmc = use_mcmc
+        return self
+
+    def _log_prob_snpe(self, theta: Tensor, x: Tensor, norm_posterior: bool) -> Tensor:
+        r"""
+        Return posterior log probability $p(\theta|x)$.
+
+        The posterior probability will be only normalized if explicitly requested,
+        but it will be always zeroed out (i.e. given -∞ log-prob) outside the prior
+        support.
+        """
+
+        unnorm_log_prob = self.net.log_prob(theta, x)
+
+        # Force probability to be zero outside prior support.
+        is_prior_finite = torch.isfinite(self._prior.log_prob(theta))
+
+        masked_log_prob = torch.where(
+            is_prior_finite,
+            unnorm_log_prob,
+            torch.tensor(float("-inf"), dtype=torch.float32),
+        )
+
+        log_factor = (
+            log(self.leakage_correction(x=batched_first_of_batch(x)))
+            if norm_posterior
+            else 0
+        )
+
+        return masked_log_prob - log_factor
+
+    @torch.no_grad()
+    def leakage_correction(
+        self,
+        x: Tensor,
+        num_rejection_samples: int = 10_000,
+        force_update: bool = False,
+        show_progress_bars: bool = False,
+    ) -> Tensor:
+        r"""Return leakage correction factor for a leaky posterior density estimate.
+
+        The factor is estimated from the acceptance probability during rejection
+        sampling from the posterior.
+
+        NOTE: This is to avoid re-estimating the acceptance probability from scratch
+              whenever `log_prob` is called and `norm_posterior_snpe=True`. Here, it
+              is estimated only once for `self.default_x` and saved for later. We
+              re-evaluate only whenever a new `x` is passed.
+
+        Arguments:
+            x: Conditioning context for posterior $p(\theta|x)$.
+            num_rejection_samples: Number of samples used to estimate correction factor.
+            force_update: Whether to force a reevaluation of the leakage correction even
+                if the context `x` is the same as `self.default_x`. This is useful to
+                enforce a new leakage estimate for rounds after the first (2, 3,..).
+            show_progress_bars: Whether to show a progress bar during sampling.
+
+        Returns:
+            Saved or newly-estimated correction factor (as a scalar `Tensor`).
+        """
+
+        def acceptance_at(x: Tensor) -> Tensor:
+            return utils.sample_posterior_within_prior(
+                self.net, self._prior, x, num_rejection_samples, show_progress_bars
+            )[1]
+
+        # Check if the provided x matches the default x (short-circuit on identity).
+        is_new_x = self.default_x is None or (
+            x is not self.default_x and (x != self.default_x).any()
+        )
+
+        not_saved_at_default_x = self._leakage_density_correction_factor is None
+
+        if is_new_x:  # Calculate at x; don't save.
+            return acceptance_at(x)
+        elif not_saved_at_default_x or force_update:  # Calculate at default_x; save.
+            self._leakage_density_correction_factor = acceptance_at(self.default_x)
+
+        return self._leakage_density_correction_factor  # type:ignore
+
+    def sample(
+        self,
+        sample_shape: Shape = torch.Size(),
+        x: Optional[Tensor] = None,
+        show_progress_bars: bool = True,
+        sample_with_mcmc: Optional[bool] = None,
+        mcmc_method: Optional[str] = None,
+        mcmc_parameters: Optional[Dict[str, Any]] = None,
+    ) -> Tensor:
+        r"""
+        Return samples from posterior distribution $p(\theta|x)$.
+
+        Samples are obtained either with rejection sampling or MCMC. SNPE can use
+        rejection sampling and MCMC (which can help to deal with strong leakage). SNL
+        and SRE are restricted to sampling with MCMC.
+
+        Args:
+            sample_shape: Desired shape of samples that are drawn from posterior. If
+                sample_shape is multidimensional we simply draw `sample_shape.numel()`
+                samples and then reshape into the desired shape.
+            x: Conditioning context for posterior $p(\theta|x)$. If not provided,
+                fall back onto `x_o` if previously provided for multiround training, or
+                to a set default (see `set_default_x()` method).
+            show_progress_bars: Whether to show sampling progress monitor.
+            sample_with_mcmc: Optional parameter to override `self.sample_with_mcmc`.
+            mcmc_method: Optional parameter to override `self.mcmc_method`.
+            mcmc_parameters: Dictionary overriding the default parameters for MCMC.
+                The following parameters are supported: `thin` to set the thinning
+                factor for the chain, `warmup_steps` to set the initial number of
+                samples to discard, `num_chains` for the number of chains, `init_strategy`
+                for the initialisation strategy for chains; `prior` will draw init
+                locations from prior, whereas `sir` will use Sequential-Importance-
+                Resampling using `init_strategy_num_candidates` to find init
+                locations.
+
+        Returns:
+            Samples from posterior.
+        """
+
+        x = atleast_2d_float32_tensor(self._x_else_default_x(x))
+        self._ensure_single_x(x)
+        self._ensure_x_consistent_with_default_x(x)
+        num_samples = torch.Size(sample_shape).numel()
+
+        sample_with_mcmc = (
+            sample_with_mcmc if sample_with_mcmc is not None else self.sample_with_mcmc
+        )
+        mcmc_method = mcmc_method if mcmc_method is not None else self.mcmc_method
+        mcmc_parameters = (
+            mcmc_parameters if mcmc_parameters is not None else self.mcmc_parameters
+        )
+
+        if sample_with_mcmc:
+            samples = self._sample_posterior_mcmc(
+                x=x,
+                num_samples=num_samples,
+                show_progress_bars=show_progress_bars,
+                mcmc_method=mcmc_method,
+                **mcmc_parameters,
+            )
+        else:
+            # Rejection sampling.
+            samples, _ = utils.sample_posterior_within_prior(
+                self.net,
+                self._prior,
+                x,
+                num_samples=num_samples,
+                show_progress_bars=show_progress_bars,
+            )
+
+        return samples.reshape((*sample_shape, -1))

--- a/sbi/inference/posteriors/snpe_posterior.py
+++ b/sbi/inference/posteriors/snpe_posterior.py
@@ -105,8 +105,8 @@ class SNPE_Posterior(NeuralPosterior):
             `NeuralPosterior` for chainable calls.
 
         Raises:
-            `ValueError` on attempt to turn off MCMC sampling for family of methods
-            that do not support rejection sampling.
+            ValueError: on attempt to turn off MCMC sampling for family of methods that
+                do not support rejection sampling.
         """
         if not use_mcmc:
             if self._method_family not in ["snpe"]:
@@ -145,6 +145,10 @@ class SNPE_Posterior(NeuralPosterior):
             support of the prior, -∞ (corresponding to 0 probability) outside.
 
         """
+
+        # TODO Train exited here, entered after sampling?
+        self.net.eval()
+
         theta, x = self._prepare_theta_and_x_for_log_prob_(theta, x)
 
         with torch.set_grad_enabled(track_gradients):

--- a/sbi/inference/posteriors/snre_posterior.py
+++ b/sbi/inference/posteriors/snre_posterior.py
@@ -1,0 +1,156 @@
+# This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
+# under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
+
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+)
+from warnings import warn
+
+import torch
+from torch import Tensor, nn
+
+from sbi.inference.posteriors.posterior import NeuralPosterior
+from sbi.types import Shape
+from sbi.utils import del_entries
+from sbi.utils.torchutils import atleast_2d_float32_tensor
+
+
+class SnrePosterior(NeuralPosterior):
+    r"""Posterior $p(\theta|x)$ with `log_prob()` and `sample()` methods.<br/><br/>
+    All inference methods in sbi train a neural network which is then used to obtain
+    the posterior distribution. The `NeuralPosterior` class wraps the trained network
+    such that one can directly evaluate the log probability and draw samples from the
+    posterior. The neural network itself can be accessed via the `.net` attribute.
+    <br/><br/>
+    Specifically, this class offers the following functionality:<br/>
+    - Correction of leakage (applicable only to SNPE): If the prior is bounded, the
+      posterior resulting from SNPE can generate samples that lie outside of the prior
+      support (i.e. the posterior leaks). This class rejects these samples or,
+      alternatively, allows to sample from the posterior with MCMC. It also corrects the
+      calculation of the log probability such that it compensates for the leakage.<br/>
+    - Posterior inference from likelihood (SNL) and likelihood ratio (SRE): SNL and SRE
+      learn to approximate the likelihood and likelihood ratio, which in turn can be
+      used to generate samples from the posterior. This class provides the needed MCMC
+      methods to sample from the posterior and to evaluate the log probability.
+
+    """
+
+    def __init__(
+        self,
+        method_family: str,
+        neural_net: nn.Module,
+        prior,
+        x_shape: torch.Size,
+        mcmc_method: str = "slice_np",
+        mcmc_parameters: Optional[Dict[str, Any]] = None,
+        get_potential_function: Optional[Callable] = None,
+    ):
+        """
+        Args:
+            method_family: One of snpe, snl, snre_a or snre_b.
+            neural_net: A classifier for SNRE, a density estimator for SNPE and SNL.
+            prior: Prior distribution with `.log_prob()` and `.sample()`.
+            x_shape: Shape of a single simulator output.
+            mcmc_method: Method used for MCMC sampling, one of `slice_np`, `slice`, `hmc`, `nuts`.
+                Currently defaults to `slice_np` for a custom numpy implementation of
+                slice sampling; select `hmc`, `nuts` or `slice` for Pyro-based sampling.
+            mcmc_parameters: Dictionary overriding the default parameters for MCMC.
+                The following parameters are supported: `thin` to set the thinning
+                factor for the chain, `warmup_steps` to set the initial number of
+                samples to discard, `num_chains` for the number of chains, `init_strategy`
+                for the initialisation strategy for chains; `prior` will draw init
+                locations from prior, whereas `sir` will use Sequential-Importance-
+                Resampling using `init_strategy_num_candidates` to find init
+                locations.
+            get_potential_function: Callable that returns the potential function used
+                for MCMC sampling.
+        """
+        kwargs = del_entries(locals(), entries=("self", "__class__"))
+        super().__init__(**kwargs)
+
+    def _log_prob_ratio_estimator(self, theta: Tensor, x: Tensor) -> Tensor:
+        log_ratio = self.net(torch.cat((theta, x), dim=1)).reshape(-1)
+        return log_ratio + self._prior.log_prob(theta)
+
+    def _log_prob_snre_a(self, theta: Tensor, x: Tensor) -> Tensor:
+        if self._num_trained_rounds > 1:
+            warn(
+                "The log-probability from AALR / SNRE-A beyond round 1 is only correct "
+                "up to a normalizing constant."
+            )
+        return self._log_prob_ratio_estimator(theta, x)
+
+    def _log_prob_snre_b(self, theta: Tensor, x: Tensor) -> Tensor:
+        warn(
+            "The log probability from SNRE_B is only correct up to a normalizing "
+            "constant."
+        )
+        return self._log_prob_ratio_estimator(theta, x)
+
+    def sample(
+        self,
+        sample_shape: Shape = torch.Size(),
+        x: Optional[Tensor] = None,
+        show_progress_bars: bool = True,
+        sample_with_mcmc: Optional[bool] = None,
+        mcmc_method: Optional[str] = None,
+        mcmc_parameters: Optional[Dict[str, Any]] = None,
+    ) -> Tensor:
+        r"""
+        Return samples from posterior distribution $p(\theta|x)$.
+
+        Samples are obtained either with rejection sampling or MCMC. SNPE can use
+        rejection sampling and MCMC (which can help to deal with strong leakage). SNL
+        and SRE are restricted to sampling with MCMC.
+
+        Args:
+            sample_shape: Desired shape of samples that are drawn from posterior. If
+                sample_shape is multidimensional we simply draw `sample_shape.numel()`
+                samples and then reshape into the desired shape.
+            x: Conditioning context for posterior $p(\theta|x)$. If not provided,
+                fall back onto `x_o` if previously provided for multiround training, or
+                to a set default (see `set_default_x()` method).
+            show_progress_bars: Whether to show sampling progress monitor.
+            sample_with_mcmc: Optional parameter to override `self.sample_with_mcmc`.
+            mcmc_method: Optional parameter to override `self.mcmc_method`.
+            mcmc_parameters: Dictionary overriding the default parameters for MCMC.
+                The following parameters are supported: `thin` to set the thinning
+                factor for the chain, `warmup_steps` to set the initial number of
+                samples to discard, `num_chains` for the number of chains, `init_strategy`
+                for the initialisation strategy for chains; `prior` will draw init
+                locations from prior, whereas `sir` will use Sequential-Importance-
+                Resampling using `init_strategy_num_candidates` to find init
+                locations.
+
+        Returns:
+            Samples from posterior.
+        """
+
+        x = atleast_2d_float32_tensor(self._x_else_default_x(x))
+        self._ensure_single_x(x)
+        self._ensure_x_consistent_with_default_x(x)
+        num_samples = torch.Size(sample_shape).numel()
+
+        mcmc_method = mcmc_method if mcmc_method is not None else self.mcmc_method
+        mcmc_parameters = (
+            mcmc_parameters if mcmc_parameters is not None else self.mcmc_parameters
+        )
+
+        samples = self._sample_posterior_mcmc(
+            x=x,
+            num_samples=num_samples,
+            show_progress_bars=show_progress_bars,
+            mcmc_method=mcmc_method,
+            **mcmc_parameters,
+        )
+
+        return samples.reshape((*sample_shape, -1))

--- a/sbi/inference/posteriors/snre_posterior.py
+++ b/sbi/inference/posteriors/snre_posterior.py
@@ -95,6 +95,10 @@ class SNRE_Posterior(NeuralPosterior):
             `(len(θ),)`-shaped log-probability $\log(p(x|\theta) \cdot p(\theta))$.
 
         """
+
+        # TODO Train exited here, entered after sampling?
+        self.net.eval()
+
         theta, x = self._prepare_theta_and_x_for_log_prob_(theta, x)
 
         self._warn_log_prob_snre()

--- a/sbi/inference/snle/snle_a.py
+++ b/sbi/inference/snle/snle_a.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Dict, Optional, Union
 
 from torch.utils.tensorboard import SummaryWriter
 
-from sbi.inference.posteriors.posterior import NeuralPosterior
+from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.inference.snle.snle_base import LikelihoodEstimator
 from sbi.utils import del_entries
 

--- a/sbi/inference/snle/snle_a.py
+++ b/sbi/inference/snle/snle_a.py
@@ -2,24 +2,11 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import Any, Callable, Dict, Optional, Union
 
-import torch
-from torch import Tensor
 from torch.utils.tensorboard import SummaryWriter
 
-from sbi.inference.posterior import NeuralPosterior
+from sbi.inference.posteriors.posterior import NeuralPosterior
 from sbi.inference.snle.snle_base import LikelihoodEstimator
 from sbi.utils import del_entries
 

--- a/sbi/inference/snle/snle_a.py
+++ b/sbi/inference/snle/snle_a.py
@@ -4,10 +4,9 @@
 
 from typing import Any, Callable, Dict, Optional, Union
 
-from torch.utils.tensorboard import SummaryWriter
-
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.inference.snle.snle_base import LikelihoodEstimator
+from sbi.types import TensorboardSummaryWriter
 from sbi.utils import del_entries
 
 
@@ -23,7 +22,7 @@ class SNLE_A(LikelihoodEstimator):
         mcmc_parameters: Optional[Dict[str, Any]] = None,
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
-        summary_writer: Optional[SummaryWriter] = None,
+        summary_writer: Optional[TensorboardSummaryWriter] = None,
         show_progress_bars: bool = True,
         show_round_summary: bool = False,
     ):
@@ -69,7 +68,7 @@ class SNLE_A(LikelihoodEstimator):
             device: torch device on which to compute, e.g. gpu, cpu.
             logging_level: Minimum severity of messages to log. One of the strings
                 INFO, WARNING, DEBUG, ERROR and CRITICAL.
-            summary_writer: A `SummaryWriter` to control, among others, log
+            summary_writer: A tensorboard `SummaryWriter` to control, among others, log
                 file location (default is `<current working directory>/logs`.)
             show_progress_bars: Whether to show a progressbar during simulation and
                 sampling.

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -16,7 +16,7 @@ from torch.utils.tensorboard import SummaryWriter
 
 from sbi import utils as utils
 from sbi.inference import NeuralInference
-from sbi.inference.posteriors.snle_posterior import SnlePosterior
+from sbi.inference.posteriors.snle_posterior import SNLE_Posterior
 from sbi.types import ScalarFloat
 from sbi.utils import check_estimator_arg, x_shape_from_simulation
 
@@ -105,7 +105,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
         exclude_invalid_x: bool = True,
         discard_prior_samples: bool = False,
         retrain_from_scratch_each_round: bool = False,
-    ) -> SnlePosterior:
+    ) -> SNLE_Posterior:
         r"""Run SNLE.
 
         Return posterior $p(\theta|x)$ after inference.
@@ -142,7 +142,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
         # can `sample()` and `log_prob()`. The network is accessible via `.net`.
         if self._posterior is None or retrain_from_scratch_each_round:
             x_shape = x_shape_from_simulation(x)
-            self._posterior = SnlePosterior(
+            self._posterior = SNLE_Posterior(
                 method_family="snle",
                 neural_net=self._build_neural_net(theta, x),
                 prior=self._prior,

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -17,7 +17,7 @@ from torch.utils.tensorboard import SummaryWriter
 
 from sbi import utils as utils
 from sbi.inference import NeuralInference
-from sbi.inference.posteriors.snpe_posterior import SnpePosterior
+from sbi.inference.posteriors.snpe_posterior import SNPE_Posterior
 from sbi.types import ScalarFloat
 from sbi.utils import check_estimator_arg, x_shape_from_simulation
 
@@ -113,7 +113,7 @@ class PosteriorEstimator(NeuralInference, ABC):
         exclude_invalid_x: bool = True,
         discard_prior_samples: bool = False,
         retrain_from_scratch_each_round: bool = False,
-    ) -> SnpePosterior:
+    ) -> SNPE_Posterior:
         r"""Run SNPE.
 
         Return posterior $p(\theta|x)$ after inference.
@@ -173,7 +173,7 @@ class PosteriorEstimator(NeuralInference, ABC):
         # can `sample()` and `log_prob()`. The network is accessible via `.net`.
         if self._posterior is None or retrain_from_scratch_each_round:
             x_shape = x_shape_from_simulation(x)
-            self._posterior = SnpePosterior(
+            self._posterior = SNPE_Posterior(
                 method_family="snpe",
                 neural_net=self._build_neural_net(theta, x),
                 prior=self._prior,

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -4,18 +4,7 @@
 
 from abc import ABC, abstractmethod
 from copy import deepcopy
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import Any, Callable, Dict, Optional, Union, cast
 from warnings import warn
 
 import numpy as np
@@ -28,9 +17,8 @@ from torch.utils.tensorboard import SummaryWriter
 
 from sbi import utils as utils
 from sbi.inference import NeuralInference
-from sbi.inference.posterior import NeuralPosterior
+from sbi.inference.posteriors.snpe_posterior import SnpePosterior
 from sbi.types import ScalarFloat
-from sbi.user_input.user_input_checks import check_estimator_arg
 from sbi.utils import check_estimator_arg, x_shape_from_simulation
 
 
@@ -125,7 +113,7 @@ class PosteriorEstimator(NeuralInference, ABC):
         exclude_invalid_x: bool = True,
         discard_prior_samples: bool = False,
         retrain_from_scratch_each_round: bool = False,
-    ) -> NeuralPosterior:
+    ) -> SnpePosterior:
         r"""Run SNPE.
 
         Return posterior $p(\theta|x)$ after inference.
@@ -185,7 +173,7 @@ class PosteriorEstimator(NeuralInference, ABC):
         # can `sample()` and `log_prob()`. The network is accessible via `.net`.
         if self._posterior is None or retrain_from_scratch_each_round:
             x_shape = x_shape_from_simulation(x)
-            self._posterior = NeuralPosterior(
+            self._posterior = SnpePosterior(
                 method_family="snpe",
                 neural_net=self._build_neural_net(theta, x),
                 prior=self._prior,

--- a/sbi/inference/snpe/snpe_c.py
+++ b/sbi/inference/snpe/snpe_c.py
@@ -6,10 +6,10 @@ from typing import Any, Callable, Dict, Optional, Union
 
 import torch
 from torch import Tensor, eye, ones
-from torch.utils.tensorboard import SummaryWriter
 
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.inference.snpe.snpe_base import PosteriorEstimator
+from sbi.types import TensorboardSummaryWriter
 from sbi.utils import clamp_and_warn, del_entries, repeat_rows
 
 
@@ -27,7 +27,7 @@ class SNPE_C(PosteriorEstimator):
         use_combined_loss: bool = False,
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
-        summary_writer: Optional[SummaryWriter] = None,
+        summary_writer: Optional[TensorboardSummaryWriter] = None,
         show_progress_bars: bool = True,
         show_round_summary: bool = False,
     ):
@@ -78,7 +78,7 @@ class SNPE_C(PosteriorEstimator):
             device: torch device on which to compute, e.g. gpu, cpu.
             logging_level: Minimum severity of messages to log. One of the strings
                 INFO, WARNING, DEBUG, ERROR and CRITICAL.
-            summary_writer: A `SummaryWriter` to control, among others, log
+            summary_writer: A tensorboard `SummaryWriter` to control, among others, log
                 file location (default is `<current working directory>/logs`.)
             show_progress_bars: Whether to show a progressbar during simulation and
                 sampling.

--- a/sbi/inference/snpe/snpe_c.py
+++ b/sbi/inference/snpe/snpe_c.py
@@ -8,7 +8,7 @@ import torch
 from torch import Tensor, eye, ones
 from torch.utils.tensorboard import SummaryWriter
 
-from sbi.inference.posteriors.posterior import NeuralPosterior
+from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.inference.snpe.snpe_base import PosteriorEstimator
 from sbi.utils import clamp_and_warn, del_entries, repeat_rows
 

--- a/sbi/inference/snpe/snpe_c.py
+++ b/sbi/inference/snpe/snpe_c.py
@@ -2,26 +2,14 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import Any, Callable, Dict, Optional, Union
 
 import torch
-from torch import Tensor, eye, nn, ones
+from torch import Tensor, eye, ones
 from torch.utils.tensorboard import SummaryWriter
 
-from sbi.inference.posterior import NeuralPosterior
+from sbi.inference.posteriors.posterior import NeuralPosterior
 from sbi.inference.snpe.snpe_base import PosteriorEstimator
-from sbi.types import OneOrMore
 from sbi.utils import clamp_and_warn, del_entries, repeat_rows
 
 

--- a/sbi/inference/snre/snre_a.py
+++ b/sbi/inference/snre/snre_a.py
@@ -2,10 +2,10 @@ from typing import Any, Callable, Dict, Optional, Union
 
 import torch
 from torch import Tensor, nn, ones
-from torch.utils.tensorboard import SummaryWriter
 
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.inference.snre.snre_base import RatioEstimator
+from sbi.types import TensorboardSummaryWriter
 from sbi.utils import del_entries
 
 
@@ -21,7 +21,7 @@ class SNRE_A(RatioEstimator):
         mcmc_parameters: Optional[Dict[str, Any]] = None,
         device: str = "cpu",
         logging_level: Union[int, str] = "warning",
-        summary_writer: Optional[SummaryWriter] = None,
+        summary_writer: Optional[TensorboardSummaryWriter] = None,
         show_progress_bars: bool = True,
         show_round_summary: bool = False,
     ):
@@ -65,7 +65,7 @@ class SNRE_A(RatioEstimator):
             device: torch device on which to compute, e.g. gpu, cpu.
             logging_level: Minimum severity of messages to log. One of the strings
                 INFO, WARNING, DEBUG, ERROR and CRITICAL.
-            summary_writer: A `SummaryWriter` to control, among others, log
+            summary_writer: A tensorboard `SummaryWriter` to control, among others, log
                 file location (default is `<current working directory>/logs`.)
             show_progress_bars: Whether to show a progressbar during simulation and
                 sampling.

--- a/sbi/inference/snre/snre_a.py
+++ b/sbi/inference/snre/snre_a.py
@@ -4,7 +4,7 @@ import torch
 from torch import Tensor, nn, ones
 from torch.utils.tensorboard import SummaryWriter
 
-from sbi.inference.posteriors.posterior import NeuralPosterior
+from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.inference.snre.snre_base import RatioEstimator
 from sbi.utils import del_entries
 
@@ -25,7 +25,7 @@ class SNRE_A(RatioEstimator):
         show_progress_bars: bool = True,
         show_round_summary: bool = False,
     ):
-        """AALR[1], here known as SNRE_A.
+        r"""AALR[1], here known as SNRE_A.
 
         [1] _Likelihood-free MCMC with Amortized Approximate Likelihood Ratios_, Hermans
             et al., ICML 2020, https://arxiv.org/abs/1903.04057

--- a/sbi/inference/snre/snre_a.py
+++ b/sbi/inference/snre/snre_a.py
@@ -1,21 +1,10 @@
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import Any, Callable, Dict, Optional, Union
 
 import torch
 from torch import Tensor, nn, ones
 from torch.utils.tensorboard import SummaryWriter
 
-from sbi.inference.posterior import NeuralPosterior
+from sbi.inference.posteriors.posterior import NeuralPosterior
 from sbi.inference.snre.snre_base import RatioEstimator
 from sbi.utils import del_entries
 

--- a/sbi/inference/snre/snre_b.py
+++ b/sbi/inference/snre/snre_b.py
@@ -2,10 +2,10 @@ from typing import Any, Callable, Dict, Optional, Union
 
 import torch
 from torch import Tensor
-from torch.utils.tensorboard import SummaryWriter
 
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.inference.snre.snre_base import RatioEstimator
+from sbi.types import TensorboardSummaryWriter
 from sbi.utils import del_entries
 
 
@@ -21,7 +21,7 @@ class SNRE_B(RatioEstimator):
         mcmc_parameters: Optional[Dict[str, Any]] = None,
         device: str = "cpu",
         logging_level: Union[int, str] = "warning",
-        summary_writer: Optional[SummaryWriter] = None,
+        summary_writer: Optional[TensorboardSummaryWriter] = None,
         show_progress_bars: bool = True,
         show_round_summary: bool = False,
     ):
@@ -65,7 +65,7 @@ class SNRE_B(RatioEstimator):
             device: torch device on which to compute, e.g. gpu, cpu.
             logging_level: Minimum severity of messages to log. One of the strings
                 INFO, WARNING, DEBUG, ERROR and CRITICAL.
-            summary_writer: A `SummaryWriter` to control, among others, log
+            summary_writer: A tensorboard `SummaryWriter` to control, among others, log
                 file location (default is `<current working directory>/logs`.)
             show_progress_bars: Whether to show a progressbar during simulation and
                 sampling.

--- a/sbi/inference/snre/snre_b.py
+++ b/sbi/inference/snre/snre_b.py
@@ -4,7 +4,7 @@ import torch
 from torch import Tensor
 from torch.utils.tensorboard import SummaryWriter
 
-from sbi.inference.posteriors.posterior import NeuralPosterior
+from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.inference.snre.snre_base import RatioEstimator
 from sbi.utils import del_entries
 
@@ -25,7 +25,7 @@ class SNRE_B(RatioEstimator):
         show_progress_bars: bool = True,
         show_round_summary: bool = False,
     ):
-        """SRE[1], here known as SNRE_B.
+        r"""SRE[1], here known as SNRE_B.
 
         [1] _On Contrastive Learning for Likelihood-free Inference_, Durkan et al.,
             ICML 2020, https://arxiv.org/pdf/2002.03712

--- a/sbi/inference/snre/snre_b.py
+++ b/sbi/inference/snre/snre_b.py
@@ -1,21 +1,10 @@
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import Any, Callable, Dict, Optional, Union
 
 import torch
 from torch import Tensor
 from torch.utils.tensorboard import SummaryWriter
 
-from sbi.inference.posterior import NeuralPosterior
+from sbi.inference.posteriors.posterior import NeuralPosterior
 from sbi.inference.snre.snre_base import RatioEstimator
 from sbi.utils import del_entries
 

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -12,7 +12,7 @@ from torch.utils.tensorboard import SummaryWriter
 
 from sbi import utils as utils
 from sbi.inference.base import NeuralInference
-from sbi.inference.posteriors.snre_posterior import SnrePosterior
+from sbi.inference.posteriors.snre_posterior import SNRE_Posterior
 from sbi.types import ScalarFloat
 from sbi.utils import check_estimator_arg, clamp_and_warn, x_shape_from_simulation
 from sbi.utils.torchutils import ensure_theta_batched, ensure_x_batched
@@ -110,8 +110,8 @@ class RatioEstimator(NeuralInference, ABC):
         exclude_invalid_x: bool = True,
         discard_prior_samples: bool = False,
         retrain_from_scratch_each_round: bool = False,
-    ) -> SnrePosterior:
-        """Run SNRE.
+    ) -> SNRE_Posterior:
+        r"""Run SNRE.
 
         Return posterior $p(\theta|x)$ after inference.
 
@@ -148,7 +148,7 @@ class RatioEstimator(NeuralInference, ABC):
         # can `sample()` and `log_prob()`. The network is accessible via `.net`.
         if self._posterior is None or retrain_from_scratch_each_round:
             x_shape = x_shape_from_simulation(x)
-            self._posterior = SnrePosterior(
+            self._posterior = SNRE_Posterior(
                 method_family=self.__class__.__name__.lower(),
                 neural_net=self._build_neural_net(theta, x),
                 prior=self._prior,

--- a/sbi/types.py
+++ b/sbi/types.py
@@ -2,9 +2,23 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    NewType,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+)
+
 import numpy as np
 import torch
+from torch.utils.tensorboard import SummaryWriter
 
 Array = Union[np.ndarray, torch.Tensor]
 Shape = Union[torch.Size, Tuple[int, ...]]
@@ -14,5 +28,9 @@ OneOrMore = Union[T, Sequence[T]]
 
 ScalarFloat = Union[torch.Tensor, float]
 
+# Define a `Writer` because otherwise, the documentation by mkdocs became very long and
+# made the website look ugly.
+TensorboardSummaryWriter = NewType("Writer", SummaryWriter)
 
-__all__ = ["Array", "Shape", "OneOrMore", "ScalarFloat"]
+
+__all__ = ["Array", "Shape", "OneOrMore", "ScalarFloat", "TensorboardSummaryWriter"]

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -83,7 +83,7 @@ def test_c2st_snpe_on_linearGaussian(
             posterior, x_o[0], likelihood_shift, likelihood_cov, prior_mean, prior_cov
         )
 
-        max_dkl = 0.1
+        max_dkl = 0.15
 
         assert (
             dkl < max_dkl

--- a/tests/linearGaussian_snre_test.py
+++ b/tests/linearGaussian_snre_test.py
@@ -231,7 +231,7 @@ def test_c2st_sre_on_linearGaussian(
             posterior, x_o[0], likelihood_shift, likelihood_cov, prior_mean, prior_cov
         )
 
-        max_dkl = 0.1
+        max_dkl = 0.15
 
         assert (
             dkl < max_dkl

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -114,10 +114,14 @@ def get_normalization_uniform_prior(
     prior_sample = prior.sample()
 
     # Compute unnormalized density, i.e. just the output of the density estimator.
-    posterior_likelihood_unnorm = torch.exp(posterior.log_prob(prior_sample))
+    posterior_likelihood_unnorm = torch.exp(
+        posterior.log_prob(prior_sample, norm_posterior=False)
+    )
     # Compute the normalized density, scale up output of the density
     # estimator by the ratio of posterior samples within the prior bounds.
-    posterior_likelihood_norm = torch.exp(posterior.log_prob(prior_sample))
+    posterior_likelihood_norm = torch.exp(
+        posterior.log_prob(prior_sample, norm_posterior=True)
+    )
 
     # Estimate acceptance ratio through rejection sampling.
     acceptance_prob = posterior.leakage_correction(x=true_observation)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,6 +10,7 @@ from torch import Tensor
 from torch.distributions import Distribution
 
 from sbi.inference.posteriors.posterior import NeuralPosterior
+from sbi.inference.posteriors.snpe_posterior import SnpePosterior
 from sbi.simulators.linear_gaussian import true_posterior_linear_gaussian_mvn_prior
 from sbi.utils.metrics import c2st
 
@@ -97,7 +98,7 @@ def get_prob_outside_uniform_prior(posterior: NeuralPosterior, num_dim: int) -> 
 
 
 def get_normalization_uniform_prior(
-    posterior: NeuralPosterior, prior: Distribution, true_observation: Tensor,
+    posterior: SnpePosterior, prior: Distribution, true_observation: Tensor,
 ) -> Tuple[Tensor, Tensor, Tensor]:
     """
     Return the unnormalized posterior likelihood, the normalized posterior likelihood,
@@ -113,14 +114,10 @@ def get_normalization_uniform_prior(
     prior_sample = prior.sample()
 
     # Compute unnormalized density, i.e. just the output of the density estimator.
-    posterior_likelihood_unnorm = torch.exp(
-        posterior.log_prob(prior_sample, norm_posterior_snpe=False)
-    )
+    posterior_likelihood_unnorm = torch.exp(posterior.log_prob(prior_sample))
     # Compute the normalized density, scale up output of the density
     # estimator by the ratio of posterior samples within the prior bounds.
-    posterior_likelihood_norm = torch.exp(
-        posterior.log_prob(prior_sample, norm_posterior_snpe=True)
-    )
+    posterior_likelihood_norm = torch.exp(posterior.log_prob(prior_sample))
 
     # Estimate acceptance ratio through rejection sampling.
     acceptance_prob = posterior.leakage_correction(x=true_observation)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,8 +9,8 @@ import torch
 from torch import Tensor
 from torch.distributions import Distribution
 
-from sbi.inference.posteriors.posterior import NeuralPosterior
-from sbi.inference.posteriors.snpe_posterior import SnpePosterior
+from sbi.inference.posteriors.base_posterior import NeuralPosterior
+from sbi.inference.posteriors.snpe_posterior import SNPE_Posterior
 from sbi.simulators.linear_gaussian import true_posterior_linear_gaussian_mvn_prior
 from sbi.utils.metrics import c2st
 
@@ -98,7 +98,7 @@ def get_prob_outside_uniform_prior(posterior: NeuralPosterior, num_dim: int) -> 
 
 
 def get_normalization_uniform_prior(
-    posterior: SnpePosterior, prior: Distribution, true_observation: Tensor,
+    posterior: SNPE_Posterior, prior: Distribution, true_observation: Tensor,
 ) -> Tuple[Tensor, Tensor, Tensor]:
     """
     Return the unnormalized posterior likelihood, the normalized posterior likelihood,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,17 +3,15 @@
 
 from __future__ import annotations
 
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
+from typing import Tuple, Union
 
 import torch
 from torch import Tensor
 from torch.distributions import Distribution
 
-from sbi.inference.posterior import NeuralPosterior
-
-from sbi.utils.metrics import c2st
-
+from sbi.inference.posteriors.posterior import NeuralPosterior
 from sbi.simulators.linear_gaussian import true_posterior_linear_gaussian_mvn_prior
+from sbi.utils.metrics import c2st
 
 
 def kl_d_via_monte_carlo(


### PR DESCRIPTION
Tackles #214 

- child classes for snpe, snle, and snre posteriors.
- `log_prob()` and `sample()` now exist in the child classes, e.g. in `SNPE_Posterior`.
- docstrings of the posterior classes are now much more focused for the specific method.
- there is a new method in `base_posterior.NeuralPosterior` called `_prepare_theta_and_x_for_log_prob_()`. Do you think we need it or should we just copy the code to each of the child classes?