### PR TITLE
Fixes init of SNRE classifier network by swapping pilot batches

### DIFF
--- a/sbi/utils/get_nn_models.py
+++ b/sbi/utils/get_nn_models.py
@@ -76,13 +76,13 @@ def classifier_nn(
     def build_fn(batch_theta, batch_x):
         if model == "linear":
             return build_linear_classifier(
-                batch_x=batch_x, batch_y=batch_theta, **kwargs
+                batch_x=batch_theta, batch_y=batch_x, **kwargs
             )
         if model == "mlp":
-            return build_mlp_classifier(batch_x=batch_x, batch_y=batch_theta, **kwargs)
+            return build_mlp_classifier(batch_x=batch_theta, batch_y=batch_x, **kwargs)
         if model == "resnet":
             return build_resnet_classifier(
-                batch_x=batch_x, batch_y=batch_theta, **kwargs
+                batch_x=batch_theta, batch_y=batch_x, **kwargs
             )
         else:
             raise NotImplementedError


### PR DESCRIPTION
In SNRE, the semantics of `x` and `theta` were swapped when building the net. When the classifier is used, thetas concatenated with xs are passed as input. During building, this was swapped, so that z-scoring wasn't performed as intended. 