### PR TITLE
z-score only using training data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.14.3
 
 - Fixup for conditional correlation matrix (thanks @JBeckUniTb, #404)
+- z-score data using only the training data (#411)
 
 
 # v0.14.2

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -148,18 +148,6 @@ class LikelihoodEstimator(NeuralInference, ABC):
         self._round = max(self._data_round_index)
         theta, x, _ = self.get_simulations(self._round, exclude_invalid_x, False)
 
-        # First round or if retraining from scratch:
-        # Call the `self._build_neural_net` with the rounds' thetas and xs as
-        # arguments, which will build the neural network
-        # This is passed into NeuralPosterior, to create a neural posterior which
-        # can `sample()` and `log_prob()`. The network is accessible via `.net`.
-        if self._neural_net is None or retrain_from_scratch_each_round:
-            self._neural_net = self._build_neural_net(theta, x)
-            self._x_shape = x_shape_from_simulation(x)
-            assert (
-                len(self._x_shape) < 3
-            ), "SNLE cannot handle multi-dimensional simulator output."
-
         # Starting index for the training set (1 = discard round-0 samples).
         start_idx = int(discard_prior_samples and self._round > 0)
         theta, x, _ = self.get_simulations(start_idx, exclude_invalid_x)
@@ -193,6 +181,20 @@ class LikelihoodEstimator(NeuralInference, ABC):
             drop_last=False,
             sampler=SubsetRandomSampler(val_indices),
         )
+
+        # First round or if retraining from scratch:
+        # Call the `self._build_neural_net` with the rounds' thetas and xs as
+        # arguments, which will build the neural network
+        # This is passed into NeuralPosterior, to create a neural posterior which
+        # can `sample()` and `log_prob()`. The network is accessible via `.net`.
+        if self._neural_net is None or retrain_from_scratch_each_round:
+            self._neural_net = self._build_neural_net(
+                theta[train_indices], x[train_indices]
+            )
+            self._x_shape = x_shape_from_simulation(x)
+            assert (
+                len(self._x_shape) < 3
+            ), "SNLE cannot handle multi-dimensional simulator output."
 
         self._neural_net.to(self._device)
         optimizer = optim.Adam(list(self._neural_net.parameters()), lr=learning_rate,)

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -150,19 +150,6 @@ class RatioEstimator(NeuralInference, ABC):
         self._round = max(self._data_round_index)
         theta, x, _ = self.get_simulations(self._round, exclude_invalid_x, False)
 
-        # First round or if retraining from scratch:
-        # Call the `self._build_neural_net` with the rounds' thetas and xs as
-        # arguments, which will build the neural network
-        # This is passed into NeuralPosterior, to create a neural posterior which
-        # can `sample()` and `log_prob()`. The network is accessible via `.net`.
-        if self._neural_net is None or retrain_from_scratch_each_round:
-            self._neural_net = self._build_neural_net(theta, x)
-            self._x_shape = x_shape_from_simulation(x)
-            assert len(self._x_shape) < 3, (
-                "For now, SNRE cannot handle multi-dimensional simulator output, see "
-                "issue #360."
-            )
-
         # Starting index for the training set (1 = discard round-0 samples).
         start_idx = int(discard_prior_samples and self._round > 0)
         theta, x, _ = self.get_simulations(start_idx, exclude_invalid_x)
@@ -202,6 +189,21 @@ class RatioEstimator(NeuralInference, ABC):
             drop_last=False,
             sampler=SubsetRandomSampler(val_indices),
         )
+
+        # First round or if retraining from scratch:
+        # Call the `self._build_neural_net` with the rounds' thetas and xs as
+        # arguments, which will build the neural network
+        # This is passed into NeuralPosterior, to create a neural posterior which
+        # can `sample()` and `log_prob()`. The network is accessible via `.net`.
+        if self._neural_net is None or retrain_from_scratch_each_round:
+            self._neural_net = self._build_neural_net(
+                theta[train_indices], x[train_indices]
+            )
+            self._x_shape = x_shape_from_simulation(x)
+            assert len(self._x_shape) < 3, (
+                "For now, SNRE cannot handle multi-dimensional simulator output, see "
+                "issue #360."
+            )
 
         self._neural_net.to(self._device)
         optimizer = optim.Adam(list(self._neural_net.parameters()), lr=learning_rate,)

--- a/tests/inference_with_NaN_simulator_test.py
+++ b/tests/inference_with_NaN_simulator_test.py
@@ -121,7 +121,7 @@ def test_inference_with_rejection_estimator(set_seed):
     num_rounds = 2
 
     for r in range(num_rounds):
-        theta, x = simulate_for_sbi(simulator, proposals[-1], 500)
+        theta, x = simulate_for_sbi(simulator, proposals[-1], 550)
         rejection_estimator.append_simulations(theta, x)
         if r < num_rounds - 1:
             _ = rejection_estimator.train()


### PR DESCRIPTION
We currently infer the mean and std of our data from all datapoints, including the validation set.

It is good practice to consider the mean and std as model parameters and therefore use only the training data to identify the mean and std.

See #393 