### PR TITLE
Pyro compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Sampling from conditional posterior (#327)
 - Allow inference with multi-dimensional x when appropriate embedding is passed (#335)
 - Fixes a bug with clamp_and_warn not overriding num_atoms for SNRE and the warning message itself (#338)
+- Compatibility with Pyro 1.4.0 (#339)
 
 
 # v0.12.2

--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -422,6 +422,7 @@ class NeuralPosterior(ABC):
             num_chains=num_chains,
             mp_context="fork",
             disable_progbar=not show_progress_bars,
+            transforms={},
         )
         sampler.run()
         samples = next(iter(sampler.get_samples().values())).reshape(

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,8 @@ REQUIRED = [
     "matplotlib",
     "numpy",
     "pillow",
-    "pyknos==0.12",
-    "pyro-ppl==1.3.1",  # TODO: Remove once #286 is addressed
+    "pyknos>=0.12",
+    "pyro-ppl>=1.3.1",
     "scipy",
     "tensorboard",
     "torch>=1.5.1",


### PR DESCRIPTION
For context, see: https://github.com/mackelab/sbi/pull/288, https://github.com/mackelab/sbi/issues/286

While the bug was fixed in Pyro, no new Pyro version has been released yet. This PR explicitly passes `transforms={}` to Pyro, which allows using `1.4.0`.