### PR TITLE
Vectorized slice sampler

### DIFF
--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -21,7 +21,7 @@ from torch import multiprocessing as mp
 from torch import nn
 
 from sbi import utils as utils
-from sbi.mcmc import Slice, SliceSampler, prior_init, sir
+from sbi.mcmc import Slice, SliceSampler, SliceSamplerVectorized, prior_init, sir
 from sbi.types import Array, Shape
 from sbi.user_input.user_input_checks import process_x
 from sbi.utils.torchutils import (
@@ -312,15 +312,17 @@ class NeuralPosterior(ABC):
 
         initial_params = torch.cat([init_fn() for _ in range(num_chains)])
 
-        track_gradients = mcmc_method != "slice" and mcmc_method != "slice_np"
+        track_gradients = mcmc_method in ("hmc", "nuts")
         with torch.set_grad_enabled(track_gradients):
-            if mcmc_method == "slice_np":
+            if mcmc_method in ("slice_np", "slice_np_vectorized"):
                 samples = self._slice_np_mcmc(
                     num_samples=num_samples,
                     potential_function=potential_fn,
                     initial_params=initial_params,
                     thin=thin,
                     warmup_steps=warmup_steps,
+                    vectorized=(mcmc_method == "slice_np_vectorized"),
+                    show_progress_bars=show_progress_bars,
                 )
             elif mcmc_method in ("hmc", "nuts", "slice"):
                 samples = self._pyro_mcmc(
@@ -345,6 +347,8 @@ class NeuralPosterior(ABC):
         initial_params: Tensor,
         thin: int,
         warmup_steps: int,
+        vectorized: bool = False,
+        show_progress_bars: bool = True,
     ) -> Tensor:
         """
         Custom implementation of slice sampling using Numpy.
@@ -355,26 +359,42 @@ class NeuralPosterior(ABC):
             initial_params: Initial parameters for MCMC chain.
             thin: Thinning (subsampling) factor.
             warmup_steps: Initial number of samples to discard.
+            vectorized: Whether to use a vectorized implementation of
+                the Slice sampler (still experimental).
+            show_progress_bars: Whether to show a progressbar during sampling;
+                can only be turned off for vectorized sampler.
 
         Returns: Tensor of shape (num_samples, shape_of_single_theta).
         """
-
         num_chains = initial_params.shape[0]
         dim_samples = initial_params.shape[1]
 
-        all_samples = []
-        for c in range(num_chains):
-            posterior_sampler = SliceSampler(
-                utils.tensor2numpy(initial_params[c, :]).reshape(-1),
-                lp_f=potential_function,
-                thin=thin,
+        if not vectorized:  # Sample all chains sequentially
+            all_samples = []
+            for c in range(num_chains):
+                posterior_sampler = SliceSampler(
+                    utils.tensor2numpy(initial_params[c, :]).reshape(-1),
+                    lp_f=potential_function,
+                    thin=thin,
+                )
+                if warmup_steps > 0:
+                    posterior_sampler.gen(int(warmup_steps))
+                all_samples.append(posterior_sampler.gen(int(num_samples / num_chains)))
+            all_samples = np.stack(all_samples).astype(np.float32)
+            samples = torch.from_numpy(all_samples)  # chains x samples x dim
+        else:  # Sample all chains at the same time
+            posterior_sampler = SliceSamplerVectorized(
+                init_params=utils.tensor2numpy(initial_params),
+                log_prob_fn=potential_function,
+                num_chains=num_chains,
+                verbose=show_progress_bars,
             )
-            if warmup_steps > 0:
-                posterior_sampler.gen(int(warmup_steps))
-            all_samples.append(posterior_sampler.gen(int(num_samples / num_chains)))
-        all_samples = np.stack(all_samples).astype(np.float32)
-
-        samples = torch.from_numpy(all_samples)  # chains x samples x dim
+            warmup_ = warmup_steps * thin
+            num_samples_ = int((num_samples * thin) / num_chains)
+            samples = posterior_sampler.run(warmup_ + num_samples_)
+            samples = samples[:, warmup_:, :]  # discard warmup steps
+            samples = samples[:, ::thin, :]  # thin chains
+            samples = torch.from_numpy(samples)  # chains x samples x dim
 
         # Save sample as potential next init (if init_strategy == 'latest_sample').
         self._mcmc_init_params = samples[:, -1, :].reshape(num_chains, dim_samples)

--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -14,6 +14,7 @@ from typing import (
 
 import numpy as np
 import torch
+from math import ceil
 from pyro.infer.mcmc import HMC, NUTS
 from pyro.infer.mcmc.api import MCMC
 from torch import Tensor
@@ -379,7 +380,9 @@ class NeuralPosterior(ABC):
                 )
                 if warmup_steps > 0:
                     posterior_sampler.gen(int(warmup_steps))
-                all_samples.append(posterior_sampler.gen(int(num_samples / num_chains)))
+                all_samples.append(
+                    posterior_sampler.gen(ceil(num_samples / num_chains))
+                )
             all_samples = np.stack(all_samples).astype(np.float32)
             samples = torch.from_numpy(all_samples)  # chains x samples x dim
         else:  # Sample all chains at the same time
@@ -390,7 +393,7 @@ class NeuralPosterior(ABC):
                 verbose=show_progress_bars,
             )
             warmup_ = warmup_steps * thin
-            num_samples_ = int((num_samples * thin) / num_chains)
+            num_samples_ = ceil((num_samples * thin) / num_chains)
             samples = posterior_sampler.run(warmup_ + num_samples_)
             samples = samples[:, warmup_:, :]  # discard warmup steps
             samples = samples[:, ::thin, :]  # thin chains

--- a/sbi/mcmc/__init__.py
+++ b/sbi/mcmc/__init__.py
@@ -1,3 +1,4 @@
 from sbi.mcmc.slice_numpy import SliceSampler
+from sbi.mcmc.slice_numpy_vectorized import SliceSamplerVectorized
 from sbi.mcmc.slice import Slice
 from sbi.mcmc.init_strategy import prior_init, sir

--- a/sbi/mcmc/slice_numpy_vectorized.py
+++ b/sbi/mcmc/slice_numpy_vectorized.py
@@ -1,0 +1,230 @@
+# This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
+# under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
+
+import numpy as np
+import os
+import sys
+
+from tqdm import trange
+
+from typing import Callable, Union
+
+
+class SliceSamplerVectorized:
+    def __init__(
+        self,
+        log_prob_fn: Callable,
+        init_params: np.ndarray,
+        num_chains: int = 1,
+        tuning: int = 50,
+        verbose: bool = True,
+        init_width: Union[float, np.ndarray] = 0.01,
+        max_width: float = float("inf"),
+    ):
+        """Slice sampler in pure Numpy, vectorized evaluations across chains.
+
+        Args:
+            log_prob_fn: Log prob function.
+            init_params: Initial parameters.
+            verbose: Show/hide additional info such as progress bars.
+            tuning: Number of tuning steps for brackets.
+            init_width: Inital width of brackets.
+            max_width: Maximum width of brackets.
+        """
+        self._log_prob_fn = log_prob_fn
+
+        self.x = init_params
+        self.num_chains = num_chains
+        self.tuning = tuning
+        self.verbose = verbose
+
+        self.init_width = init_width
+        self.max_width = max_width
+
+        self.logger = open(os.devnull, "w") if not self.verbose else sys.stdout
+
+        self.n_dims = self.x.size
+
+        self._reset()
+
+    def _reset(self):
+        self.rng = np.random
+        self.state = {}
+        for c in range(self.num_chains):
+            self.state[c] = {}
+            self.state[c]["t"] = 0
+            self.state[c]["width"] = None
+            self.state[c]["x"] = None
+
+    def run(self, num_samples: int) -> np.ndarray:
+        """Runs MCMC
+
+        Args:
+            num_samples: Number of samples to generate
+
+        Returns:
+            MCMC samples
+        """
+        assert num_samples >= 0
+
+        self.n_dims = self.x.shape[1]
+
+        # Init chains
+        for c in range(self.num_chains):
+            self.state[c]["x"] = self.x[c, :]
+
+            self.state[c]["i"] = 0
+            self.state[c]["order"] = list(range(self.n_dims))
+            self.rng.shuffle(self.state[c]["order"])
+
+            self.state[c]["samples"] = np.empty([int(num_samples), int(self.n_dims)])
+
+            self.state[c]["state"] = "BEGIN"
+
+            self.state[c]["width"] = np.full(self.n_dims, self.init_width)
+
+        num_chains_finished = 0
+        while num_chains_finished != self.num_chains:
+
+            num_chains_finished = 0
+
+            for sc in self.state.values():
+                if sc["state"] == "BEGIN":
+                    sc["cxi"] = sc["x"][sc["order"][sc["i"]]]
+                    sc["wi"] = sc["width"][sc["order"][sc["i"]]]
+                    sc["next_param"] = np.concatenate(
+                        [
+                            sc["x"][: sc["order"][sc["i"]]],
+                            [sc["cxi"]],
+                            sc["x"][sc["order"][sc["i"]] + 1 :],
+                        ]
+                    )
+
+            params = np.stack([sc["next_param"] for sc in self.state.values()])
+            log_probs = self._log_prob_fn(params)
+
+            for c in range(self.num_chains):
+                sc = self.state[c]
+
+                if sc["state"] == "BEGIN":
+                    # position the bracket randomly around the current sample
+                    sc["logu"] = log_probs[c] + np.log(1.0 - self.rng.rand())
+                    sc["lx"] = sc["cxi"] - sc["wi"] * self.rng.rand()
+                    sc["ux"] = sc["lx"] + sc["wi"]
+                    sc["next_param"] = np.concatenate(
+                        [
+                            sc["x"][: sc["order"][sc["i"]]],
+                            [sc["lx"]],
+                            sc["x"][sc["order"][sc["i"]] + 1 :],
+                        ]
+                    )
+                    sc["state"] = "LOWER"
+
+                elif sc["state"] == "LOWER":
+                    outside_lower = (
+                        log_probs[c] >= sc["logu"]
+                        and sc["cxi"] - sc["lx"] < self.max_width
+                    )
+
+                    if outside_lower:
+                        sc["lx"] -= sc["wi"]
+                        sc["next_param"] = np.concatenate(
+                            [
+                                sc["x"][: sc["order"][sc["i"]]],
+                                [sc["lx"]],
+                                sc["x"][sc["order"][sc["i"]] + 1 :],
+                            ]
+                        )
+
+                    else:
+                        sc["next_param"] = np.concatenate(
+                            [
+                                sc["x"][: sc["order"][sc["i"]]],
+                                [sc["ux"]],
+                                sc["x"][sc["order"][sc["i"]] + 1 :],
+                            ]
+                        )
+                        sc["state"] = "UPPER"
+
+                elif sc["state"] == "UPPER":
+                    outside_upper = (
+                        log_probs[c] >= sc["logu"]
+                        and sc["ux"] - sc["cxi"] < self.max_width
+                    )
+
+                    if outside_upper:
+                        sc["ux"] += sc["wi"]
+                        sc["next_param"] = np.concatenate(
+                            [
+                                sc["x"][: sc["order"][sc["i"]]],
+                                [sc["ux"]],
+                                sc["x"][sc["order"][sc["i"]] + 1 :],
+                            ]
+                        )
+                    else:
+                        # sample uniformly from bracket
+                        sc["xi"] = (sc["ux"] - sc["lx"]) * self.rng.rand() + sc["lx"]
+                        sc["next_param"] = np.concatenate(
+                            [
+                                sc["x"][: sc["order"][sc["i"]]],
+                                [sc["xi"]],
+                                sc["x"][sc["order"][sc["i"]] + 1 :],
+                            ]
+                        )
+                        sc["state"] = "SAMPLE_SLICE"
+
+                elif sc["state"] == "SAMPLE_SLICE":
+                    # if outside slice, reject sample and shrink bracket
+                    rejected = log_probs[c] < sc["logu"]
+
+                    if rejected:
+                        if sc["xi"] < sc["cxi"]:
+                            sc["lx"] = sc["xi"]
+                        else:
+                            sc["ux"] = sc["xi"]
+                        sc["xi"] = (sc["ux"] - sc["lx"]) * self.rng.rand() + sc["lx"]
+                        sc["next_param"] = np.concatenate(
+                            [
+                                sc["x"][: sc["order"][sc["i"]]],
+                                [sc["xi"]],
+                                sc["x"][sc["order"][sc["i"]] + 1 :],
+                            ]
+                        )
+
+                    else:
+                        if sc["t"] < num_samples:
+                            sc["state"] = "BEGIN"
+
+                            sc["x"] = sc["next_param"].copy()
+
+                            if sc["t"] <= (self.tuning):
+                                i = sc["order"][sc["i"]]
+                                sc["width"][i] += (
+                                    (sc["ux"] - sc["lx"]) - sc["width"][i]
+                                ) / (sc["t"] + 1)
+
+                            if sc["i"] < len(sc["order"]) - 1:
+                                sc["i"] += 1
+
+                            else:
+                                if sc["t"] > self.tuning:
+                                    sc["samples"][sc["t"]] = sc["x"].copy()
+
+                                sc["t"] += 1
+
+                                self.state[c]["i"] = 0
+                                self.state[c]["order"] = list(range(self.n_dims))
+                                self.rng.shuffle(self.state[c]["order"])
+
+                                # print(f"{c}: t={sc['t']}")
+
+                        else:
+                            sc["state"] = "DONE"
+                            print(f"Chain {c} is DONE")
+
+                if sc["state"] == "DONE":
+                    num_chains_finished += 1
+
+        samples = np.stack(self.state[c]["samples"] for c in range(self.num_chains))
+
+        return samples

--- a/sbi/mcmc/slice_numpy_vectorized.py
+++ b/sbi/mcmc/slice_numpy_vectorized.py
@@ -5,7 +5,7 @@ import numpy as np
 import os
 import sys
 
-from tqdm import trange
+from tqdm import tqdm
 
 from typing import Callable, Union
 
@@ -82,6 +82,9 @@ class SliceSamplerVectorized:
             self.state[c]["state"] = "BEGIN"
 
             self.state[c]["width"] = np.full(self.n_dims, self.init_width)
+
+        if self.verbose:
+            pbar = tqdm(range(self.num_chains * num_samples))
 
         num_chains_finished = 0
         while num_chains_finished != self.num_chains:
@@ -216,7 +219,9 @@ class SliceSamplerVectorized:
                                 self.state[c]["order"] = list(range(self.n_dims))
                                 self.rng.shuffle(self.state[c]["order"])
 
-                                # print(f"{c}: t={sc['t']}")
+                                if self.verbose:
+                                    if sc["t"] % 10 == 0:
+                                        pbar.update(10)
 
                         else:
                             sc["state"] = "DONE"

--- a/sbi/mcmc/slice_numpy_vectorized.py
+++ b/sbi/mcmc/slice_numpy_vectorized.py
@@ -41,8 +41,6 @@ class SliceSamplerVectorized:
         self.init_width = init_width
         self.max_width = max_width
 
-        self.logger = open(os.devnull, "w") if not self.verbose else sys.stdout
-
         self.n_dims = self.x.size
 
         self._reset()

--- a/sbi/mcmc/slice_numpy_vectorized.py
+++ b/sbi/mcmc/slice_numpy_vectorized.py
@@ -85,6 +85,7 @@ class SliceSamplerVectorized:
 
         if self.verbose:
             pbar = tqdm(range(self.num_chains * num_samples))
+            print("Generating MCMC samples")
 
         num_chains_finished = 0
         while num_chains_finished != self.num_chains:

--- a/tests/linearGaussian_snle_test.py
+++ b/tests/linearGaussian_snle_test.py
@@ -156,12 +156,14 @@ def test_c2st_snle_external_data_on_linearGaussian(set_seed):
 @pytest.mark.slow
 @pytest.mark.parametrize("num_dim", (1, 2))
 @pytest.mark.parametrize("prior_str", ("uniform", "gaussian"))
-def test_c2st_snl_on_linearGaussian(num_dim: int, prior_str: str, set_seed):
+@pytest.mark.parametrize("mcmc_method", ("slice", "slice_np", "slice_np_vectorized"))
+def test_c2st_snl_on_linearGaussian(num_dim: int, prior_str: str, mcmc_method: str, set_seed):
     """Test SNL on linear Gaussian, comparing to ground truth posterior via c2st.
 
     Args:
         num_dim: parameter dimension of the gaussian model
         prior_str: one of "gaussian" or "uniform"
+        mcmc_method: which mcmc method to use for sampling
         set_seed: fixture for manual seeding
     """
 
@@ -190,7 +192,8 @@ def test_c2st_snl_on_linearGaussian(num_dim: int, prior_str: str, set_seed):
 
     infer = SNL(
         *prepare_for_sbi(simulator, prior),
-        mcmc_method="slice_np",
+        mcmc_method=mcmc_method,
+        mcmc_parameters={"num_chains": 5},
         show_progress_bars=False,
     )
 
@@ -212,10 +215,12 @@ def test_c2st_snl_on_linearGaussian(num_dim: int, prior_str: str, set_seed):
 
 
 @pytest.mark.slow
-def test_c2st_multi_round_snl_on_linearGaussian(set_seed):
+@pytest.mark.parametrize("mcmc_method", ("slice", "slice_np", "slice_np_vectorized"))
+def test_c2st_multi_round_snl_on_linearGaussian(mcmc_method: str, set_seed):
     """Test SNL on linear Gaussian, comparing to ground truth posterior via c2st.
 
     Args:
+        mcmc_method: which mcmc method to use for sampling
         set_seed: fixture for manual seeding
     """
 
@@ -240,7 +245,8 @@ def test_c2st_multi_round_snl_on_linearGaussian(set_seed):
     infer = SNL(
         *prepare_for_sbi(simulator, prior),
         simulation_batch_size=50,
-        mcmc_method="slice",
+        mcmc_method=mcmc_method,
+        mcmc_parameters={"num_chains": 5},
         show_progress_bars=False,
     )
 
@@ -254,23 +260,14 @@ def test_c2st_multi_round_snl_on_linearGaussian(set_seed):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize(
-    "mcmc_method, prior_str",
-    (
-        ("slice", "gaussian"),
-        ("slice", "uniform"),
-        ("slice_np", "gaussian"),
-        ("slice_np", "uniform"),
-        ("slice_np_vectorized", "gaussian"),
-        ("slice_np_vectorized", "uniform"),
-    ),
-)
-def test_api_snl_sampling_methods(mcmc_method: str, prior_str: str, set_seed):
+@pytest.mark.parametrize("prior_str", ("uniform", "gaussian"))
+@pytest.mark.parametrize("mcmc_method", ("slice", "slice_np", "slice_np_vectorized"))
+def test_api_snl_sampling_methods(prior_str: str, mcmc_method: str, set_seed):
     """Runs SNL on linear Gaussian and tests sampling from posterior via mcmc.
 
     Args:
-        mcmc_method: which mcmc method to use for sampling
         prior_str: use gaussian or uniform prior
+        mcmc_method: which mcmc method to use for sampling
         set_seed: fixture for manual seeding
     """
 
@@ -287,7 +284,7 @@ def test_api_snl_sampling_methods(mcmc_method: str, prior_str: str, set_seed):
         *prepare_for_sbi(diagonal_linear_gaussian, prior),
         simulation_batch_size=50,
         mcmc_method=mcmc_method,
-        mcmc_parameters={"num_chains": 10},
+        mcmc_parameters={"num_chains": 5},
         show_progress_bars=False,
     )
 

