### PR TITLE
fixup for conditional correlation matrix, #403

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.14.3
+
+- Fixup for conditional correlation matrix (thanks @JBeckUniTb, #404)
+
+
 # v0.14.2
 
 - Small fix for SMC-ABC with semi-automatic summary statistics (#402)

--- a/sbi/utils/conditional_density.py
+++ b/sbi/utils/conditional_density.py
@@ -233,7 +233,7 @@ def _expected_value_f_of_x(
     simply be summed over.
 
     Args:
-        probs: probs: Matrix of evaluations of the density.
+        probs: Matrix of evaluations of the density.
         limits: Limits within which the entries of the matrix are evenly spaced.
         f: The operation to be applied to the expected values.
 
@@ -245,8 +245,8 @@ def _expected_value_f_of_x(
 
     x_values_over_which_we_integrate = [
         torch.linspace(lim[0], lim[1], prob.shape[0])
-        for lim, prob in zip(limits, probs)
-    ]
+        for lim, prob in zip(torch.flip(limits, [0]), probs)
+    ]  # See #403 and #404 for flip().
     grids = list(torch.meshgrid(x_values_over_which_we_integrate))
     expected_val = torch.sum(f(*grids) * probs)
 

--- a/tests/sbiutils_test.py
+++ b/tests/sbiutils_test.py
@@ -6,9 +6,9 @@ from torch import Tensor
 from torch.distributions import MultivariateNormal
 
 from sbi.utils import (
-    eval_conditional_density,
     conditional_corrcoeff,
     conditional_pairplot,
+    eval_conditional_density,
 )
 
 
@@ -167,7 +167,7 @@ def test_conditional_corrcoeff(corr):
     estimated_corr = conditional_corrcoeff(
         density=d,
         condition=torch.ones(1, 2),
-        limits=torch.tensor([[-3.0, 3.0], [-90, 90]]),
+        limits=torch.tensor([[-2.0, 3.0], [-70, 90]]),
         resolution=500,
     )[0, 1]
 


### PR DESCRIPTION
Fixes the issue reported in #403. The issue arises only when the `limits` are not symmetric around the origin **and** are not the same in each dimension. Because of this, the issue slipped through the tests.

This PR is a one-line fix, and it also updates tests so that such a problem would be caught in the future.

`torch.flip()` is needed because `meshgrid` generates axes that are transposed to the probability matrix that we generate with `torch.repeat()` and `torch.repeat_interleave()`. See:
- for meshgrid: https://github.com/mackelab/sbi/blob/1534cff14dee1c1e0013ad22b2f931eb7424bb42/sbi/utils/conditional_density.py#L250
- for the probability axes: https://github.com/mackelab/sbi/blob/1534cff14dee1c1e0013ad22b2f931eb7424bb42/sbi/utils/conditional_density.py#L66-L70
By flipping the limits, we implicitly transpose the grids generated by `meshgrid()`