### PR TITLE
Fix the pyro samplers

### DIFF
--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -459,6 +459,7 @@ class NeuralPosterior(ABC):
             initial_params={"": self._mcmc_init_params},
             num_chains=num_chains,
             mp_context="fork",
+            transforms={},
             disable_progbar=not show_progress_bars,
         )
         sampler.run()


### PR DESCRIPTION
Fix for #286 

Ok, I'm still pretty confused why this happens. It seems that, after the mcmc chain is run, `.cleanup` is called [here](https://github.com/pyro-ppl/pyro/blob/2dfa8da0dd400c3712768385d8306848e93dab9a/pyro/infer/mcmc/api.py#L171) which then calls `._reset()`, which sets the `init_params=None`, see [here](https://github.com/pyro-ppl/pyro/blob/2dfa8da0dd400c3712768385d8306848e93dab9a/pyro/infer/mcmc/hmc.py#L148).

However, **after** all this, transforms are performed on the samples. If `transforms=None` was specified, a transformation is automatically inferred, as explained [here](https://github.com/pyro-ppl/pyro/blob/2dfa8da0dd400c3712768385d8306848e93dab9a/pyro/infer/mcmc/hmc.py#L50). However, this again sets up the kernel [here](https://github.com/pyro-ppl/pyro/blob/2dfa8da0dd400c3712768385d8306848e93dab9a/pyro/infer/mcmc/api.py#L414), which **requires init_params**. It breaks because the `init_params` had been set to `None`.

A fix is to set `transforms={}`. With this, transforms are not automatically inferred and everything works fine.

**--- Update ---**
[This](https://github.com/pyro-ppl/pyro/commit/4996a77fe56e26982b3dec0012744885f48ea404#diff-6075bc4ce62e591e03146eae732344e7) is the exact commit that broke our code. After this change, if `kernel` is None, it still tries to run `self.kernel.setup`, which will break.

Should we report this as an issue to pyro?