### PR TITLE
Neural net creation documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # v0.11.3
 
 - Added an FAQ (#293)
+- Fixed bug in embedding_net when output dimension does not equal input dimension (#299)
+- Exposed arguments of functions used to build custom networks (#299)
 
 
 # v0.11.2

--- a/sbi/neural_nets/classifier.py
+++ b/sbi/neural_nets/classifier.py
@@ -88,7 +88,12 @@ def build_linear_classifier(
     Returns:
         Neural network.
     """
-    neural_net = nn.Linear(batch_x[0].numel() + batch_y[0].numel(), 1)
+
+    # Infer the output dimensionalities of the embedding_net by making a forward pass.
+    x_numel = embedding_net_x(batch_x[:1]).numel()
+    y_numel = embedding_net_y(batch_y[:1]).numel()
+
+    neural_net = nn.Linear(x_numel + y_numel, 1)
 
     input_layer = build_input_layer(
         batch_x, batch_y, z_score_x, z_score_y, embedding_net_x, embedding_net_y
@@ -124,8 +129,13 @@ def build_mlp_classifier(
     Returns:
         Neural network.
     """
+
+    # Infer the output dimensionalities of the embedding_net by making a forward pass.
+    x_numel = embedding_net_x(batch_x[:1]).numel()
+    y_numel = embedding_net_y(batch_y[:1]).numel()
+
     neural_net = nn.Sequential(
-        nn.Linear(batch_x[0].numel() + batch_y[0].numel(), hidden_features),
+        nn.Linear(x_numel + y_numel, hidden_features),
         nn.BatchNorm1d(hidden_features),
         nn.ReLU(),
         nn.Linear(hidden_features, hidden_features),
@@ -168,8 +178,13 @@ def build_resnet_classifier(
     Returns:
         Neural network.
     """
+
+    # Infer the output dimensionalities of the embedding_net by making a forward pass.
+    x_numel = embedding_net_x(batch_x[:1]).numel()
+    y_numel = embedding_net_y(batch_y[:1]).numel()
+
     neural_net = nets.ResidualNet(
-        in_features=batch_x[0].numel() + batch_y[0].numel(),
+        in_features=x_numel + y_numel,
         out_features=1,
         hidden_features=hidden_features,
         context_features=None,

--- a/sbi/neural_nets/classifier.py
+++ b/sbi/neural_nets/classifier.py
@@ -72,6 +72,7 @@ def build_linear_classifier(
     z_score_y: bool = True,
     embedding_net_x: nn.Module = nn.Identity(),
     embedding_net_y: nn.Module = nn.Identity(),
+    **kwargs
 ) -> nn.Module:
     """Builds linear classifier.
 
@@ -84,6 +85,8 @@ def build_linear_classifier(
         z_score_y: Whether to z-score ys passing into the network.
         embedding_net_x: Optional embedding network for x.
         embedding_net_y: Optional embedding network for y.
+        kwargs: Additional arguments that are passed by the build function but are not
+            relevant for linear classifiers and are therefore ignored.
 
     Returns:
         Neural network.

--- a/sbi/neural_nets/flow.py
+++ b/sbi/neural_nets/flow.py
@@ -39,7 +39,8 @@ def build_made(
         Neural network.
     """
     x_numel = batch_x[0].numel()
-    y_numel = batch_y[0].numel()
+    # Infer the output dimensionality of the embedding_net by making a forward pass.
+    y_numel = embedding_net(batch_y[:1]).numel()
 
     if x_numel == 1:
         warn(f"In one-dimensional output space, this flow is limited to Gaussians")
@@ -96,7 +97,8 @@ def build_maf(
         Neural network.
     """
     x_numel = batch_x[0].numel()
-    y_numel = batch_y[0].numel()
+    # Infer the output dimensionality of the embedding_net by making a forward pass.
+    y_numel = embedding_net(batch_y[:1]).numel()
 
     if x_numel == 1:
         warn(f"In one-dimensional output space, this flow is limited to Gaussians")
@@ -160,7 +162,8 @@ def build_nsf(
         Neural network.
     """
     x_numel = batch_x[0].numel()
-    y_numel = batch_y[0].numel()
+    # Infer the output dimensionality of the embedding_net by making a forward pass.
+    y_numel = embedding_net(batch_y[:1]).numel()
 
     if x_numel == 1:
         raise NotImplementedError

--- a/sbi/neural_nets/flow.py
+++ b/sbi/neural_nets/flow.py
@@ -19,9 +19,9 @@ def build_made(
     z_score_x: bool = True,
     z_score_y: bool = True,
     hidden_features: int = 50,
-    num_blocks: int = 5,
     num_mixture_components: int = 10,
     embedding_net: nn.Module = nn.Identity(),
+    **kwargs,
 ) -> nn.Module:
     """Builds MADE p(x|y).
 
@@ -31,9 +31,10 @@ def build_made(
         z_score_x: Whether to z-score xs passing into the network.
         z_score_y: Whether to z-score ys passing into the network.
         hidden_features: Number of hidden features.
-        num_blocks: Number of MADE blocks.
         num_mixture_components: Number of mixture components.
         embedding_net: Optional embedding network for y.
+        kwargs: Additional arguments that are passed by the build function but are not
+            relevant for mades and are therefore ignored.
 
     Returns:
         Neural network.
@@ -58,7 +59,7 @@ def build_made(
         features=x_numel,
         hidden_features=hidden_features,
         context_features=y_numel,
-        num_blocks=num_blocks,
+        num_blocks=5,
         num_mixture_components=num_mixture_components,
         use_residual_blocks=True,
         random_mask=False,
@@ -181,7 +182,7 @@ def build_nsf(
                             out_features=out_features,
                             hidden_features=hidden_features,
                             context_features=y_numel,
-                            num_blocks=2,
+                            num_blocks=num_blocks,
                             activation=relu,
                             dropout_probability=0.0,
                             use_batch_norm=False,

--- a/sbi/neural_nets/mdn.py
+++ b/sbi/neural_nets/mdn.py
@@ -33,7 +33,8 @@ def build_mdn(
         Neural network.
     """
     x_numel = batch_x[0].numel()
-    y_numel = batch_y[0].numel()
+    # Infer the output dimensionality of the embedding_net by making a forward pass.
+    y_numel = embedding_net(batch_y[:1]).numel()
 
     transform = transforms.IdentityTransform()
 

--- a/sbi/neural_nets/mdn.py
+++ b/sbi/neural_nets/mdn.py
@@ -17,6 +17,7 @@ def build_mdn(
     hidden_features: int = 50,
     num_components: int = 10,
     embedding_net: nn.Module = nn.Identity(),
+    **kwargs
 ) -> nn.Module:
     """Builds MDN p(x|y).
 
@@ -28,6 +29,8 @@ def build_mdn(
         hidden_features: Number of hidden features.
         num_components: Number of components.
         embedding_net: Optional embedding network for y.
+        kwargs: Additional arguments that are passed by the build function but are not
+            relevant for MDNs and are therefore ignored.
 
     Returns:
         Neural network.

--- a/sbi/utils/get_nn_models.py
+++ b/sbi/utils/get_nn_models.py
@@ -49,7 +49,7 @@ def classifier_nn(
             the network.
         hidden_features: Number of hidden features.
         embedding_net_theta:  Optional embedding network for parameters $\theta$.
-        embedding_net_x:  Optional embedding network for simulation outputs $x. This
+        embedding_net_x:  Optional embedding network for simulation outputs $x$. This
             embedding net allows to learn features from potentially high-dimensional
             simulation outputs.
     """
@@ -112,7 +112,9 @@ def likelihood_nn(
         z_score_x: Whether to z-score simulation outputs $x$ before passing them into
             the network.
         hidden_features: Number of hidden features.
-        num_transforms: Number of transforms when a flow is used.
+        num_transforms: Number of transforms when a flow is used. Only relevant if
+            density estimator is a normalizing flow (i.e. currently either a `maf` or a
+            `nsf`). Ignored if density estimator is a `mdn` or `made`.
         embedding_net: Optional embedding network for parameters $\theta$.
     """
 
@@ -125,7 +127,7 @@ def likelihood_nn(
                 "num_transforms",
                 "embedding_net",
             ),
-            (z_score_x, z_score_theta, hidden_features, num_transforms, embedding_net),
+            (z_score_x, z_score_theta, hidden_features, num_transforms, embedding_net,),
         )
     )
 
@@ -166,7 +168,9 @@ def posterior_nn(
         z_score_x: Whether to z-score simulation outputs $x$ before passing them into
             the network.
         hidden_features: Number of hidden features.
-        num_transforms: Number of transforms when a flow is used.
+        num_transforms: Number of transforms when a flow is used. Only relevant if
+            density estimator is a normalizing flow (i.e. currently either a `maf` or a
+            `nsf`). Ignored if density estimator is a `mdn` or `made`.
         embedding_net: Optional embedding network for simulation outputs $x$. This
             embedding net allows to learn features from potentially high-dimensional
             simulation outputs.
@@ -181,7 +185,7 @@ def posterior_nn(
                 "num_transforms",
                 "embedding_net",
             ),
-            (z_score_theta, z_score_x, hidden_features, num_transforms, embedding_net),
+            (z_score_theta, z_score_x, hidden_features, num_transforms, embedding_net,),
         )
     )
 

--- a/sbi/utils/get_nn_models.py
+++ b/sbi/utils/get_nn_models.py
@@ -28,12 +28,31 @@ from sbi.neural_nets.mdn import build_mdn
 
 def classifier_nn(
     model: str,
+    z_score_theta: bool = True,
     z_score_x: bool = True,
-    z_score_y: bool = True,
     hidden_features: int = 50,
+    embedding_net_theta: nn.Module = nn.Identity(),
     embedding_net_x: nn.Module = nn.Identity(),
-    embedding_net_y: nn.Module = nn.Identity(),
 ) -> Callable:
+    r"""
+    Returns a function that builds a classifier for learning density ratios.
+
+    This function will usually be used for SNRE. The returned function is to be passed
+    to the inference class when using the flexible interface.
+
+    Args:
+        model: The type of classifier that will be created. One of [`linear`, `mlp`,
+            `resnet`].
+        z_score_theta: Whether to z-score parameters $\theta$ before passing them into
+            the network.
+        z_score_x: Whether to z-score simulation outputs $x$ before passing them into
+            the network.
+        hidden_features: Number of hidden features.
+        embedding_net_theta:  Optional embedding network for parameters $\theta$.
+        embedding_net_x:  Optional embedding network for simulation outputs $x. This
+            embedding net allows to learn features from potentially high-dimensional
+            simulation outputs.
+    """
 
     kwargs = dict(
         zip(
@@ -44,7 +63,13 @@ def classifier_nn(
                 "embedding_net_x",
                 "embedding_net_y",
             ),
-            (z_score_x, z_score_y, hidden_features, embedding_net_x, embedding_net_y),
+            (
+                z_score_x,
+                z_score_theta,
+                hidden_features,
+                embedding_net_x,
+                embedding_net_theta,
+            ),
         )
     )
 
@@ -67,12 +92,29 @@ def classifier_nn(
 
 def likelihood_nn(
     model: str,
+    z_score_theta: bool = True,
     z_score_x: bool = True,
-    z_score_y: bool = True,
     hidden_features: int = 50,
     num_transforms: int = 5,
     embedding_net: nn.Module = nn.Identity(),
 ) -> Callable:
+    r"""
+    Returns a function that builds a density estimator for learning the likelihood.
+
+    This function will usually be used for SNLE. The returned function is to be passed
+    to the inference class when using the flexible interface.
+
+    Args:
+        model: The type of density estimator that will be created. One of [`mdn`,
+            `made`, `maf`, `nsf`].
+        z_score_theta: Whether to z-score parameters $\theta$ before passing them into
+            the network.
+        z_score_x: Whether to z-score simulation outputs $x$ before passing them into
+            the network.
+        hidden_features: Number of hidden features.
+        num_transforms: Number of transforms when a flow is used.
+        embedding_net: Optional embedding network for parameters $\theta$.
+    """
 
     kwargs = dict(
         zip(
@@ -83,7 +125,7 @@ def likelihood_nn(
                 "num_transforms",
                 "embedding_net",
             ),
-            (z_score_x, z_score_y, hidden_features, num_transforms, embedding_net),
+            (z_score_x, z_score_theta, hidden_features, num_transforms, embedding_net),
         )
     )
 
@@ -110,6 +152,25 @@ def posterior_nn(
     num_transforms: int = 5,
     embedding_net: nn.Module = nn.Identity(),
 ) -> Callable:
+    r"""
+    Returns a function that builds a density estimator for learning the posterior.
+
+    This function will usually be used for SNPE. The returned function is to be passed
+    to the inference class when using the flexible interface.
+
+    Args:
+        model: The type of density estimator that will be created. One of [`mdn`,
+            `made`, `maf`, `nsf`].
+        z_score_theta: Whether to z-score parameters $\theta$ before passing them into
+            the network.
+        z_score_x: Whether to z-score simulation outputs $x$ before passing them into
+            the network.
+        hidden_features: Number of hidden features.
+        num_transforms: Number of transforms when a flow is used.
+        embedding_net: Optional embedding network for simulation outputs $x$. This
+            embedding net allows to learn features from potentially high-dimensional
+            simulation outputs.
+    """
 
     kwargs = dict(
         zip(

--- a/sbi/utils/get_nn_models.py
+++ b/sbi/utils/get_nn_models.py
@@ -2,17 +2,52 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 
-from typing import Callable, Optional, Union, Dict, Any, Tuple, Union, cast, List, Sequence, TypeVar
-from sbi.neural_nets.flow import build_made, build_maf, build_nsf
-from sbi.neural_nets.mdn import build_mdn
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+)
+
+from torch import nn
+
 from sbi.neural_nets.classifier import (
     build_linear_classifier,
     build_mlp_classifier,
     build_resnet_classifier,
 )
+from sbi.neural_nets.flow import build_made, build_maf, build_nsf
+from sbi.neural_nets.mdn import build_mdn
 
 
-def classifier_nn(model: str, **kwargs: Any) -> Callable:
+def classifier_nn(
+    model: str,
+    z_score_x: bool = True,
+    z_score_y: bool = True,
+    hidden_features: int = 50,
+    embedding_net_x: nn.Module = nn.Identity(),
+    embedding_net_y: nn.Module = nn.Identity(),
+) -> Callable:
+
+    kwargs = dict(
+        zip(
+            (
+                "z_score_x",
+                "z_score_y",
+                "hidden_features",
+                "embedding_net_x",
+                "embedding_net_y",
+            ),
+            (z_score_x, z_score_y, hidden_features, embedding_net_x, embedding_net_y),
+        )
+    )
+
     def build_fn(batch_theta, batch_x):
         if model == "linear":
             return build_linear_classifier(
@@ -24,12 +59,34 @@ def classifier_nn(model: str, **kwargs: Any) -> Callable:
             return build_resnet_classifier(
                 batch_x=batch_x, batch_y=batch_theta, **kwargs
             )
+        else:
             raise NotImplementedError
 
     return build_fn
 
 
-def likelihood_nn(model: str, **kwargs: Any) -> Callable:
+def likelihood_nn(
+    model: str,
+    z_score_x: bool = True,
+    z_score_y: bool = True,
+    hidden_features: int = 50,
+    num_transforms: int = 5,
+    embedding_net: nn.Module = nn.Identity(),
+) -> Callable:
+
+    kwargs = dict(
+        zip(
+            (
+                "z_score_x",
+                "z_score_y",
+                "hidden_features",
+                "num_transforms",
+                "embedding_net",
+            ),
+            (z_score_x, z_score_y, hidden_features, num_transforms, embedding_net),
+        )
+    )
+
     def build_fn(batch_theta, batch_x):
         if model == "mdn":
             return build_mdn(batch_x=batch_x, batch_y=batch_theta, **kwargs)
@@ -45,7 +102,28 @@ def likelihood_nn(model: str, **kwargs: Any) -> Callable:
     return build_fn
 
 
-def posterior_nn(model: str, **kwargs: Any) -> Callable:
+def posterior_nn(
+    model: str,
+    z_score_theta: bool = True,
+    z_score_x: bool = True,
+    hidden_features: int = 50,
+    num_transforms: int = 5,
+    embedding_net: nn.Module = nn.Identity(),
+) -> Callable:
+
+    kwargs = dict(
+        zip(
+            (
+                "z_score_x",
+                "z_score_y",
+                "hidden_features",
+                "num_transforms",
+                "embedding_net",
+            ),
+            (z_score_theta, z_score_x, hidden_features, num_transforms, embedding_net),
+        )
+    )
+
     def build_fn(batch_theta, batch_x):
         if model == "mdn":
             return build_mdn(batch_x=batch_theta, batch_y=batch_x, **kwargs)


### PR DESCRIPTION
Fixes #298 

### Problem desciption

We introduced `**kwargs` e.g. to `posterior_nn` [here](https://github.com/mackelab/sbi/blob/7c56cc210f226839bf91d037ccd258a733096de5/sbi/utils/get_nn_models.py#L48), which hides e.g. the `embedding_net` from the API reference.

### Solution

The arguments to the functions are now explicit. We post-hoc rebuild the dictionary to avoid having to pass everything to each density estimator. If a specific `kwarg` does not apply to a specific density estimator, it is simply used up in the `**kwargs` of the build function and not used. For example, `build_mdn` will not have an argument `num_transforms` -> will be in `**kwargs`.

### Consideration of other implementations

It is in theory possible to get all variables into a `dict` without having to retype the variable names (see [here](https://stackoverflow.com/questions/3972872/python-variables-as-keys-to-dict) Christian Vanderwall's answer for python 2.7). However, there are two reasons to not do this:
1) I find it a bit ugly
2) re-typing the variable names allows us to change the names. For the density estimators we opted for the syntax `p(x|y)` in order to be general for both `SNPE` and `SNLE`. We can hide this confusion from users by 'renaming' the arguments in this step.

### Other changes...

- Includes docstring for the function visible to the user.
- Fixes a bug with `embedding_net`: it had previously only worked if the networks output dimension was the same as the input dimension. Now, the output dimension can be anything.
