### PR TITLE
Optimizing `test_c2st_sre_on_linearGaussian_different_dims` test

### DIFF
--- a/tests/linearGaussian_snre_test.py
+++ b/tests/linearGaussian_snre_test.py
@@ -61,7 +61,7 @@ def test_c2st_sre_on_linearGaussian_different_dims(set_seed):
     discard_dims = theta_dim - x_dim
 
     x_o = ones(1, x_dim)
-    num_samples = 1000
+    num_samples = 130
 
     likelihood_shift = -1.0 * ones(
         x_dim
@@ -89,7 +89,7 @@ def test_c2st_sre_on_linearGaussian_different_dims(set_seed):
     simulator, prior = prepare_for_sbi(simulator, prior)
     inference = SRE(prior, classifier="resnet", show_progress_bars=False,)
 
-    theta, x = simulate_for_sbi(simulator, prior, 5000, simulation_batch_size=50)
+    theta, x = simulate_for_sbi(simulator, prior, 100, simulation_batch_size=50)
     _ = inference.append_simulations(theta, x).train()
     posterior = inference.build_posterior()
     samples = posterior.sample((num_samples,), x=x_o, mcmc_parameters={"thin": 3})


### PR DESCRIPTION
Hi,

I was able to reduce the running time of `test_c2st_sre_on_linearGaussian_different_dims` test from `78` seconds to about `8` seconds on my local machine by changing two hyper-parameters `num_samples` and `num_simulations_per_round`. 

I also ran the test several times to ensure that the test is not flaky. 

Environment:
```
python 3.8.5
torch==1.7.1
numpy==1.19.5
```
Is this something that you guys will be interested in? If yes, then I can help you optimize some other tests in this repo as well. If you have any other suggestions/edits I will be happy to integrate them as well. Please let me know.

Thanks!
