### PR TITLE
Allow vectorized evaluation of numpy potentials

### DIFF
--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -3,6 +3,7 @@
 
 from abc import ABC, abstractmethod
 from copy import deepcopy
+from sbi.mcmc import init_strategy
 from typing import (
     Any,
     Callable,
@@ -65,8 +66,8 @@ class NeuralPosterior(ABC):
                 samples to discard, `num_chains` for the number of chains,
                 `init_strategy` for the initialisation strategy for chains; `prior`
                 will draw init locations from prior, whereas `sir` will use Sequential-
-                Importance-Resampling using `init_strategy_num_candidates` to find init
-                locations.
+                Importance-Resampling. Init strategies may have their own keywords
+                which can also be set from `mcmc_parameters`.
         """
         if method_family in ("snpe", "snle", "snre_a", "snre_b"):
             self._method_family = method_family
@@ -546,12 +547,7 @@ class NeuralPosterior(ABC):
         return samples.reshape((*sample_shape, -1))
 
     def _build_mcmc_init_fn(
-        self,
-        prior: Any,
-        potential_fn: Callable,
-        init_strategy: str = "prior",
-        init_strategy_num_candidates: int = 10000,
-        **kwargs,
+        self, prior: Any, potential_fn: Callable, init_strategy: str, **kwargs,
     ) -> Callable:
         """
         Return function that, when called, creates an initial parameter set for MCMC.
@@ -561,19 +557,16 @@ class NeuralPosterior(ABC):
             potential_fn: Potential function that the candidate samples are weighted
                 with.
             init_strategy: Specifies the initialization method. Either of
-                [`prior`|`sir`].
-            init_strategy_num_candidates: Number of candidate samples drawn.
-            kwargs: Absorbs passed but unused arguments. E.g. in
-                `DirectPosterior.sample()` we pass `mcmc_parameters` which might
-                contain entries that are not used here.
+                [`prior`|`sir`|`latest_sample`].
+            kwargs: Passed on init function. This way, init specific keywords can
+                be set through `mcmc_parameters`. Unused arguments should be absorbed.
 
         Returns: Initialization function.
         """
-
         if init_strategy == "prior":
-            return lambda: prior_init(prior)
+            return lambda: prior_init(prior, **kwargs)
         elif init_strategy == "sir":
-            return lambda: sir(prior, potential_fn, init_strategy_num_candidates,)
+            return lambda: sir(prior, potential_fn, **kwargs)
         elif init_strategy == "latest_sample":
             return lambda: self._mcmc_init_params
         else:

--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -547,7 +547,11 @@ class NeuralPosterior(ABC):
         return samples.reshape((*sample_shape, -1))
 
     def _build_mcmc_init_fn(
-        self, prior: Any, potential_fn: Callable, init_strategy: str, **kwargs,
+        self,
+        prior: Any,
+        potential_fn: Callable,
+        init_strategy: str = "prior",
+        **kwargs,
     ) -> Callable:
         """
         Return function that, when called, creates an initial parameter set for MCMC.

--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -3,7 +3,6 @@
 
 from abc import ABC, abstractmethod
 from copy import deepcopy
-from sbi.mcmc import init_strategy
 from typing import (
     Any,
     Callable,

--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -561,7 +561,7 @@ class NeuralPosterior(ABC):
                 with.
             init_strategy: Specifies the initialization method. Either of
                 [`prior`|`sir`|`latest_sample`].
-            kwargs: Passed on init function. This way, init specific keywords can
+            kwargs: Passed on to init function. This way, init specific keywords can
                 be set through `mcmc_parameters`. Unused arguments should be absorbed.
 
         Returns: Initialization function.

--- a/sbi/inference/posteriors/ratio_based_posterior.py
+++ b/sbi/inference/posteriors/ratio_based_posterior.py
@@ -325,12 +325,12 @@ class PotentialFunctionProvider:
             Posterior log probability of theta.
         """
         theta = torch.as_tensor(theta, dtype=torch.float32)
-
-        # Theta and x should have shape (1, dim).
         theta = ensure_theta_batched(theta)
-        x = ensure_x_batched(self.x)
+        num_batch = theta.shape[0]
+        x = ensure_x_batched(self.x).repeat(num_batch, 1)
 
-        log_ratio = self.classifier(torch.cat((theta, x), dim=1).reshape(1, -1))
+        with torch.set_grad_enabled(False):
+            log_ratio = self.classifier(torch.cat((theta, x), dim=1)).reshape(-1)
 
         # Notice opposite sign to pyro potential.
         return log_ratio + self.prior.log_prob(theta)

--- a/sbi/mcmc/init_strategy.py
+++ b/sbi/mcmc/init_strategy.py
@@ -28,6 +28,7 @@ def sir(
         potential_fn: Potential function that the candidate samples are weighted with.
             Note that the function needs to return log probabilities.
         init_strategy_num_candidates: Number of candidate samples drawn.
+        batch_size: Batch size used for evaluating candidates.
 
     Returns:
         A single sample.

--- a/sbi/mcmc/init_strategy.py
+++ b/sbi/mcmc/init_strategy.py
@@ -1,4 +1,4 @@
-f  # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
+# This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 from copy import deepcopy


### PR DESCRIPTION
Changes numpy potential functions to allow vectorized evaluations. The SIR init strategy is adapted to make use of the speedup.

Will merge upon 1 approving review