### PR TITLE
Additions to posterior refactoring (see #283)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # v0.11.2
-- Subclassed Posterior (#282)
+- Subclassed Posterior (#282, #285)
 
 
 # v0.11.1

--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -58,18 +58,21 @@
     rendering:
       show_root_heading: true
     selection:
+      filters: [ "!^_", "^__", "!^__class__" ]
       inherited_members: true
       
 ::: sbi.inference.posteriors.snle_posterior.SNLE_Posterior
     rendering:
       show_root_heading: true
     selection:
+      filters: [ "!^_", "^__", "!^__class__" ]
       inherited_members: true
       
 ::: sbi.inference.posteriors.snre_posterior.SNRE_Posterior
     rendering:
       show_root_heading: true
     selection:
+      filters: [ "!^_", "^__", "!^__class__" ]
       inherited_members: true
 
 ## Models

--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -54,21 +54,21 @@
 
 ## Posteriors
 
-::: sbi.inference.posteriors.snpe_posterior.SNPE_Posterior
+::: sbi.inference.posteriors.direct_posterior.DirectPosterior
     rendering:
       show_root_heading: true
     selection:
       filters: [ "!^_", "^__", "!^__class__" ]
       inherited_members: true
       
-::: sbi.inference.posteriors.snle_posterior.SNLE_Posterior
+::: sbi.inference.posteriors.likelihood_based_posterior.LikelihoodBasedPosterior
     rendering:
       show_root_heading: true
     selection:
       filters: [ "!^_", "^__", "!^__class__" ]
       inherited_members: true
       
-::: sbi.inference.posteriors.snre_posterior.SNRE_Posterior
+::: sbi.inference.posteriors.ratio_based_posterior.RatioBasedPosterior
     rendering:
       show_root_heading: true
     selection:

--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -1,6 +1,7 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
+from abc import ABC, abstractmethod
 from typing import (
     Any,
     Callable,
@@ -29,7 +30,7 @@ from sbi.user_input.user_input_checks import process_x
 from sbi.utils.torchutils import atleast_2d_float32_tensor, ensure_theta_batched
 
 
-class NeuralPosterior:
+class NeuralPosterior(ABC):
     r"""Posterior $p(\theta|x)$ with `log_prob()` and `sample()` methods.<br/><br/>
     All inference methods in sbi train a neural network which is then used to obtain
     the posterior distribution. The `NeuralPosterior` class wraps the trained network
@@ -177,12 +178,14 @@ class NeuralPosterior:
         self._mcmc_parameters = parameters
         return self
 
+    @abstractmethod
     def log_prob(
         self, theta: Tensor, x: Optional[Tensor] = None, track_gradients: bool = False,
     ) -> Tensor:
         """See child classes for docstring."""
         pass
 
+    @abstractmethod
     def sample(
         self,
         sample_shape: Shape = torch.Size(),

--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -532,24 +532,6 @@ class NeuralPosterior(ABC):
             else ""
         )
 
-        purpose_leakage = (
-            "It allows to .sample() and .log_prob() the posterior"
-            " and wraps the output of the .net to avoid leakage into regions with 0"
-            " prior probability."
-        )
-
-        normalized_or_not = (
-            ""
-            if (self._method_family == "snre_a" and self._num_trained_rounds == 1)
-            else "_unnormalized_ "
-        )
-        purpose_mcmc = (
-            f"It provides MCMC to .sample() from the posterior and "
-            f"can evaluate the {normalized_or_not}posterior density with .log_prob()."
-        )
-
-        purpose = purpose_leakage if self._method_family == "snpe" else purpose_mcmc
-
         # The net might be sequential because it can have a standardization net. Hence,
         # we only access its last entry if it is a nn.Sequential.
         actual_net = self.net[-1] if isinstance(self.net, nn.Sequential) else self.net
@@ -559,7 +541,7 @@ class NeuralPosterior(ABC):
             f"This {self.__class__.__name__}-object was obtained with a "
             f"{self._method_family.upper()}-class "
             f"method using a {actual_net.__class__.__name__.lower()}.\n"
-            f"{purpose}"
+            f"{self._purpose}"
         )
 
         return desc

--- a/sbi/inference/posteriors/direct_posterior.py
+++ b/sbi/inference/posteriors/direct_posterior.py
@@ -24,7 +24,7 @@ from sbi.utils import del_entries
 from sbi.utils.torchutils import atleast_2d_float32_tensor, batched_first_of_batch
 
 
-class SNPE_Posterior(NeuralPosterior):
+class DirectPosterior(NeuralPosterior):
     r"""Posterior $p(\theta|x)$ with `log_prob()` and `sample()` methods, obtained with
     SNPE.<br/><br/>
     SNPE trains a neural network to directly approximate the posterior distribution.

--- a/sbi/inference/posteriors/direct_posterior.py
+++ b/sbi/inference/posteriors/direct_posterior.py
@@ -264,14 +264,8 @@ class DirectPosterior(NeuralPosterior):
             Samples from posterior.
         """
 
-        x = atleast_2d_float32_tensor(self._x_else_default_x(x))
-        self._ensure_single_x(x)
-        self._ensure_x_consistent_with_default_x(x)
-        num_samples = torch.Size(sample_shape).numel()
-
-        mcmc_method = mcmc_method if mcmc_method is not None else self.mcmc_method
-        mcmc_parameters = (
-            mcmc_parameters if mcmc_parameters is not None else self.mcmc_parameters
+        x, num_samples, mcmc_method, mcmc_parameters = self._prepare_for_sample(
+            x, sample_shape, mcmc_method, mcmc_parameters
         )
 
         sample_with_mcmc = (

--- a/sbi/inference/posteriors/direct_posterior.py
+++ b/sbi/inference/posteriors/direct_posterior.py
@@ -82,6 +82,10 @@ class DirectPosterior(NeuralPosterior):
         super().__init__(**kwargs)
 
         self.set_sample_with_mcmc(sample_with_mcmc)
+        self._purpose = (
+            "It allows to .sample() and .log_prob() the posterior and wraps the "
+            "output of the .net to avoid leakage into regions with 0 prior probability."
+        )
 
     @property
     def sample_with_mcmc(self) -> bool:

--- a/sbi/inference/posteriors/likelihood_based_posterior.py
+++ b/sbi/inference/posteriors/likelihood_based_posterior.py
@@ -143,14 +143,8 @@ class LikelihoodBasedPosterior(NeuralPosterior):
             Samples from posterior.
         """
 
-        x = atleast_2d_float32_tensor(self._x_else_default_x(x))
-        self._ensure_single_x(x)
-        self._ensure_x_consistent_with_default_x(x)
-        num_samples = torch.Size(sample_shape).numel()
-
-        mcmc_method = mcmc_method if mcmc_method is not None else self.mcmc_method
-        mcmc_parameters = (
-            mcmc_parameters if mcmc_parameters is not None else self.mcmc_parameters
+        x, num_samples, mcmc_method, mcmc_parameters = self._prepare_for_sample(
+            x, sample_shape, mcmc_method, mcmc_parameters
         )
 
         samples = self._sample_posterior_mcmc(

--- a/sbi/inference/posteriors/likelihood_based_posterior.py
+++ b/sbi/inference/posteriors/likelihood_based_posterior.py
@@ -65,8 +65,14 @@ class LikelihoodBasedPosterior(NeuralPosterior):
             get_potential_function: Callable that returns the potential function used
                 for MCMC sampling.
         """
+
         kwargs = del_entries(locals(), entries=("self", "__class__"))
         super().__init__(**kwargs)
+
+        self._purpose = (
+            f"It provides MCMC to .sample() from the posterior and "
+            f"can evaluate the _unnormalized_ posterior density with .log_prob()."
+        )
 
     def log_prob(
         self, theta: Tensor, x: Optional[Tensor] = None, track_gradients: bool = False,

--- a/sbi/inference/posteriors/ratio_based_posterior.py
+++ b/sbi/inference/posteriors/ratio_based_posterior.py
@@ -155,14 +155,8 @@ class RatioBasedPosterior(NeuralPosterior):
             Samples from posterior.
         """
 
-        x = atleast_2d_float32_tensor(self._x_else_default_x(x))
-        self._ensure_single_x(x)
-        self._ensure_x_consistent_with_default_x(x)
-        num_samples = torch.Size(sample_shape).numel()
-
-        mcmc_method = mcmc_method if mcmc_method is not None else self.mcmc_method
-        mcmc_parameters = (
-            mcmc_parameters if mcmc_parameters is not None else self.mcmc_parameters
+        x, num_samples, mcmc_method, mcmc_parameters = self._prepare_for_sample(
+            x, sample_shape, mcmc_method, mcmc_parameters
         )
 
         samples = self._sample_posterior_mcmc(
@@ -176,11 +170,11 @@ class RatioBasedPosterior(NeuralPosterior):
         return samples.reshape((*sample_shape, -1))
 
     @property
-    def _num_trained_rounds(self):
+    def _num_trained_rounds(self) -> int:
         return self._trained_rounds
 
     @_num_trained_rounds.setter
-    def _num_trained_rounds(self, trained_rounds):
+    def _num_trained_rounds(self, trained_rounds: int) -> None:
         """
         Sets the number of trained rounds and updates the purpose.
 

--- a/sbi/inference/posteriors/ratio_based_posterior.py
+++ b/sbi/inference/posteriors/ratio_based_posterior.py
@@ -174,3 +174,30 @@ class RatioBasedPosterior(NeuralPosterior):
         )
 
         return samples.reshape((*sample_shape, -1))
+
+    @property
+    def _num_trained_rounds(self):
+        return self._trained_rounds
+
+    @_num_trained_rounds.setter
+    def _num_trained_rounds(self, trained_rounds):
+        """
+        Sets the number of trained rounds and updates the purpose.
+
+        When the number of trained rounds is 1 and the algorithm is SNRE_A, then the
+        log_prob will be normalized, as specified in the purpose.
+
+        The reason we made this a property is that the purpose gets updated
+        automatically whenever the number of rounds is updated.
+        """
+        self._trained_rounds = trained_rounds
+
+        normalized_or_not = (
+            ""
+            if (self._method_family == "snre_a" and self._trained_rounds == 1)
+            else "_unnormalized_ "
+        )
+        self._purpose = (
+            f"It provides MCMC to .sample() from the posterior and "
+            f"can evaluate the {normalized_or_not}posterior density with .log_prob()."
+        )

--- a/sbi/inference/posteriors/ratio_based_posterior.py
+++ b/sbi/inference/posteriors/ratio_based_posterior.py
@@ -24,13 +24,17 @@ from sbi.utils import del_entries
 from sbi.utils.torchutils import atleast_2d_float32_tensor
 
 
-class SNLE_Posterior(NeuralPosterior):
+class RatioBasedPosterior(NeuralPosterior):
     r"""Posterior $p(\theta|x)$ with `log_prob()` and `sample()` methods, obtained with
-    SNLE.<br/><br/>
-    SNLE trains a neural network to approximate the likelihood $p(x|\theta)$. The
-    `SNLE_Posterior` class wraps the trained network such that one can directly evaluate
-    the unnormalized posterior log probability $p(\theta|x) \propto p(x|\theta) \cdot
-    p(\theta)$ and draw samples from the posterior with MCMC.<br/><br/>
+    SNRE.<br/><br/>
+    SNRE trains a neural network to approximate likelihood ratios, which in turn can be
+    used obtain an unnormalized posterior $p(\theta|x) \propto p(x|\theta) \cdot
+    p(\theta)$. The `SNRE_Posterior` class wraps the trained network such that one can
+    directly evaluate the unnormalized posterior log-probability $p(\theta|x) \propto
+    p(x|\theta) \cdot p(\theta)$ and draw samples from the posterior with
+    MCMC. Note that, in the case of single-round SNRE_A / AALR, it is possible to
+    evaluate the log-probability of the **normalized** posterior, but sampling still
+    requires MCMC.<br/><br/>
     The neural network itself can be accessed via the `.net` attribute.
     """
 
@@ -74,7 +78,9 @@ class SNLE_Posterior(NeuralPosterior):
         r"""
         Returns the log-probability of $p(x|\theta) \cdot p(\theta).$
 
-        This corresponds to an **unnormalized** posterior log-probability.
+        This corresponds to an **unnormalized** posterior log-probability. Only for
+        single-round SNRE_A / AALR, the returned log-probability will correspond to the
+        **normalized** log-probability.
 
         Args:
             theta: Parameters $\theta$.
@@ -95,12 +101,24 @@ class SNLE_Posterior(NeuralPosterior):
 
         theta, x = self._prepare_theta_and_x_for_log_prob_(theta, x)
 
-        warn(
-            "The log probability from SNL is only correct up to a normalizing constant."
-        )
+        self._warn_log_prob_snre()
 
         with torch.set_grad_enabled(track_gradients):
-            return self.net.log_prob(x, theta) + self._prior.log_prob(theta)
+            log_ratio = self.net(torch.cat((theta, x), dim=1)).reshape(-1)
+            return log_ratio + self._prior.log_prob(theta)
+
+    def _warn_log_prob_snre(self) -> None:
+        if self._method_family == "snre_a":
+            if self._num_trained_rounds > 1:
+                warn(
+                    "The log-probability from AALR / SNRE-A beyond round 1 is only"
+                    " correct up to a normalizing constant."
+                )
+        elif self._method_family == "snre_b":
+            warn(
+                "The log probability from SNRE_B is only correct up to a normalizing "
+                "constant."
+            )
 
     def sample(
         self,

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -16,7 +16,7 @@ from torch.utils.tensorboard import SummaryWriter
 
 from sbi import utils as utils
 from sbi.inference import NeuralInference
-from sbi.inference.posteriors.snle_posterior import SNLE_Posterior
+from sbi.inference.posteriors.likelihood_based_posterior import LikelihoodBasedPosterior
 from sbi.types import ScalarFloat
 from sbi.utils import check_estimator_arg, x_shape_from_simulation
 
@@ -105,7 +105,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
         exclude_invalid_x: bool = True,
         discard_prior_samples: bool = False,
         retrain_from_scratch_each_round: bool = False,
-    ) -> SNLE_Posterior:
+    ) -> LikelihoodBasedPosterior:
         r"""Run SNLE.
 
         Return posterior $p(\theta|x)$ after inference.
@@ -142,7 +142,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
         # can `sample()` and `log_prob()`. The network is accessible via `.net`.
         if self._posterior is None or retrain_from_scratch_each_round:
             x_shape = x_shape_from_simulation(x)
-            self._posterior = SNLE_Posterior(
+            self._posterior = LikelihoodBasedPosterior(
                 method_family="snle",
                 neural_net=self._build_neural_net(theta, x),
                 prior=self._prior,

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -17,7 +17,7 @@ from torch.utils.tensorboard import SummaryWriter
 
 from sbi import utils as utils
 from sbi.inference import NeuralInference
-from sbi.inference.posteriors.snpe_posterior import SNPE_Posterior
+from sbi.inference.posteriors.direct_posterior import DirectPosterior
 from sbi.types import ScalarFloat
 from sbi.utils import check_estimator_arg, x_shape_from_simulation
 
@@ -113,7 +113,7 @@ class PosteriorEstimator(NeuralInference, ABC):
         exclude_invalid_x: bool = True,
         discard_prior_samples: bool = False,
         retrain_from_scratch_each_round: bool = False,
-    ) -> SNPE_Posterior:
+    ) -> DirectPosterior:
         r"""Run SNPE.
 
         Return posterior $p(\theta|x)$ after inference.
@@ -173,7 +173,7 @@ class PosteriorEstimator(NeuralInference, ABC):
         # can `sample()` and `log_prob()`. The network is accessible via `.net`.
         if self._posterior is None or retrain_from_scratch_each_round:
             x_shape = x_shape_from_simulation(x)
-            self._posterior = SNPE_Posterior(
+            self._posterior = DirectPosterior(
                 method_family="snpe",
                 neural_net=self._build_neural_net(theta, x),
                 prior=self._prior,

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -12,7 +12,7 @@ from torch.utils.tensorboard import SummaryWriter
 
 from sbi import utils as utils
 from sbi.inference.base import NeuralInference
-from sbi.inference.posteriors.snre_posterior import SNRE_Posterior
+from sbi.inference.posteriors.ratio_based_posterior import RatioBasedPosterior
 from sbi.types import ScalarFloat
 from sbi.utils import check_estimator_arg, clamp_and_warn, x_shape_from_simulation
 from sbi.utils.torchutils import ensure_theta_batched, ensure_x_batched
@@ -110,7 +110,7 @@ class RatioEstimator(NeuralInference, ABC):
         exclude_invalid_x: bool = True,
         discard_prior_samples: bool = False,
         retrain_from_scratch_each_round: bool = False,
-    ) -> SNRE_Posterior:
+    ) -> RatioBasedPosterior:
         r"""Run SNRE.
 
         Return posterior $p(\theta|x)$ after inference.
@@ -148,7 +148,7 @@ class RatioEstimator(NeuralInference, ABC):
         # can `sample()` and `log_prob()`. The network is accessible via `.net`.
         if self._posterior is None or retrain_from_scratch_each_round:
             x_shape = x_shape_from_simulation(x)
-            self._posterior = SNRE_Posterior(
+            self._posterior = RatioBasedPosterior(
                 method_family=self.__class__.__name__.lower(),
                 neural_net=self._build_neural_net(theta, x),
                 prior=self._prior,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,7 +10,7 @@ from torch import Tensor
 from torch.distributions import Distribution
 
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
-from sbi.inference.posteriors.snpe_posterior import SNPE_Posterior
+from sbi.inference.posteriors.direct_posterior import DirectPosterior
 from sbi.simulators.linear_gaussian import true_posterior_linear_gaussian_mvn_prior
 from sbi.utils.metrics import c2st
 
@@ -98,7 +98,7 @@ def get_prob_outside_uniform_prior(posterior: NeuralPosterior, num_dim: int) -> 
 
 
 def get_normalization_uniform_prior(
-    posterior: SNPE_Posterior, prior: Distribution, true_observation: Tensor,
+    posterior: DirectPosterior, prior: Distribution, true_observation: Tensor,
 ) -> Tuple[Tensor, Tensor, Tensor]:
     """
     Return the unnormalized posterior likelihood, the normalized posterior likelihood,


### PR DESCRIPTION
## Make base posterior an abstract base class (ABC).

Children have to implement `.sample()` and `.log_prob()`. Future methods might not allow to evaluate `log_prob()`, but I think it is good practice that these methods still implement a `.log_prob()` function which just raises an error.

## Rename posterior classes
- DirectPosterior
- LikelihoodBasedPosterior
- RatioBasedPosterior

## Updated __desc__ and __str__ of posterior
str now also prints a `purpose` which can be either correcting leakage or doing mcmc.