### PR TITLE
allow multiD x with appropriate embedding, add warning.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Conditional distributions and correlations for analysing the posterior (#321)
 - Moved rarely used arguments from pairplot into kwargs (#321)
 - Sampling from conditional posterior (#327)
+- Allow inference with multi-dimensional x when appropriate embedding is passed (#335)
 
 
 # v0.12.2

--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -9,18 +9,14 @@ from typing import (
     Dict,
     List,
     Optional,
-    Sequence,
     Tuple,
-    TypeVar,
-    Union,
-    cast,
 )
 
 import numpy as np
 import torch
 from pyro.infer.mcmc import HMC, NUTS
 from pyro.infer.mcmc.api import MCMC
-from torch import Tensor, log
+from torch import Tensor
 from torch import multiprocessing as mp
 from torch import nn
 

--- a/sbi/user_input/user_input_checks.py
+++ b/sbi/user_input/user_input_checks.py
@@ -257,14 +257,6 @@ def check_for_possibly_batched_x_shape(x_shape):
             respectively, without the user needing to wrap or unsqueeze them.
             """
         )
-    # Warn on multidimensional data with `batch_size` one.
-    elif inferred_data_ndim > 1 and inferred_batch_shape == 1:
-        warnings.warn(
-            f"""Beware: The observed data (x_o) you passed was interpreted to have
-            matrix shape: {inferred_data_shape}. The current implementation of sbi
-            might not provide stable support for this and result in shape mismatches.
-            """
-        )
     else:
         pass
 

--- a/tests/multidimensional_x_test.py
+++ b/tests/multidimensional_x_test.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from torch import zeros
+import torch
+import pytest
+from sbi import utils as utils
+from sbi.inference import SNPE, prepare_for_sbi
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+# Minimal 2D simulator.
+def simulator_2d(theta):
+    x = torch.rand(theta.shape[0], 32, 32)
+    return x
+
+
+class CNNEmbedding(nn.Module):
+    """Big CNN embedding net to levarage GPU computation."""
+
+    def __init__(self):
+        super().__init__()
+        # 2D convolutional layer
+        self.conv1 = nn.Conv2d(in_channels=1, out_channels=16, kernel_size=5, padding=2)
+        self.conv2 = nn.Conv2d(in_channels=16, out_channels=6, kernel_size=5, padding=2)
+        # Maxpool layer that reduces 32x32 image to 4x4
+        self.pool = nn.MaxPool2d(kernel_size=8, stride=8)
+        # Fully connected layer taking as input the 6 flattened output arrays from the
+        # maxpooling layer
+        self.fc = nn.Linear(in_features=6 * 4 * 4, out_features=8)
+
+    def forward(self, x):
+        x = x.view(-1, 1, 32, 32)
+        x = F.relu(self.conv1(x))
+        x = self.pool(F.relu(self.conv2(x)))
+        x = x.view(-1, 6 * 4 * 4)
+        x = F.relu(self.fc(x))
+        return x
+
+
+@pytest.mark.parametrize(
+    "embedding",
+    (
+        pytest.param(nn.Identity, marks=pytest.mark.xfail(reason="Invalid embedding.")),
+        pytest.param(CNNEmbedding),
+    ),
+)
+def test_inference_with_2d_x(embedding):
+
+    num_dim = 2
+    num_samples = 10
+    num_simulations = 100
+
+    prior = utils.BoxUniform(zeros(num_dim), torch.ones(num_dim))
+
+    simulator, prior = prepare_for_sbi(simulator_2d, prior)
+
+    theta_o = torch.ones(1, num_dim)
+    x_o = simulator(theta_o)
+
+    infer = SNPE(
+        simulator,
+        prior,
+        show_progress_bars=False,
+        density_estimator=utils.posterior_nn(model="mdn", embedding_net=embedding(),),
+    )
+
+    posterior = infer(
+        num_simulations=num_simulations, training_batch_size=100, max_num_epochs=10
+    ).set_default_x(x_o)
+
+    posterior.log_prob(posterior.sample((num_samples,), show_progress_bars=False))


### PR DESCRIPTION
Previously, the warning about multi-D `x` was raised when an `x_o` was passed, i.e., only during evaluation or sampling.

This PR changes the warning and raises as soon as one can infer the shape of `x`, i.e., after simulating. 
It also changes the search for invalid `x` and one assert to allow for multi-D in inference. Seems to work just fine. 

closes #333 
closes #332 