--- a/tests/linearGaussian_snle_test.py
+++ b/tests/linearGaussian_snle_test.py
@@ -255,8 +255,15 @@ def test_c2st_multi_round_snl_on_linearGaussian(set_seed):
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
-    "mcmc_method, prior_str", (("slice", "gaussian"),("slice", "uniform"), ("slice_np", "gaussian"), ("slice_np", "uniform"),
-    ("slice_np_vectorized", "gaussian"), ("slice_np_vectorized", "uniform"),),
+    "mcmc_method, prior_str",
+    (
+        ("slice", "gaussian"),
+        ("slice", "uniform"),
+        ("slice_np", "gaussian"),
+        ("slice_np", "uniform"),
+        ("slice_np_vectorized", "gaussian"),
+        ("slice_np_vectorized", "uniform"),
+    ),
 )
 def test_api_snl_sampling_methods(mcmc_method: str, prior_str: str, set_seed):
     """Runs SNL on linear Gaussian and tests sampling from posterior via mcmc.

--- a/tests/linearGaussian_snle_test.py
+++ b/tests/linearGaussian_snle_test.py
@@ -156,14 +156,12 @@ def test_c2st_snle_external_data_on_linearGaussian(set_seed):
 @pytest.mark.slow
 @pytest.mark.parametrize("num_dim", (1, 2))
 @pytest.mark.parametrize("prior_str", ("uniform", "gaussian"))
-@pytest.mark.parametrize("mcmc_method", ("slice", "slice_np", "slice_np_vectorized"))
-def test_c2st_snl_on_linearGaussian(num_dim: int, prior_str: str, mcmc_method: str, set_seed):
+def test_c2st_snl_on_linearGaussian(num_dim: int, prior_str: str, set_seed):
     """Test SNL on linear Gaussian, comparing to ground truth posterior via c2st.
 
     Args:
         num_dim: parameter dimension of the gaussian model
         prior_str: one of "gaussian" or "uniform"
