### PR TITLE
Fixing call to `infer` in the first snippet of the home page

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -8,7 +8,7 @@ Inference can be run in a single
 line of code:
 
 ```python
-posterior = infer(prior, simulator, num_simulations=1000, method='SNPE')
+posterior = infer(simulator, infer, num_simulations=1000, method='SNPE')
 ```
 
 - To learn about the general motivation behind simulation-based inference, and the

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -8,7 +8,7 @@ Inference can be run in a single
 line of code:
 
 ```python
-posterior = infer(simulator, infer, num_simulations=1000, method='SNPE')
+posterior = infer(simulator, prior, num_simulations=1000, method='SNPE')
 ```
 
 - To learn about the general motivation behind simulation-based inference, and the


### PR DESCRIPTION
I believe the `simulator` and `prior` arguments to `infer` are swapped in the example from the home page. Cheers!