### PR TITLE
refactor np mcmc, pass verbose arg.

### DIFF
--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -384,6 +384,7 @@ class NeuralPosterior(ABC):
                     utils.tensor2numpy(initial_params[c, :]).reshape(-1),
                     lp_f=potential_function,
                     thin=thin,
+                    verbose=show_progress_bars,
                 )
                 if warmup_steps > 0:
                     posterior_sampler.gen(int(warmup_steps))


### PR DESCRIPTION
- pass `show_progress_bar` as verbose arg to `slice_np` to avoid showing pbars all the time.