### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ![Tests](https://github.com/mackelab/sbi/workflows/Tests/badge.svg?branch=main)
 
 ## sbi: simulation-based inference
+[Documentation](https://www.mackelab.org/sbi/)
 
 `sbi` is a PyTorch package for simulation-based inference. Simulation-based inference is
 the process of finding parameters of a simulator from observations.

--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -1,16 +1,16 @@
 # Installation
 
-`sbi` requires Python 3.6 or higher. It can be installed using `pip`:
-```commandline
-$ pip install sbi
-```
-
-We recommend to use a [`conda`](https://docs.conda.io/en/latest/miniconda.html) virtual
+`sbi` requires Python 3.6 or higher. We recommend to use a [`conda`](https://docs.conda.io/en/latest/miniconda.html) virtual
 environment ([Miniconda installation instructions](https://docs.conda.io/en/latest/miniconda.html])). If `conda` is installed on the system, an environment for
 installing `sbi` can be created as follows:
 ```commandline
 # Create an environment for sbi (indicate Python 3.6 or higher); activate it
 $ conda create -n sbi_env python=3.7 && conda activate sbi_env
+```
+
+Independent of whether you are using `conda` or not, `sbi` can be installed using `pip`:
+```commandline
+$ pip install sbi
 ```
 
 To test the installation, drop into a python prompt and run

--- a/tutorial/00_getting_started.ipynb
+++ b/tutorial/00_getting_started.ipynb
@@ -8,6 +8,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note, you find the original version of this notebook at [https://github.com/mackelab/sbi/blob/main/tutorial/00_getting_started.ipynb](https://github.com/mackelab/sbi/blob/main/tutorial/00_getting_started.ipynb) in the `sbi` repository."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},

--- a/tutorial/01_gaussian_amortized.ipynb
+++ b/tutorial/01_gaussian_amortized.ipynb
@@ -11,6 +11,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Note, you find the original version of this notebook at [https://github.com/mackelab/sbi/blob/main/tutorial/01_gaussian_amortized.ipynb](https://github.com/mackelab/sbi/blob/main/tutorial/01_gaussian_amortized.ipynb) in the `sbi` repository."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "In this tutorial, we will demonstrate how `sbi` can infer an amortized posterior for a simple toy model with a uniform prior and Gaussian likelihood."
    ]
   },

--- a/tutorial/02_HH_simulator.ipynb
+++ b/tutorial/02_HH_simulator.ipynb
@@ -13,6 +13,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Note, you find the original version of this notebook at [https://github.com/mackelab/sbi/blob/main/tutorial/02_HH_simulator.ipynb](https://github.com/mackelab/sbi/blob/main/tutorial/02_HH_simulator.ipynb) in the `sbi` repository."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "First we are going to import basic packages."
    ]
   },

--- a/tutorial/03_flexible_interface.ipynb
+++ b/tutorial/03_flexible_interface.ipynb
@@ -15,6 +15,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Note, you find the original version of this notebook at [https://github.com/mackelab/sbi/blob/main/tutorial/03_flexible_interface.ipynb](https://github.com/mackelab/sbi/blob/main/tutorial/03_flexible_interface.ipynb) in the `sbi` repository."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Features\n",
     "\n",
     "The flexible interface allows you to customize the following:\n",


### PR DESCRIPTION
# Changes
- add links in readme: makes it easier for users to find the documentation and tutorials. 
- re-order installation instructions: let users install / set up conda env before installing via pip.
- add link to all tutorial notebooks so that users can find them in the repo when they look at them in the documentation. 

# issues
fixes #295 
fixes #296 
fixes #297 

# Input needed:
- for the links to the documentation: do you prefer a badge? (we already have quite many) 
- links in the notebook are repetitive, do you have a better idea? 