### PR TITLE
z-score using only training data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ posterior = inference.build_posterior(density_estimator)  # MCMC kwargs go here.
 ```
 More information can be found here [here](https://www.mackelab.org/sbi/tutorial/02_flexible_interface/).
 - Fixed typo in docs for `infer` (thanks @glouppe, #370)
+- z-score data using only the training data (#393)
 
 
 # v0.13.2

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -148,18 +148,6 @@ class LikelihoodEstimator(NeuralInference, ABC):
         self._round = max(self._data_round_index)
         theta, x, _ = self.get_simulations(self._round, exclude_invalid_x, False)
 
-        # First round or if retraining from scratch:
-        # Call the `self._build_neural_net` with the rounds' thetas and xs as
-        # arguments, which will build the neural network
-        # This is passed into NeuralPosterior, to create a neural posterior which
-        # can `sample()` and `log_prob()`. The network is accessible via `.net`.
-        if self._neural_net is None or retrain_from_scratch_each_round:
-            self._neural_net = self._build_neural_net(theta, x)
-            self._x_shape = x_shape_from_simulation(x)
-            assert (
-                len(self._x_shape) < 3
-            ), "SNLE cannot handle multi-dimensional simulator output."
-
         # Starting index for the training set (1 = discard round-0 samples).
         start_idx = int(discard_prior_samples and self._round > 0)
         theta, x, _ = self.get_simulations(start_idx, exclude_invalid_x)
@@ -193,6 +181,20 @@ class LikelihoodEstimator(NeuralInference, ABC):
             drop_last=False,
             sampler=SubsetRandomSampler(val_indices),
         )
+
+        # First round or if retraining from scratch:
+        # Call the `self._build_neural_net` with the rounds' thetas and xs as
+        # arguments, which will build the neural network
+        # This is passed into NeuralPosterior, to create a neural posterior which
+        # can `sample()` and `log_prob()`. The network is accessible via `.net`.
+        if self._neural_net is None or retrain_from_scratch_each_round:
+            self._neural_net = self._build_neural_net(
+                theta[train_indices], x[train_indices]
+            )
+            self._x_shape = x_shape_from_simulation(x)
+            assert (
+                len(self._x_shape) < 3
+            ), "SNLE cannot handle multi-dimensional simulator output."
 
         optimizer = optim.Adam(list(self._neural_net.parameters()), lr=learning_rate,)
 

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -183,16 +183,6 @@ class PosteriorEstimator(NeuralInference, ABC):
         self._round = max(self._data_round_index)
         theta, x, _ = self.get_simulations(self._round, exclude_invalid_x, False)
 
-        # First round or if retraining from scratch:
-        # Call the `self._build_neural_net` with the rounds' thetas and xs as
-        # arguments, which will build the neural network.
-        # This is passed into NeuralPosterior, to create a neural posterior which
-        # can `sample()` and `log_prob()`. The network is accessible via `.net`.
-        if self._neural_net is None or retrain_from_scratch_each_round:
-            self._neural_net = self._build_neural_net(theta, x)
-            test_posterior_net_for_multi_d_x(self._neural_net, theta, x)
-            self._x_shape = x_shape_from_simulation(x)
-
         # Starting index for the training set (1 = discard round-0 samples).
         start_idx = int(discard_prior_samples and self._round > 0)
 
@@ -235,6 +225,18 @@ class PosteriorEstimator(NeuralInference, ABC):
             drop_last=True,
             sampler=SubsetRandomSampler(val_indices),
         )
+
+        # First round or if retraining from scratch:
+        # Call the `self._build_neural_net` with the rounds' thetas and xs as
+        # arguments, which will build the neural network.
+        # This is passed into NeuralPosterior, to create a neural posterior which
+        # can `sample()` and `log_prob()`. The network is accessible via `.net`.
+        if self._neural_net is None or retrain_from_scratch_each_round:
+            self._neural_net = self._build_neural_net(
+                theta[train_indices], x[train_indices]
+            )
+            test_posterior_net_for_multi_d_x(self._neural_net, theta, x)
+            self._x_shape = x_shape_from_simulation(x)
 
         optimizer = optim.Adam(list(self._neural_net.parameters()), lr=learning_rate,)
 

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -151,19 +151,6 @@ class RatioEstimator(NeuralInference, ABC):
         self._round = max(self._data_round_index)
         theta, x, _ = self.get_simulations(self._round, exclude_invalid_x, False)
 
-        # First round or if retraining from scratch:
-        # Call the `self._build_neural_net` with the rounds' thetas and xs as
-        # arguments, which will build the neural network
-        # This is passed into NeuralPosterior, to create a neural posterior which
-        # can `sample()` and `log_prob()`. The network is accessible via `.net`.
-        if self._neural_net is None or retrain_from_scratch_each_round:
-            self._neural_net = self._build_neural_net(theta, x)
-            self._x_shape = x_shape_from_simulation(x)
-            assert len(self._x_shape) < 3, (
-                "For now, SNRE cannot handle multi-dimensional simulator output, see "
-                "issue #360."
-            )
-
         # Starting index for the training set (1 = discard round-0 samples).
         start_idx = int(discard_prior_samples and self._round > 0)
         theta, x, _ = self.get_simulations(start_idx, exclude_invalid_x)
@@ -203,6 +190,21 @@ class RatioEstimator(NeuralInference, ABC):
             drop_last=False,
             sampler=SubsetRandomSampler(val_indices),
         )
+
+        # First round or if retraining from scratch:
+        # Call the `self._build_neural_net` with the rounds' thetas and xs as
+        # arguments, which will build the neural network
+        # This is passed into NeuralPosterior, to create a neural posterior which
+        # can `sample()` and `log_prob()`. The network is accessible via `.net`.
+        if self._neural_net is None or retrain_from_scratch_each_round:
+            self._neural_net = self._build_neural_net(
+                theta[train_indices], x[train_indices]
+            )
+            self._x_shape = x_shape_from_simulation(x)
+            assert len(self._x_shape) < 3, (
+                "For now, SNRE cannot handle multi-dimensional simulator output, see "
+                "issue #360."
+            )
 
         optimizer = optim.Adam(list(self._neural_net.parameters()), lr=learning_rate,)
 


### PR DESCRIPTION
We currently infer the mean and std of our data from all datapoints, including the validation set.

It is good practice to consider the mean and std as model parameters and therefore use only the training data to identify the mean and std.