-        mcmc_method: which mcmc method to use for sampling
         set_seed: fixture for manual seeding
     """
 
@@ -192,8 +190,7 @@ def test_c2st_snl_on_linearGaussian(num_dim: int, prior_str: str, mcmc_method: s
 
     infer = SNL(
         *prepare_for_sbi(simulator, prior),
-        mcmc_method=mcmc_method,
-        mcmc_parameters={"num_chains": 5},
+        mcmc_method="slice_np",
         show_progress_bars=False,
     )
 
@@ -215,12 +212,10 @@ def test_c2st_snl_on_linearGaussian(num_dim: int, prior_str: str, mcmc_method: s
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize("mcmc_method", ("slice", "slice_np", "slice_np_vectorized"))
-def test_c2st_multi_round_snl_on_linearGaussian(mcmc_method: str, set_seed):
+def test_c2st_multi_round_snl_on_linearGaussian(set_seed):
     """Test SNL on linear Gaussian, comparing to ground truth posterior via c2st.
 
     Args:
-        mcmc_method: which mcmc method to use for sampling
         set_seed: fixture for manual seeding
     """
 
@@ -245,8 +240,7 @@ def test_c2st_multi_round_snl_on_linearGaussian(mcmc_method: str, set_seed):
     infer = SNL(
         *prepare_for_sbi(simulator, prior),
         simulation_batch_size=50,
-        mcmc_method=mcmc_method,
-        mcmc_parameters={"num_chains": 5},
+        mcmc_method="slice",
         show_progress_bars=False,
     )
 
@@ -260,14 +254,15 @@ def test_c2st_multi_round_snl_on_linearGaussian(mcmc_method: str, set_seed):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize("prior_str", ("uniform", "gaussian"))
-@pytest.mark.parametrize("mcmc_method", ("slice", "slice_np", "slice_np_vectorized"))
-def test_api_snl_sampling_methods(prior_str: str, mcmc_method: str, set_seed):
+@pytest.mark.parametrize(
+    "mcmc_method, prior_str", (("slice", "gaussian"), ("slice", "uniform"),),
+)
+def test_api_snl_sampling_methods(mcmc_method: str, prior_str: str, set_seed):
     """Runs SNL on linear Gaussian and tests sampling from posterior via mcmc.
 
     Args:
