### PR TITLE
SNRE embedding fixes

### DIFF
--- a/sbi/inference/posteriors/ratio_based_posterior.py
+++ b/sbi/inference/posteriors/ratio_based_posterior.py
@@ -105,7 +105,7 @@ class RatioBasedPosterior(NeuralPosterior):
         with torch.set_grad_enabled(track_gradients):
             # Send to device for evaluation, send to CPU for comparison with prior.
             log_ratio = (
-                self.net(torch.cat((theta.to(self._device), x.to(self._device)), dim=1))
+                self.net([theta.to(self._device), x.to(self._device)])
                 .reshape(-1)
                 .to("cpu")
             )
@@ -334,15 +334,9 @@ class PotentialFunctionProvider:
             num_batch, *(1 for _ in range(x_batched.ndim - 1))
         )
 
-        assert (
-            x_batched.ndim == 2
-        ), """X must not be multidimensional for ratio-based methods because it will be
-              concatenated with theta."""
         with torch.set_grad_enabled(False):
             log_ratio = (
-                self.classifier(torch.cat((theta.to(self.x.device), x_repeated), dim=1))
-                .reshape(-1)
-                .cpu()
+                self.classifier([theta.to(self.x.device), x_repeated]).reshape(-1).cpu()
             )
 
         # Notice opposite sign to pyro potential.
@@ -366,8 +360,6 @@ class PotentialFunctionProvider:
         theta = ensure_theta_batched(theta)
         x = ensure_x_batched(self.x)
 
-        log_ratio = self.classifier(
-            torch.cat((theta.to(x.device), x), dim=1).reshape(1, -1)
-        ).cpu()
+        log_ratio = self.classifier([theta.to(x.device), x]).cpu()
 
         return -(log_ratio + self.prior.log_prob(theta))

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -200,10 +200,6 @@ class RatioEstimator(NeuralInference, ABC):
                 theta[train_indices], x[train_indices]
             )
             self._x_shape = x_shape_from_simulation(x)
-            assert len(self._x_shape) < 3, (
-                "For now, SNRE cannot handle multi-dimensional simulator output, see "
-                "issue #360."
-            )
 
         self._neural_net.to(self._device)
         optimizer = optim.Adam(list(self._neural_net.parameters()), lr=learning_rate,)
@@ -348,9 +344,7 @@ class RatioEstimator(NeuralInference, ABC):
             batch_size * num_atoms, -1
         )
 
-        theta_and_x = torch.cat((atomic_theta, repeated_x), dim=1)
-
-        return self._neural_net(theta_and_x)
+        return self._neural_net([atomic_theta, repeated_x])
 
     @abstractmethod
     def _loss(self, theta: Tensor, x: Tensor, num_atoms: int) -> Tensor:

--- a/sbi/neural_nets/classifier.py
+++ b/sbi/neural_nets/classifier.py
@@ -17,11 +17,12 @@ class StandardizeInputs(nn.Module):
         self.dim_x = dim_x
         self.dim_y = dim_y
 
-    def forward(self, t):
-        assert type(t) is list
-        assert len(t) == 2
+    def forward(self, inputs: list) -> Tensor:
+        assert (
+            type(inputs) is list and len(inputs) == 2
+        ), """Inputs to (s)nre classifier must be a list containing raw theta and x."""
         out = torch.cat(
-            [self.embedding_net_x(t[0]), self.embedding_net_y(t[1]),], dim=1,
+            [self.embedding_net_x(inputs[0]), self.embedding_net_y(inputs[1]),], dim=1,
         )
         return out
 

--- a/sbi/neural_nets/classifier.py
+++ b/sbi/neural_nets/classifier.py
@@ -18,12 +18,10 @@ class StandardizeInputs(nn.Module):
         self.dim_y = dim_y
 
     def forward(self, t):
+        assert type(t) is list
+        assert len(t) == 2
         out = torch.cat(
-            [
-                self.embedding_net_x(t[:, : self.dim_x]),
-                self.embedding_net_y(t[:, self.dim_x : self.dim_x + self.dim_y]),
-            ],
-            dim=1,
+            [self.embedding_net_x(t[0]), self.embedding_net_y(t[1]),], dim=1,
         )
         return out
 

--- a/sbi/utils/get_nn_models.py
+++ b/sbi/utils/get_nn_models.py
@@ -56,8 +56,8 @@ def classifier_nn(
                 z_score_x,
                 z_score_theta,
                 hidden_features,
-                embedding_net_x,
                 embedding_net_theta,
+                embedding_net_x,
             ),
         )
     )

--- a/sbi/utils/get_nn_models.py
+++ b/sbi/utils/get_nn_models.py
@@ -29,6 +29,8 @@ def classifier_nn(
     This function will usually be used for SNRE. The returned function is to be passed
     to the inference class when using the flexible interface.
 
+    Note that in the view of the SNRE classifier we build below, x=theta and y=x.
+
     Args:
         model: The type of classifier that will be created. One of [`linear`, `mlp`,
             `resnet`].
@@ -53,8 +55,8 @@ def classifier_nn(
                 "embedding_net_y",
             ),
             (
-                z_score_x,
                 z_score_theta,
+                z_score_x,
                 hidden_features,
                 embedding_net_theta,
                 embedding_net_x,

--- a/tests/multidimensional_x_test.py
+++ b/tests/multidimensional_x_test.py
@@ -47,14 +47,10 @@ class CNNEmbedding(nn.Module):
         ),
         pytest.param(
             nn.Identity,
-            SNRE,
+            SNLE,
             marks=pytest.mark.xfail(reason="SNLE cannot handle multiD x."),
         ),
-        pytest.param(
-            CNNEmbedding,
-            SNLE,
-            marks=pytest.mark.xfail(reason="SNRE cannot handle multiD x."),
-        ),
+        pytest.param(CNNEmbedding, SNRE,),
         pytest.param(CNNEmbedding, SNPE),
     ),
 )


### PR DESCRIPTION
This PR fixes the issue reported in https://github.com/mackelab/sbi/issues/424 (thank you @adittmann). 

It also changes the code such that SNRE passes inputs as lists. Previously, inputs were concatenated. With lists, it becomes possible to e.g. use a convolutional network for embedding xs and no embedding for thetas.

closes #424 
closes #360 