### PR TITLE
Fix clamp_and_warn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # v0.13.0
+
 - Conditional distributions and correlations for analysing the posterior (#321)
 - Moved rarely used arguments from pairplot into kwargs (#321)
 - Sampling from conditional posterior (#327)
 - Allow inference with multi-dimensional x when appropriate embedding is passed (#335)
+- Fixes a bug with clamp_and_warn not overriding num_atoms for SNRE and the warning message itself (#338)
 
 
 # v0.12.2

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -234,8 +234,9 @@ class RatioEstimator(NeuralInference, ABC):
 
         clipped_batch_size = min(training_batch_size, num_validation_examples)
 
-        # num_atoms = theta.shape[0]
-        clamp_and_warn("num_atoms", num_atoms, min_val=2, max_val=clipped_batch_size)
+        num_atoms = clamp_and_warn(
+            "num_atoms", num_atoms, min_val=2, max_val=clipped_batch_size
+        )
 
         # Dataset is shared for training and validation loaders.
         dataset = data.TensorDataset(theta, x)

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -50,7 +50,7 @@ def clamp_and_warn(name: str, value: float, min_val: float, max_val: float) -> f
     if clamped_val != value:
         logging.warning(
             f"{name}={value} was clamped to {clamped_val}; "
-            "must be in [{min_val},{max_val}] range"
+            f"must be in [{min_val},{max_val}] range"
         )
 
     return clamped_val


### PR DESCRIPTION
Fixes a bug with `clamp_and_warn` not overriding `num_atoms` for SNRE and the warning message itself