-        prior_str: use gaussian or uniform prior
         mcmc_method: which mcmc method to use for sampling
+        prior_str: use gaussian or uniform prior
         set_seed: fixture for manual seeding
     """
 
@@ -283,8 +278,7 @@ def test_api_snl_sampling_methods(prior_str: str, mcmc_method: str, set_seed):
     infer = SNL(
         *prepare_for_sbi(diagonal_linear_gaussian, prior),
         simulation_batch_size=50,
-        mcmc_method=mcmc_method,
-        mcmc_parameters={"num_chains": 5},
+        mcmc_method="slice_np",
         show_progress_bars=False,
     )
 

--- a/tests/linearGaussian_snle_test.py
+++ b/tests/linearGaussian_snle_test.py
@@ -255,7 +255,8 @@ def test_c2st_multi_round_snl_on_linearGaussian(set_seed):
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
-    "mcmc_method, prior_str", (("slice", "gaussian"), ("slice", "uniform"),),
+    "mcmc_method, prior_str", (("slice", "gaussian"),("slice", "uniform"), ("slice_np", "gaussian"), ("slice_np", "uniform"),
+    ("slice_np_vectorized", "gaussian"), ("slice_np_vectorized", "uniform"),),
 )
 def test_api_snl_sampling_methods(mcmc_method: str, prior_str: str, set_seed):
     """Runs SNL on linear Gaussian and tests sampling from posterior via mcmc.
