### PR TITLE
MAP estimate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Major changes
 - Active subspaces for sensitivity analysis (#394, [tutorial](https://www.mackelab.org/sbi/tutorial/09_sensitivity_analysis/))
+- Method to compute the maximum-a-posteriori estimate from the posterior (#412)
 
 ## API changes
 - `pairplot()`, `conditional_pairplot()`, and `conditional_corrcoeff()` should now be imported from `sbi.analysis` instead of `sbi.utils` (#394).
@@ -9,6 +10,7 @@
 
 ## Minor changes
 - Depend on new `joblib=1.0.0` and fix progress bar updates for multiprocessing (#421).
+- Fix for embedding nets with `SNRE` (thanks @adittmann, #425)
 
 
 # v0.14.3

--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -4,15 +4,16 @@
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from math import ceil
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from warnings import warn
 
 import numpy as np
 import torch
 from pyro.infer.mcmc import HMC, NUTS
 from pyro.infer.mcmc.api import MCMC
-from torch import Tensor
+from torch import Tensor, float32
 from torch import multiprocessing as mp
-from torch import nn
+from torch import nn, optim
 
 from sbi import utils as utils
 from sbi.mcmc import (
@@ -25,6 +26,7 @@ from sbi.mcmc import (
 )
 from sbi.types import Array, Shape
 from sbi.user_input.user_input_checks import process_x
+from sbi.utils.sbiutils import check_if_boxuniform
 from sbi.utils.torchutils import (
     ScalarFloat,
     atleast_2d_float32_tensor,
@@ -180,7 +182,10 @@ class NeuralPosterior(ABC):
 
     @abstractmethod
     def log_prob(
-        self, theta: Tensor, x: Optional[Tensor] = None, track_gradients: bool = False,
+        self,
+        theta: Tensor,
+        x: Optional[Tensor] = None,
+        track_gradients: bool = False,
     ) -> Tensor:
         """See child classes for docstring."""
         pass
@@ -208,7 +213,7 @@ class NeuralPosterior(ABC):
 
         Args:
             posterior: Posterior that the hyperparameters are copied from.
-        
+
         Returns: Posterior object with the same hyperparameters as the passed posterior.
             This makes the call chainable:
             `posterior = infer.build_posterior().copy_hyperparameters_from(proposal)`
@@ -232,7 +237,9 @@ class NeuralPosterior(ABC):
         return self
 
     def _prepare_theta_and_x_for_log_prob_(
-        self, theta: Tensor, x: Optional[Tensor] = None,
+        self,
+        theta: Tensor,
+        x: Optional[Tensor] = None,
     ) -> Tuple[Tensor, Tensor]:
         r"""Returns $\theta$ and $x$ in shape that can be used by posterior.log_prob().
 
@@ -582,6 +589,187 @@ class NeuralPosterior(ABC):
 
         return samples.reshape((*sample_shape, -1))
 
+    def map(
+        self,
+        x: Optional[Tensor] = None,
+        num_iter: int = 1000,
+        learning_rate: float = 0.1,
+        init_method: Union[str, Tensor] = "posterior",
+        num_init_samples: int = 1_000,
+        num_to_optimize: int = 100,
+        save_best_every: int = 10,
+        show_progress_bars: bool = True,
+        log_prob_kwargs: Dict = {},
+    ) -> Tensor:
+        """
+        Returns the maximum-a-posteriori estimate (MAP).
+
+        The method can be interrupted (Ctrl-C) when the user sees that the
+        log-probability converges. The best estimate will be saved in `self.map_`.
+
+        The MAP is obtained by running gradient ascent from a given number of starting
+        positions (samples from the posterior with the highest log-probability). After
+        the optimization is done, we select the parameter set that has the highest
+        log-probability after the optimization.
+
+        For developers: if the prior is a `BoxUniform`, we carry out the optimization
+        in unbounded space and transform the result back into bounded space.
+
+        Args:
+            x: Conditioning context for posterior $p(\theta|x)$. If not provided,
+                fall back onto `x` passed to `set_default_x()`.
+            num_iter: Number of optimization steps that the algorithm takes
+                to find the MAP.
+            learning_rate: Learning rate of the optimizer.
+            init_method: How to select the starting parameters for the optimization. If
+                it is a string, it can be either [`posterior`, `prior`], which samples
+                the respective distribution `num_init_samples` times. If it is a
+                tensor, the tensor will be used as init locations.
+            num_init_samples: Draw this number of samples from the posterior and
+                evaluate the log-probability of all of them.
+            num_to_optimize: From the drawn `num_init_samples`, use the
+                `num_to_optimize` with highest log-probability as the initial points
+                for the optimization.
+            save_best_every: The best log-probability is computed, saved in the
+                `map`-attribute, and printed every `save_best_every`-th iteration.
+                Computing the best log-probability creates a significant overhead
+                (thus, the default is `10`.)
+            show_progress_bars: Whether or not to show a progressbar for sampling from
+                the posterior.
+            log_prob_kwargs: Will be empty for SNLE and SNRE. Will contain
+                {'norm_posterior': True} for SNPE.
+
+        Returns:
+            The MAP estimate.
+        """
+
+        warn(
+            "This method for obtaining the MAP estimate was introduced recently "
+            "(sbi v0.15.0) and has not been tested extensively yet. You might have to "
+            "tune the hyperparameters, especially `num_iter` and `learning_rate`. If "
+            "you experience problems, please create an issue on Github: "
+            "https://github.com/mackelab/sbi/issues"
+        )
+
+        # If the prior is `BoxUniform`, define a transformation to optimize in
+        # unbounded space.
+        is_boxuniform, boxuniform = check_if_boxuniform(self._prior)
+        if is_boxuniform:
+
+            def tf_inv(theta_t):
+                return utils.expit(
+                    theta_t,
+                    torch.as_tensor(boxuniform.support.lower_bound, dtype=float32),
+                    torch.as_tensor(boxuniform.support.upper_bound, dtype=float32),
+                )
+
+            def tf(theta):
+                return utils.logit(
+                    theta,
+                    torch.as_tensor(boxuniform.support.lower_bound, dtype=float32),
+                    torch.as_tensor(boxuniform.support.upper_bound, dtype=float32),
+                )
+
+        else:
+
+            def tf_inv(theta_t):
+                return theta_t
+
+            def tf(theta):
+                return theta
+
+        if isinstance(init_method, str):
+            # Find initial position.
+            if init_method == "posterior":
+                inits = self.sample(
+                    (num_init_samples,), x=x, show_progress_bars=show_progress_bars
+                )
+            elif init_method == "prior":
+                inits = self._prior.sample((num_init_samples,))
+            elif isinstance(init_method, Tensor):
+                inits = init_method
+            else:
+                raise NameError(
+                    "`init_method` not specified. Use either `posterior` "
+                    "or `prior` or provide a tensor."
+                )
+        else:
+            inits = init_method
+
+        init_probs = self.log_prob(inits, x=x, **log_prob_kwargs)
+
+        # Pick the `num_to_optimize` best init locations.
+        sort_indices = torch.argsort(init_probs, dim=0)
+        sorted_inits = inits[sort_indices]
+        optimize_inits = sorted_inits[-num_to_optimize:]
+
+        # The `_overall` variables store data accross the iterations, whereas the
+        # `_iter` variables contain data exclusively extracted from the current
+        # iteration.
+        best_log_prob_iter = torch.max(init_probs)
+        best_theta_iter = sorted_inits[-1]
+        best_theta_overall = best_theta_iter.detach().clone()
+        best_log_prob_overall = best_log_prob_iter.detach().clone()
+
+        self.map_ = best_theta_overall
+
+        optimize_inits = tf(optimize_inits)
+        optimize_inits.requires_grad_(True)
+        optimizer = optim.Adam([optimize_inits], lr=learning_rate)
+
+        iter_ = 0
+
+        # Try-except block in case the user interrupts the program and wants to fall
+        # back on the last saved `.map_`. We want to avoid a long error-message here.
+        try:
+
+            while iter_ < num_iter:
+
+                optimizer.zero_grad()
+                probs = self.log_prob(
+                    tf_inv(optimize_inits), x=x, track_gradients=True, **log_prob_kwargs
+                ).squeeze()
+                loss = -probs.sum()
+                loss.backward()
+                optimizer.step()
+
+                with torch.no_grad():
+                    if iter_ % save_best_every == 0 or iter_ == num_iter - 1:
+                        # Evaluate the optimized locations and pick the best one.
+                        log_probs_of_optimized = self.log_prob(
+                            tf_inv(optimize_inits), x=x, **log_prob_kwargs
+                        )
+                        best_theta_iter = optimize_inits[
+                            torch.argmax(log_probs_of_optimized)
+                        ]
+                        best_log_prob_iter = self.log_prob(
+                            tf_inv(best_theta_iter), x=x, **log_prob_kwargs
+                        )
+                        if best_log_prob_iter > best_log_prob_overall:
+                            best_theta_overall = best_theta_iter.detach().clone()
+                            best_log_prob_overall = best_log_prob_iter.detach().clone()
+
+                    print(
+                        f"Optimizing MAP estimate. Iterations: "
+                        f"{iter_+1} / {num_iter}.    "
+                        f"Performance in iteration "
+                        f"{divmod(iter_+1, save_best_every)[0] * save_best_every}: "
+                        f"{best_log_prob_iter.item():.2f} (= unnormalized log-prob)",
+                        end="\r",
+                    )
+                    self.map_ = tf_inv(best_theta_overall)
+
+                iter_ += 1
+
+        except KeyboardInterrupt:
+            print(
+                f"Optimization was interrupted after {iter_} iterations. The last "
+                "estimate of the MAP can be accessed via the `posterior.map_` "
+                "attribute."
+            )
+
+        return tf_inv(best_theta_overall)
+
     def _build_mcmc_init_fn(
         self,
         prior: Any,
@@ -776,7 +964,13 @@ class ConditionalPotentialFunctionProvider:
         self.condition = ensure_theta_batched(condition)
         self.dims_to_sample = dims_to_sample
 
-    def __call__(self, prior, net: nn.Module, x: Tensor, mcmc_method: str,) -> Callable:
+    def __call__(
+        self,
+        prior,
+        net: nn.Module,
+        x: Tensor,
+        mcmc_method: str,
+    ) -> Callable:
         """Return potential function.
 
         Switch on numpy or pyro potential function based on `mcmc_method`.
@@ -844,7 +1038,9 @@ class RestrictedPriorForConditional:
     """
 
     def __init__(
-        self, full_prior: Any, dims_to_sample: List[int],
+        self,
+        full_prior: Any,
+        dims_to_sample: List[int],
     ):
         self.full_prior = full_prior
         self.dims_to_sample = dims_to_sample

--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -202,7 +202,9 @@ class NeuralPosterior(ABC):
         """See child classes for docstring."""
         pass
 
-    def copy_hyperparameters_from(self, posterior: "NeuralPosterior"):
+    def copy_hyperparameters_from(
+        self, posterior: "NeuralPosterior"
+    ) -> "NeuralPosterior":
         """
         Copies the hyperparameters from a given posterior to `self`.
 
@@ -214,7 +216,8 @@ class NeuralPosterior(ABC):
         Args:
             posterior: Posterior that the hyperparameters are copied from.
 
-        Returns: Posterior object with the same hyperparameters as the passed posterior.
+        Returns:
+            Posterior object with the same hyperparameters as the passed posterior.
             This makes the call chainable:
             `posterior = infer.build_posterior().copy_hyperparameters_from(proposal)`
         """
@@ -611,6 +614,9 @@ class NeuralPosterior(ABC):
         positions (samples from the posterior with the highest log-probability). After
         the optimization is done, we select the parameter set that has the highest
         log-probability after the optimization.
+
+        Warning: The default values used by this function are not well-tested. They
+        might require hand-tuning for the problem at hand.
 
         For developers: if the prior is a `BoxUniform`, we carry out the optimization
         in unbounded space and transform the result back into bounded space.

--- a/sbi/inference/posteriors/likelihood_based_posterior.py
+++ b/sbi/inference/posteriors/likelihood_based_posterior.py
@@ -1,13 +1,7 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-)
+from typing import Any, Callable, Dict, List, Optional
 from warnings import warn
 
 import numpy as np
@@ -17,11 +11,7 @@ from torch import Tensor, nn
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.types import Shape
 from sbi.utils import del_entries
-from sbi.utils.torchutils import (
-    ScalarFloat,
-    ensure_theta_batched,
-    ensure_x_batched,
-)
+from sbi.utils.torchutils import ScalarFloat, ensure_theta_batched, ensure_x_batched
 
 
 class LikelihoodBasedPosterior(NeuralPosterior):
@@ -83,9 +73,8 @@ class LikelihoodBasedPosterior(NeuralPosterior):
 
         Args:
             theta: Parameters $\theta$.
-            x: Conditioning context for posterior $p(\theta|x)$. If not provided, fall
-                back onto an `x_o` if previously provided for multi-round training, or
-                to another default if set later for convenience, see `.set_default_x()`.
+            x: Conditioning context for posterior $p(\theta|x)$. If not provided,
+                fall back onto `x` passed to `set_default_x()`.
             track_gradients: Whether the returned tensor supports tracking gradients.
                 This can be helpful for e.g. sensitivity analysis, but increases memory
                 consumption.
@@ -127,8 +116,7 @@ class LikelihoodBasedPosterior(NeuralPosterior):
                 sample_shape is multidimensional we simply draw `sample_shape.numel()`
                 samples and then reshape into the desired shape.
             x: Conditioning context for posterior $p(\theta|x)$. If not provided,
-                fall back onto `x_o` if previously provided for multiround training, or
-                to a set default (see `set_default_x()` method).
+                fall back onto `x` passed to `set_default_x()`.
             show_progress_bars: Whether to show sampling progress monitor.
             sample_with_mcmc: Optional parameter to override `self.sample_with_mcmc`.
             mcmc_method: Optional parameter to override `self.mcmc_method`.
@@ -200,8 +188,7 @@ class LikelihoodBasedPosterior(NeuralPosterior):
                 specified in `dims_to_sample` will be fixed to values given in
                 `condition`.
             x: Conditioning context for posterior $p(\theta|x)$. If not provided,
-                fall back onto `x_o` if previously provided for multiround training, or
-                to a set default (see `set_default_x()` method).
+                fall back onto `x` passed to `set_default_x()`.
             show_progress_bars: Whether to show sampling progress monitor.
             mcmc_method: Optional parameter to override `self.mcmc_method`.
             mcmc_parameters: Dictionary overriding the default parameters for MCMC.

--- a/sbi/inference/posteriors/ratio_based_posterior.py
+++ b/sbi/inference/posteriors/ratio_based_posterior.py
@@ -1,13 +1,7 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-)
+from typing import Any, Callable, Dict, List, Optional
 from warnings import warn
 
 import numpy as np
@@ -17,11 +11,7 @@ from torch import Tensor, nn
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.types import Shape
 from sbi.utils import del_entries
-from sbi.utils.torchutils import (
-    ScalarFloat,
-    ensure_theta_batched,
-    ensure_x_batched,
-)
+from sbi.utils.torchutils import ScalarFloat, ensure_theta_batched, ensure_x_batched
 
 
 class RatioBasedPosterior(NeuralPosterior):
@@ -83,9 +73,8 @@ class RatioBasedPosterior(NeuralPosterior):
 
         Args:
             theta: Parameters $\theta$.
-            x: Conditioning context for posterior $p(\theta|x)$. If not provided, fall
-                back onto an `x_o` if previously provided for multi-round training, or
-                to another default if set later for convenience, see `.set_default_x()`.
+            x: Conditioning context for posterior $p(\theta|x)$. If not provided,
+                fall back onto `x` passed to `set_default_x()`.
             track_gradients: Whether the returned tensor supports tracking gradients.
                 This can be helpful for e.g. sensitivity analysis, but increases memory
                 consumption.
@@ -141,8 +130,7 @@ class RatioBasedPosterior(NeuralPosterior):
                 sample_shape is multidimensional we simply draw `sample_shape.numel()`
                 samples and then reshape into the desired shape.
             x: Conditioning context for posterior $p(\theta|x)$. If not provided,
-                fall back onto `x_o` if previously provided for multiround training, or
-                to a set default (see `set_default_x()` method).
+                fall back onto `x` passed to `set_default_x()`.
             show_progress_bars: Whether to show sampling progress monitor.
             sample_with_mcmc: Optional parameter to override `self.sample_with_mcmc`.
             mcmc_method: Optional parameter to override `self.mcmc_method`.
@@ -214,8 +202,7 @@ class RatioBasedPosterior(NeuralPosterior):
                 specified in `dims_to_sample` will be fixed to values given in
                 `condition`.
             x: Conditioning context for posterior $p(\theta|x)$. If not provided,
-                fall back onto `x_o` if previously provided for multiround training, or
-                to a set default (see `set_default_x()` method).
+                fall back onto `x` passed to `set_default_x()`.
             show_progress_bars: Whether to show sampling progress monitor.
             mcmc_method: Optional parameter to override `self.mcmc_method`.
             mcmc_parameters: Dictionary overriding the default parameters for MCMC.

--- a/sbi/inference/posteriors/ratio_based_posterior.py
+++ b/sbi/inference/posteriors/ratio_based_posterior.py
@@ -1,7 +1,7 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Union
 from warnings import warn
 
 import numpy as np
@@ -62,7 +62,10 @@ class RatioBasedPosterior(NeuralPosterior):
         super().__init__(**kwargs)
 
     def log_prob(
-        self, theta: Tensor, x: Optional[Tensor] = None, track_gradients: bool = False,
+        self,
+        theta: Tensor,
+        x: Optional[Tensor] = None,
+        track_gradients: bool = False,
     ) -> Tensor:
         r"""
         Returns the log-probability of $p(x|\theta) \cdot p(\theta).$
@@ -229,6 +232,71 @@ class RatioBasedPosterior(NeuralPosterior):
             mcmc_parameters,
         )
 
+    def map(
+        self,
+        x: Optional[Tensor] = None,
+        num_iter: int = 1000,
+        learning_rate: float = 1e-2,
+        init_method: Union[str, Tensor] = "posterior",
+        num_init_samples: int = 500,
+        num_to_optimize: int = 100,
+        save_best_every: int = 10,
+        show_progress_bars: bool = True,
+    ) -> Tensor:
+        """
+        Returns the maximum-a-posteriori estimate (MAP).
+
+        The method can be interrupted (Ctrl-C) when the user sees that the
+        log-probability converges. The best estimate will be saved in `self.map_`.
+
+        The MAP is obtained by running gradient ascent from a given number of starting
+        positions (samples from the posterior with the highest log-probability). After
+        the optimization is done, we select the parameter set that has the highest
+        log-probability after the optimization.
+
+        Warning: The default values used by this function are not well-tested. They
+        might require hand-tuning for the problem at hand.
+
+        Args:
+            x: Conditioning context for posterior $p(\theta|x)$. If not provided,
+                fall back onto `x` passed to `set_default_x()`.
+            num_iter: Maximum Number of optimization steps that the algorithm takes
+                to find the MAP.
+            early_stop_at: If `None`, it will optimize for `max_num_iter` iterations.
+                If `float`, the optimization will stop as soon as the steps taken by
+                the optimizer are smaller than `early_stop_at` times the standard
+                deviation of the initial guesses.
+            learning_rate: Learning rate of the optimizer.
+            init_method: How to select the starting parameters for the optimization. If
+                it is a string, it can be either [`posterior`, `prior`], which samples
+                the respective distribution `num_init_samples` times. If it is a,
+                the tensor will be used as init locations.
+            num_init_samples: Draw this number of samples from the posterior and
+                evaluate the log-probability of all of them.
+            num_to_optimize: From the drawn `num_init_samples`, use the
+                `num_to_optimize` with highest log-probability as the initial points
+                for the optimization.
+            save_best_every: The best log-probability is computed, saved in the
+                `map`-attribute, and printed every `print_best_every`-th iteration.
+                Computing the best log-probability creates a significant overhead
+                (thus, the default is `10`.)
+            show_progress_bars: Whether or not to show a progressbar for sampling from
+                the posterior.
+
+        Returns:
+            The MAP estimate.
+        """
+        return super().map(
+            x=x,
+            num_iter=num_iter,
+            learning_rate=learning_rate,
+            init_method=init_method,
+            num_init_samples=num_init_samples,
+            num_to_optimize=num_to_optimize,
+            save_best_every=save_best_every,
+            show_progress_bars=show_progress_bars,
+        )
+
     @property
     def _num_trained_rounds(self) -> int:
         return self._trained_rounds
@@ -277,7 +345,11 @@ class PotentialFunctionProvider:
     """
 
     def __call__(
-        self, prior, classifier: nn.Module, x: Tensor, mcmc_method: str,
+        self,
+        prior,
+        classifier: nn.Module,
+        x: Tensor,
+        mcmc_method: str,
     ) -> Callable:
         r"""Return potential function for posterior $p(\theta|x)$.
 

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -84,7 +84,10 @@ class PosteriorEstimator(NeuralInference, ABC):
         self._summary.update({"rejection_sampling_acceptance_rates": []})  # type:ignore
 
     def append_simulations(
-        self, theta: Tensor, x: Tensor, proposal: Optional[Any] = None,
+        self,
+        theta: Tensor,
+        x: Tensor,
+        proposal: Optional[Any] = None,
     ) -> "PosteriorEstimator":
         r"""
         Store parameters and simulation outputs to use them for later training.
@@ -215,7 +218,11 @@ class PosteriorEstimator(NeuralInference, ABC):
         )
 
         # Dataset is shared for training and validation loaders.
-        dataset = data.TensorDataset(theta, x, prior_masks,)
+        dataset = data.TensorDataset(
+            theta,
+            x,
+            prior_masks,
+        )
 
         # Create neural net and validation loaders using a subset sampler.
         train_loader = data.DataLoader(
@@ -246,7 +253,10 @@ class PosteriorEstimator(NeuralInference, ABC):
 
         # Move entire net to device for training.
         self._neural_net.to(self._device)
-        optimizer = optim.Adam(list(self._neural_net.parameters()), lr=learning_rate,)
+        optimizer = optim.Adam(
+            list(self._neural_net.parameters()),
+            lr=learning_rate,
+        )
 
         epoch, self._val_log_prob = 0, float("-Inf")
         while epoch <= max_num_epochs and not self._converged(epoch, stop_after_epochs):
@@ -264,13 +274,18 @@ class PosteriorEstimator(NeuralInference, ABC):
 
                 batch_loss = torch.mean(
                     self._loss(
-                        theta_batch, x_batch, masks_batch, proposal, calibration_kernel,
+                        theta_batch,
+                        x_batch,
+                        masks_batch,
+                        proposal,
+                        calibration_kernel,
                     )
                 )
                 batch_loss.backward()
                 if clip_max_norm is not None:
                     clip_grad_norm_(
-                        self._neural_net.parameters(), max_norm=clip_max_norm,
+                        self._neural_net.parameters(),
+                        max_norm=clip_max_norm,
                     )
                 optimizer.step()
 
@@ -288,7 +303,11 @@ class PosteriorEstimator(NeuralInference, ABC):
                     )
                     # Take negative loss here to get validation log_prob.
                     batch_log_prob = -self._loss(
-                        theta_batch, x_batch, masks_batch, proposal, calibration_kernel,
+                        theta_batch,
+                        x_batch,
+                        masks_batch,
+                        proposal,
+                        calibration_kernel,
                     )
                     log_prob_sum += batch_log_prob.sum().item()
 
@@ -306,7 +325,10 @@ class PosteriorEstimator(NeuralInference, ABC):
 
         # Update tensorboard and summary dict.
         self._summarize(
-            round_=self._round, x_o=None, theta_bank=theta, x_bank=x,
+            round_=self._round,
+            x_o=None,
+            theta_bank=theta,
+            x_bank=x,
         )
 
         # Update description for progress bar.

--- a/sbi/inference/snpe/snpe_c.py
+++ b/sbi/inference/snpe/snpe_c.py
@@ -18,6 +18,7 @@ from sbi.types import TensorboardSummaryWriter
 from sbi.utils import (
     batched_mixture_mv,
     batched_mixture_vmv,
+    check_if_boxuniform,
     clamp_and_warn,
     del_entries,
     repeat_rows,
@@ -163,7 +164,7 @@ class SNPE_C(PosteriorEstimator):
                     isinstance(proposal.net._distribution, mdn)
                     and isinstance(self._neural_net._distribution, mdn)
                     and (
-                        isinstance(self._prior, utils.BoxUniform)
+                        check_if_boxuniform(self._prior)[0]
                         or isinstance(self._prior, MultivariateNormal)
                     )
                 )

--- a/sbi/utils/__init__.py
+++ b/sbi/utils/__init__.py
@@ -16,10 +16,13 @@ from sbi.utils.restriction_estimator import RestrictedPrior, RestrictionEstimato
 from sbi.utils.sbiutils import (
     batched_mixture_mv,
     batched_mixture_vmv,
+    check_if_boxuniform,
     clamp_and_warn,
     del_entries,
+    expit,
     get_simulations_since_round,
     handle_invalid_x,
+    logit,
     mask_sims_from_prior,
     sample_posterior_within_prior,
     standardizing_net,

--- a/tests/linearGaussian_snle_test.py
+++ b/tests/linearGaussian_snle_test.py
@@ -37,7 +37,10 @@ def test_api_snl_on_linearGaussian(num_dim: int, set_seed):
     prior = MultivariateNormal(loc=prior_mean, covariance_matrix=prior_cov)
 
     simulator, prior = prepare_for_sbi(diagonal_linear_gaussian, prior)
-    inference = SNL(prior, show_progress_bars=False,)
+    inference = SNL(
+        prior,
+        show_progress_bars=False,
+    )
 
     theta, x = simulate_for_sbi(simulator, prior, 1000, simulation_batch_size=50)
     _ = inference.append_simulations(theta, x).train(max_num_epochs=5)
@@ -85,7 +88,10 @@ def test_c2st_snl_on_linearGaussian_different_dims(set_seed):
     )
 
     simulator, prior = prepare_for_sbi(simulator, prior)
-    inference = SNL(prior, show_progress_bars=False,)
+    inference = SNL(
+        prior,
+        show_progress_bars=False,
+    )
 
     theta, x = simulate_for_sbi(simulator, prior, 5000, simulation_batch_size=50)
     _ = inference.append_simulations(theta, x).train()
@@ -132,7 +138,10 @@ def test_c2st_snl_on_linearGaussian(num_dim: int, prior_str: str, set_seed):
     simulator = lambda theta: linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
     simulator, prior = prepare_for_sbi(simulator, prior)
-    inference = SNL(prior, show_progress_bars=False,)
+    inference = SNL(
+        prior,
+        show_progress_bars=False,
+    )
 
     theta, x = simulate_for_sbi(simulator, prior, 1000, simulation_batch_size=50)
     _ = inference.append_simulations(theta, x).train()
@@ -143,6 +152,8 @@ def test_c2st_snl_on_linearGaussian(num_dim: int, prior_str: str, set_seed):
     # Check performance based on c2st accuracy.
     check_c2st(samples, target_samples, alg=f"snle_a-{prior_str}-prior")
 
+    map_ = posterior.map(num_init_samples=1_000, init_method="prior")
+
     # TODO: we do not have a test for SNL log_prob(). This is because the output
     # TODO: density is not normalized, so KLd does not make sense.
     if prior_str == "uniform":
@@ -151,6 +162,10 @@ def test_c2st_snl_on_linearGaussian(num_dim: int, prior_str: str, set_seed):
         assert (
             posterior_prob == 0.0
         ), "The posterior probability outside of the prior support is not zero"
+
+        assert ((map_ - ones(num_dim)) ** 2).sum() < 0.5
+    else:
+        assert ((map_ - gt_posterior.mean) ** 2).sum() < 0.5
 
 
 @pytest.mark.slow
@@ -180,7 +195,10 @@ def test_c2st_multi_round_snl_on_linearGaussian(set_seed):
     simulator = lambda theta: linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
     simulator, prior = prepare_for_sbi(simulator, prior)
-    inference = SNL(prior, show_progress_bars=False,)
+    inference = SNL(
+        prior,
+        show_progress_bars=False,
+    )
 
     theta, x = simulate_for_sbi(simulator, prior, 750, simulation_batch_size=50)
     _ = inference.append_simulations(theta, x).train()
@@ -200,7 +218,11 @@ def test_c2st_multi_round_snl_on_linearGaussian(set_seed):
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
-    "mcmc_method, prior_str", (("slice", "gaussian"), ("slice", "uniform"),),
+    "mcmc_method, prior_str",
+    (
+        ("slice", "gaussian"),
+        ("slice", "uniform"),
+    ),
 )
 def test_api_snl_sampling_methods(mcmc_method: str, prior_str: str, set_seed):
     """Runs SNL on linear Gaussian and tests sampling from posterior via mcmc.
@@ -221,7 +243,10 @@ def test_api_snl_sampling_methods(mcmc_method: str, prior_str: str, set_seed):
         prior = utils.BoxUniform(-1.0 * ones(num_dim), ones(num_dim))
 
     simulator, prior = prepare_for_sbi(diagonal_linear_gaussian, prior)
-    inference = SNL(prior, show_progress_bars=False,)
+    inference = SNL(
+        prior,
+        show_progress_bars=False,
+    )
 
     theta, x = simulate_for_sbi(simulator, prior, 200, simulation_batch_size=50)
     _ = inference.append_simulations(theta, x).train(max_num_epochs=5)

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -28,10 +28,17 @@ from tests.test_utils import (
 
 
 @pytest.mark.parametrize(
-    "num_dim, prior_str", ((2, "gaussian"), (2, "uniform"), (1, "gaussian"),),
+    "num_dim, prior_str",
+    (
+        (2, "gaussian"),
+        (2, "uniform"),
+        (1, "gaussian"),
+    ),
 )
 def test_c2st_snpe_on_linearGaussian(
-    num_dim: int, prior_str: str, set_seed,
+    num_dim: int,
+    prior_str: str,
+    set_seed,
 ):
     """Test whether SNPE C infers well a simple example with available ground truth.
 
@@ -64,7 +71,10 @@ def test_c2st_snpe_on_linearGaussian(
         return linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
     simulator, prior = prepare_for_sbi(simulator, prior)
-    inference = SNPE_C(prior, show_progress_bars=False,)
+    inference = SNPE_C(
+        prior,
+        show_progress_bars=False,
+    )
 
     theta, x = simulate_for_sbi(simulator, prior, 2000, simulation_batch_size=1000)
     _ = inference.append_simulations(theta, x).train(training_batch_size=100)
@@ -73,6 +83,8 @@ def test_c2st_snpe_on_linearGaussian(
 
     # Compute the c2st and assert it is near chance level of 0.5.
     check_c2st(samples, target_samples, alg="snpe_c")
+
+    map_ = posterior.map(num_init_samples=1_000)
 
     # Checks for log_prob()
     if prior_str == "gaussian":
@@ -86,6 +98,8 @@ def test_c2st_snpe_on_linearGaussian(
         assert (
             dkl < max_dkl
         ), f"D-KL={dkl} is more than 2 stds above the average performance."
+
+        assert ((map_ - gt_posterior.mean) ** 2).sum() < 0.5
 
     elif prior_str == "uniform":
         # Check whether the returned probability outside of the support is zero.
@@ -111,6 +125,8 @@ def test_c2st_snpe_on_linearGaussian(
             < posterior_likelihood_unnorm / posterior_likelihood_norm
             < acceptance_prob * 1.01
         ), "Normalizing the posterior density using the acceptance probability failed."
+
+        assert ((map_ - ones(num_dim)) ** 2).sum() < 0.5
 
 
 def test_c2st_snpe_on_linearGaussian_different_dims(set_seed):
@@ -153,7 +169,11 @@ def test_c2st_snpe_on_linearGaussian_different_dims(set_seed):
         )
 
     simulator, prior = prepare_for_sbi(simulator, prior)
-    inference = SNPE_C(prior, density_estimator="maf", show_progress_bars=False,)
+    inference = SNPE_C(
+        prior,
+        density_estimator="maf",
+        show_progress_bars=False,
+    )
 
     theta, x = simulate_for_sbi(simulator, prior, 2000, simulation_batch_size=1)  # type: ignore
     _ = inference.append_simulations(theta, x).train()
@@ -172,7 +192,8 @@ def test_c2st_snpe_on_linearGaussian_different_dims(set_seed):
         pytest.param(
             "snpe_b",
             marks=pytest.mark.xfail(
-                raises=NotImplementedError, reason="""SNPE-B not implemented""",
+                raises=NotImplementedError,
+                reason="""SNPE-B not implemented""",
             ),
         ),
         "snpe_c",
@@ -342,7 +363,11 @@ def test_sample_conditional(set_seed):
     net = utils.posterior_nn("maf", hidden_features=20)
 
     simulator, prior = prepare_for_sbi(simulator, prior)
-    inference = SNPE_C(prior, density_estimator=net, show_progress_bars=False,)
+    inference = SNPE_C(
+        prior,
+        density_estimator=net,
+        show_progress_bars=False,
+    )
 
     # We need a pretty big dataset to properly model the bimodality.
     theta, x = simulate_for_sbi(simulator, prior, 10000)
@@ -368,8 +393,16 @@ def test_sample_conditional(set_seed):
     density = gaussian_kde(cond_samples.numpy().T, bw_method="scott")
 
     X, Y = np.meshgrid(
-        np.linspace(limits[0][0], limits[0][1], 50,),
-        np.linspace(limits[1][0], limits[1][1], 50,),
+        np.linspace(
+            limits[0][0],
+            limits[0][1],
+            50,
+        ),
+        np.linspace(
+            limits[1][0],
+            limits[1][1],
+            50,
+        ),
     )
     positions = np.vstack([X.ravel(), Y.ravel()])
     sample_kde_grid = np.reshape(density(positions).T, X.shape)
@@ -410,7 +443,10 @@ def example_posterior():
         return linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
     simulator, prior = prepare_for_sbi(simulator, prior)
-    inference = SNPE_C(prior, show_progress_bars=False,)
+    inference = SNPE_C(
+        prior,
+        show_progress_bars=False,
+    )
     theta, x = simulate_for_sbi(
         simulator, prior, 1000, simulation_batch_size=10, num_workers=6
     )

--- a/tests/linearGaussian_snre_test.py
+++ b/tests/linearGaussian_snre_test.py
@@ -37,7 +37,11 @@ def test_api_sre_on_linearGaussian(num_dim: int):
     prior = MultivariateNormal(loc=zeros(num_dim), covariance_matrix=eye(num_dim))
 
     simulator, prior = prepare_for_sbi(diagonal_linear_gaussian, prior)
-    inference = SRE(prior, classifier="resnet", show_progress_bars=False,)
+    inference = SRE(
+        prior,
+        classifier="resnet",
+        show_progress_bars=False,
+    )
 
     theta, x = simulate_for_sbi(simulator, prior, 1000, simulation_batch_size=50)
     _ = inference.append_simulations(theta, x).train(max_num_epochs=5)
@@ -87,7 +91,11 @@ def test_c2st_sre_on_linearGaussian_different_dims(set_seed):
         )
 
     simulator, prior = prepare_for_sbi(simulator, prior)
-    inference = SRE(prior, classifier="resnet", show_progress_bars=False,)
+    inference = SRE(
+        prior,
+        classifier="resnet",
+        show_progress_bars=False,
+    )
 
     theta, x = simulate_for_sbi(simulator, prior, 5000, simulation_batch_size=50)
     _ = inference.append_simulations(theta, x).train()
@@ -109,7 +117,10 @@ def test_c2st_sre_on_linearGaussian_different_dims(set_seed):
     ),
 )
 def test_c2st_sre_on_linearGaussian(
-    num_dim: int, prior_str: str, method_str: str, set_seed,
+    num_dim: int,
+    prior_str: str,
+    method_str: str,
+    set_seed,
 ):
     """Test c2st accuracy of inference with SRE on linear Gaussian model.
 
@@ -144,7 +155,11 @@ def test_c2st_sre_on_linearGaussian(
         return linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
     simulator, prior = prepare_for_sbi(simulator, prior)
-    kwargs = dict(prior=prior, classifier="resnet", show_progress_bars=False,)
+    kwargs = dict(
+        prior=prior,
+        classifier="resnet",
+        show_progress_bars=False,
+    )
 
     inference = SRE(**kwargs) if method_str == "sre" else AALR(**kwargs)
 
@@ -157,6 +172,8 @@ def test_c2st_sre_on_linearGaussian(
 
     # Check performance based on c2st accuracy.
     check_c2st(samples, target_samples, alg=f"sre-{prior_str}-{method_str}")
+
+    map_ = posterior.map(num_init_samples=1_000, init_method="prior")
 
     # Checks for log_prob()
     if prior_str == "gaussian" and method_str == "aalr":
@@ -174,12 +191,17 @@ def test_c2st_sre_on_linearGaussian(
         assert (
             dkl < max_dkl
         ), f"KLd={dkl} is more than 2 stds above the average performance."
+
+        assert ((map_ - gt_posterior.mean) ** 2).sum() < 0.5
+
     if prior_str == "uniform":
         # Check whether the returned probability outside of the support is zero.
         posterior_prob = get_prob_outside_uniform_prior(posterior, num_dim)
         assert (
             posterior_prob == 0.0
         ), "The posterior probability outside of the prior support is not zero"
+
+        assert ((map_ - ones(num_dim)) ** 2).sum() < 0.5
 
 
 @pytest.mark.slow
@@ -209,7 +231,11 @@ def test_api_sre_sampling_methods(mcmc_method: str, prior_str: str, set_seed):
         prior = utils.BoxUniform(low=-1.0 * ones(num_dim), high=ones(num_dim))
 
     simulator, prior = prepare_for_sbi(diagonal_linear_gaussian, prior)
-    inference = SRE(prior, classifier="resnet", show_progress_bars=False,)
+    inference = SRE(
+        prior,
+        classifier="resnet",
+        show_progress_bars=False,
+    )
 
     theta, x = simulate_for_sbi(simulator, prior, 200, simulation_batch_size=50)
     _ = inference.append_simulations(theta, x).train(max_num_epochs=5)


### PR DESCRIPTION
This PR implements the Maximum-a-posteriori (MAP) estimate for SNPE, SNLE, SNRE. It is obtained by gradient ascent from some starting locations (usually sampled from the posterior).

See #306 and #276 and #392

## API

```
posterior = inference.build_posterior()
map_ = posterior.map(x=xo)
```
While the optimization is running, we print:
![screenshot7](https://user-images.githubusercontent.com/24639769/106465607-796f2380-649a-11eb-96a0-f755e1bb4725.png)

When interrupting:
![screenshot9](https://user-images.githubusercontent.com/24639769/106465619-7c6a1400-649a-11eb-8de3-f01428e360c4.png)

## Timing
for a 3D Gaussian, it is around 30 seconds. For the 31D STG, it's at 100 seconds with default parameters.

## Why not use `cma`?
- relatively high interrun-variability.
- black-box algorithm, I have no idea what is happening there.
- one more dependency
- why not use gradients if we have them?

We could still revert to `cma` though, I will not squash the commit.

## Why not implement the Maximum-likelihood-estimate?
- for SNPE: we would obtain the likelihood by dividing the posterior by the prior. However, if the prior drops off faster than the posterior, the likelihood will explode, leading to highly unstable results.
- for SNRE and SNLE: the likelihood estimate will be highly inaccurate in regions where there is not much data for theta. In these regions, the trained NN can do whatever it wants and it might just assign very high probabilities to some absurd regions (for sampling the posterior, this does not matter since the prior makes the posterior log-prob very small)

We could still revert to using it though, I will not squash the commit.

## Dealing with bounded priors
If the prior is `BoxUniform`, we transform it into unbounded space and optimize there.