### PR TITLE
Adding an FAQ section to website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.11.3
+
+- Added an FAQ (#293)
+
+
 # v0.11.2
 
 - Fixed pickling of SNRE by moving StandardizeInputs (#291)

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,3 +14,10 @@ The docs can be updated to GitHub using:
 ```bash
 jupyter nbconvert --to markdown ../tutorial/*.ipynb --output-dir docs/tutorial/ && mkdocs gh-deploy
 ```
+
+## Contributing FAQ
+
+Create a new markdown file named `question_XX.md` in the `docs/faq` folder, where `XX` 
+is a running index for the questions. The file should start with the question as title 
+(i.e. starting with a `#`) and then have the answer below. Additionally, you need to 
+add a link to your question in the markdown file `docs/faq.md`.

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -1,0 +1,5 @@
+# Frequently asked questions
+
+[Can the algorithms deal with invalid data, e.g. NaN or inf?](faq/question_02.md)
+
+[What should I do when my 'posterior samples are outside of the prior support' in SNPE?](faq/question_01.md)

--- a/docs/docs/faq/question_01.md
+++ b/docs/docs/faq/question_01.md
@@ -1,0 +1,19 @@
+# What should I do when my 'posterior samples are outside of the prior support' in SNPE?
+
+When working with **multi-round** SNPE, you might have experienced the following
+warning: 
+```
+Only x% posterior samples are within the prior support. It may take a long time to collect the remaining 10000 samples. Consider interrupting (Ctrl-C) and switching to 'sample_with_mcmc=True'.
+```
+
+This reason for this issue is described in more detail 
+[here](https://arxiv.org/abs/2002.03712) and [here](https://arxiv.org/abs/1905.07488). 
+The following fixes are possible:  
+
+- sample with MCMC: `samples = posterior((num_samples,), x=x_o, sample_with_mcmc=True)`.
+This will make sampling slower, but samples will not 'leak'.  
+
+- resort to single-round SNPE and (if necessary) increase your simulation budget.  
+
+- use a different algorithm, e.g. SNRE and SNLE. Note, however, that these algorithms
+can have different issues and potential pitfalls.  

--- a/docs/docs/faq/question_02.md
+++ b/docs/docs/faq/question_02.md
@@ -1,0 +1,23 @@
+# Can the algorithms deal with invalid data, e.g. NaN or inf?
+
+Yes. By default, whenever a simulation returns at least one `NaN` or `inf`, it is 
+completely excluded from the training data. In other words, the simulation is simply 
+discarded.
+
+In cases where a very large fraction of simulations return `NaN` or `inf`, discarding 
+many simulations can be wasteful. Hence, it can be 
+beneficial to manually substitute the 'invalid' values with a reasonable replacement. 
+I.e., at the end of your simulation code, you search for invalid entries and replace 
+them with a floating point number. Importantly, in order for neural network training 
+work well, the floating point number should still be in a reasonable range, i.e. maybe a
+ few standard deviations outside of 'good' values.
+
+If you are running **multi-round** SNPE, however, things can go fully wrong if invalid
+ data are encountered. In that case, you will get the following warning
+```
+When invalid simulations are excluded, multi-round SNPE-C can leak into the regions where parameters led to invalid simulations. This can lead to poor results.
+```
+Hence, if you are running multi-round SNPE and a significant fraction of simulations
+returns at least one invalid number, we strongly recommend to manually replace the value
+ in your simulation code as described above (or resort to single-round SNPE or use a 
+ different method).

--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -1,6 +1,6 @@
 # Installation
 
-`sbi` requires Python 3.7 or higher. It can be installed using `pip`:
+`sbi` requires Python 3.6 or higher. It can be installed using `pip`:
 ```commandline
 $ pip install sbi
 ```
@@ -9,7 +9,7 @@ We recommend to use a [`conda`](https://docs.conda.io/en/latest/miniconda.html) 
 environment ([Miniconda installation instructions](https://docs.conda.io/en/latest/miniconda.html])). If `conda` is installed on the system, an environment for
 installing `sbi` can be created as follows:
 ```commandline
-# Create an environment for sbi (indicate Python 3.7 or higher); activate it
+# Create an environment for sbi (indicate Python 3.6 or higher); activate it
 $ conda create -n sbi_env python=3.7 && conda activate sbi_env
 ```
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
       - Flexible interface: tutorial/03_flexible_interface.md
   - Contribute: contribute.md
   - API Reference: reference.md
+  - FAQ: faq.md
   - Credits: credits.md
 
 repo_name: 'mackelab/sbi'


### PR DESCRIPTION
Seeded an FAQ for the website.

We could also add each of the questions to `nav`, but I think this would make the dropdown menu look quite ugly because of the long titles of the questions.

This is what it looks like:
![file1](https://user-images.githubusercontent.com/24639769/89805843-87209d80-db36-11ea-8159-a9bdb8c4abed.png)

And after clicking on one of the questions...
![file2](https://user-images.githubusercontent.com/24639769/89805864-8ee04200-db36-11ea-9402-972bf3148cb8.png)