@@ -278,7 +279,8 @@ def test_api_snl_sampling_methods(mcmc_method: str, prior_str: str, set_seed):
     infer = SNL(
         *prepare_for_sbi(diagonal_linear_gaussian, prior),
         simulation_batch_size=50,
-        mcmc_method="slice_np",
+        mcmc_method=mcmc_method,
+        mcmc_parameters={"num_chains": 10},
         show_progress_bars=False,
     )
 

--- a/tests/mcmc_test.py
+++ b/tests/mcmc_test.py
@@ -1,0 +1,88 @@
+# This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
+# under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+from torch import eye, ones, zeros
+
+from sbi.mcmc.slice_numpy import SliceSampler
+from sbi.mcmc.slice_numpy_vectorized import SliceSamplerVectorized
+from sbi.simulators.linear_gaussian import true_posterior_linear_gaussian_mvn_prior
+from tests.test_utils import check_c2st
+
+
+@pytest.mark.parametrize("num_dim", (1, 2))
+def test_c2st_slice_np_on_Gaussian(num_dim: int, set_seed):
+    """Test SNL on linear Gaussian, comparing to ground truth posterior via c2st.
+
+    Args:
+        num_dim: parameter dimension of the gaussian model
+        mcmc_method: which mcmc method to use for sampling
+        set_seed: fixture for manual seeding
+    """
+    warmup = 100
+    num_samples = 500
+
+    likelihood_shift = -1.0 * ones(num_dim)
+    likelihood_cov = 0.3 * eye(num_dim)
+    prior_mean = zeros(num_dim)
+    prior_cov = eye(num_dim)
+    x_o = zeros((1, num_dim))
+    target_distribution = true_posterior_linear_gaussian_mvn_prior(
+        x_o[0], likelihood_shift, likelihood_cov, prior_mean, prior_cov
+    )
+    target_samples = target_distribution.sample((num_samples,))
+
+    def lp_f(x):
+        return target_distribution.log_prob(torch.as_tensor(x, dtype=torch.float32))
+
+    sampler = SliceSampler(lp_f=lp_f, x=np.zeros((num_dim,)).astype(np.float32))
+    _ = sampler.gen(warmup)
+    samples = sampler.gen(num_samples)
+
+    samples = torch.as_tensor(samples, dtype=torch.float32)
+
+    check_c2st(samples, target_samples, alg=f"slice_np")
+
+
+@pytest.mark.parametrize("num_dim", (1, 2))
+def test_c2st_slice_np_vectorized_on_Gaussian(num_dim: int, set_seed):
+    """Test SNL on linear Gaussian, comparing to ground truth posterior via c2st.
+
+    Args:
+        num_dim: parameter dimension of the gaussian model
+        mcmc_method: which mcmc method to use for sampling
+        set_seed: fixture for manual seeding
+    """
+    num_samples = 500
+    warmup = 500
+    num_chains = 5
+
+    likelihood_shift = -1.0 * ones(num_dim)
+    likelihood_cov = 0.3 * eye(num_dim)
+    prior_mean = zeros(num_dim)
+    prior_cov = eye(num_dim)
+    x_o = zeros((1, num_dim))
+    target_distribution = true_posterior_linear_gaussian_mvn_prior(
+        x_o[0], likelihood_shift, likelihood_cov, prior_mean, prior_cov
+    )
+    target_samples = target_distribution.sample((num_samples,))
+
+    def lp_f(x):
+        return target_distribution.log_prob(torch.as_tensor(x, dtype=torch.float32))
+
+    sampler = SliceSamplerVectorized(
+        log_prob_fn=lp_f,
+        init_params=np.zeros((num_chains, num_dim,)).astype(np.float32),
+        num_chains=num_chains,
+    )
+    samples = sampler.run(warmup + int(num_samples / num_chains))
+    samples = samples[:, warmup:, :]
+    samples = samples.reshape(-1, num_dim)
+
+    samples = torch.as_tensor(samples, dtype=torch.float32)
+
+    check_c2st(samples, target_samples, alg=f"slice_np_vectorized")

