### PR TITLE
logging of validation logprobs for each epoch.

### DIFF
--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -158,7 +158,10 @@ class NeuralInference(ABC):
 
         # Logging during training (by SummaryWriter).
         self._summary = dict(
-            median_observation_distances=[], epochs=[], best_validation_log_probs=[],
+            median_observation_distances=[],
+            epochs=[],
+            best_validation_log_probs=[],
+            validation_log_probs=[],
         )
 
     def provide_presimulated(
@@ -446,6 +449,16 @@ class NeuralInference(ABC):
             scalar_value=self._summary["best_validation_log_probs"][-1],
             global_step=round_ + 1,
         )
+
+        # Add validation log prob for every epoch.
+        # Offset with all previous epochs.
+        offset = torch.tensor(self._summary["epochs"][:-1], dtype=int).sum().item()
+        for i, vlp in enumerate(self._summary["validation_log_probs"][offset:]):
+            self._summary_writer.add_scalar(
+                tag="validation_log_probs_across_rounds",
+                scalar_value=vlp,
+                global_step=offset + i,
+            )
 
         self._summary_writer.flush()
 

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -287,6 +287,8 @@ class LikelihoodEstimator(NeuralInference, ABC):
                     )
                     log_prob_sum += log_prob.sum().item()
             self._val_log_prob = log_prob_sum / num_validation_examples
+            # Log validation log prob for every epoch.
+            self._summary["validation_log_probs"].append(self._val_log_prob)
 
             self._maybe_show_progress(self._show_progress_bars, epoch)
 

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -367,6 +367,8 @@ class PosteriorEstimator(NeuralInference, ABC):
                     log_prob_sum += batch_log_prob.sum().item()
 
             self._val_log_prob = log_prob_sum / num_validation_examples
+            # Log validation log prob for every epoch.
+            self._summary["validation_log_probs"].append(self._val_log_prob)
 
             self._maybe_show_progress(self._show_progress_bars, epoch)
 

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -302,6 +302,8 @@ class RatioEstimator(NeuralInference, ABC):
                     log_prob = self._loss(theta_batch, x_batch, num_atoms)
                     log_prob_sum -= log_prob.sum().item()
                 self._val_log_prob = log_prob_sum / num_validation_examples
+                # Log validation log prob for every epoch.
+                self._summary["validation_log_probs"].append(self._val_log_prob)
 
             self._maybe_show_progress(self._show_progress_bars, epoch)
 


### PR DESCRIPTION
to better analyse training performance and convergence we were lacking the validation log probs for each epoch. We were only logging the single best validation log prob across all epochs, for each round. 

This PR adds a trace of validation log probs across all epochs and rounds that can be inspected using `tensorboard`. 