--- a/tests/mcmc_test.py
+++ b/tests/mcmc_test.py
@@ -16,11 +16,10 @@ from tests.test_utils import check_c2st
 
 @pytest.mark.parametrize("num_dim", (1, 2))
 def test_c2st_slice_np_on_Gaussian(num_dim: int, set_seed):
-    """Test SNL on linear Gaussian, comparing to ground truth posterior via c2st.
+    """Test MCMC on Gaussian, comparing to ground truth target via c2st.
 
     Args:
         num_dim: parameter dimension of the gaussian model
-        mcmc_method: which mcmc method to use for sampling
         set_seed: fixture for manual seeding
     """
     warmup = 100
@@ -50,11 +49,10 @@ def test_c2st_slice_np_on_Gaussian(num_dim: int, set_seed):
 
 @pytest.mark.parametrize("num_dim", (1, 2))
 def test_c2st_slice_np_vectorized_on_Gaussian(num_dim: int, set_seed):
-    """Test SNL on linear Gaussian, comparing to ground truth posterior via c2st.
+    """Test MCMC on Gaussian, comparing to ground truth target via c2st.
 
     Args:
         num_dim: parameter dimension of the gaussian model
-        mcmc_method: which mcmc method to use for sampling
         set_seed: fixture for manual seeding
     """
     num_samples = 500


### PR DESCRIPTION
Adds vectorized version of numpy slice sampler which allows parallel log prob evaluations across all chains, making use of #341. This enables tremendous speed-ups for algorithms that use MCMC. 

All seems to work, and ready to be merged from my side. However, I would wait till we have used it internally for a longer time before making it the default choice.