### PR TITLE
Make prior optional for SNPE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## Minor changes
 - Depend on new `joblib=1.0.0` and fix progress bar updates for multiprocessing (#421).
 - Fix for embedding nets with `SNRE` (thanks @adittmann, #425)
+- Is it now optional to pass a prior distribution when using SNPE (#426)
 
 
 # v0.14.3

--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -85,7 +85,7 @@ class NeuralInference(ABC):
 
     def __init__(
         self,
-        prior,
+        prior: Optional[Any] = None,
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
         summary_writer: Optional[SummaryWriter] = None,
@@ -308,7 +308,9 @@ class NeuralInference(ABC):
 
         method = self.__class__.__name__
         logdir = Path(
-            get_log_root(), method, datetime.now().isoformat().replace(":", "_"),
+            get_log_root(),
+            method,
+            datetime.now().isoformat().replace(":", "_"),
         )
         return SummaryWriter(logdir)
 
@@ -316,8 +318,7 @@ class NeuralInference(ABC):
     def _ensure_list(
         num_simulations_per_round: Union[List[int], int], num_rounds: int
     ) -> List[int]:
-        """Return `num_simulations_per_round` as a list of length `num_rounds`.
-        """
+        """Return `num_simulations_per_round` as a list of length `num_rounds`."""
         try:
             assert len(num_simulations_per_round) == num_rounds, (
                 "Please provide a list with number of simulations per round for each "
@@ -370,7 +371,11 @@ class NeuralInference(ABC):
         assert torch.isfinite(quantity).all(), msg
 
     def _summarize(
-        self, round_: int, x_o: Union[Tensor, None], theta_bank: Tensor, x_bank: Tensor,
+        self,
+        round_: int,
+        x_o: Union[Tensor, None],
+        theta_bank: Tensor,
+        x_bank: Tensor,
     ) -> None:
         """Update the summary_writer with statistics for a given round.
 
@@ -385,7 +390,12 @@ class NeuralInference(ABC):
         # Median |x - x0| for most recent round.
         if x_o is not None:
             median_observation_distance = torch.median(
-                torch.sqrt(torch.sum((x_bank - x_o.reshape(1, -1)) ** 2, dim=-1,))
+                torch.sqrt(
+                    torch.sum(
+                        (x_bank - x_o.reshape(1, -1)) ** 2,
+                        dim=-1,
+                    )
+                )
             )
             self._summary["median_observation_distances"].append(
                 median_observation_distance.item()
@@ -468,7 +478,11 @@ def simulate_for_sbi(
     theta = proposal.sample((num_simulations,))
 
     x = simulate_in_batches(
-        simulator, theta, simulation_batch_size, num_workers, show_progress_bar,
+        simulator,
+        theta,
+        simulation_batch_size,
+        num_workers,
+        show_progress_bar,
     )
 
     return theta, x

--- a/sbi/inference/posteriors/direct_posterior.py
+++ b/sbi/inference/posteriors/direct_posterior.py
@@ -195,22 +195,27 @@ class DirectPosterior(NeuralPosterior):
                 theta.to(self._device), x.to(self._device)
             ).cpu()
 
-            # Force probability to be zero outside prior support.
-            is_prior_finite = torch.isfinite(self._prior.log_prob(theta))
+            if self._prior is not None:
 
-            masked_log_prob = torch.where(
-                is_prior_finite,
-                unnorm_log_prob,
-                torch.tensor(float("-inf"), dtype=torch.float32),
-            )
+                # Force probability to be zero outside prior support.
+                is_prior_finite = torch.isfinite(self._prior.log_prob(theta))
 
-            log_factor = (
-                log(self.leakage_correction(x=batched_first_of_batch(x)))
-                if norm_posterior
-                else 0
-            )
+                masked_log_prob = torch.where(
+                    is_prior_finite,
+                    unnorm_log_prob,
+                    torch.tensor(float("-inf"), dtype=torch.float32),
+                )
 
-            return masked_log_prob - log_factor
+                log_factor = (
+                    log(self.leakage_correction(x=batched_first_of_batch(x)))
+                    if norm_posterior
+                    else 0
+                )
+
+                return masked_log_prob - log_factor
+
+            else:
+                return unnorm_log_prob
 
     @torch.no_grad()
     def leakage_correction(
@@ -324,6 +329,9 @@ class DirectPosterior(NeuralPosterior):
         self.net.eval()
 
         if sample_with_mcmc:
+            if self._prior is None:
+                raise ValueError("`sample_with_mcmc` is not allowed when `prior=None`.")
+
             potential_fn_provider = PotentialFunctionProvider()
             samples = self._sample_posterior_mcmc(
                 num_samples=num_samples,

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -31,7 +31,7 @@ from sbi.utils.sbiutils import mask_sims_from_prior
 class PosteriorEstimator(NeuralInference, ABC):
     def __init__(
         self,
-        prior,
+        prior: Optional[Any] = None,
         density_estimator: Union[str, Callable] = "maf",
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
@@ -111,6 +111,16 @@ class PosteriorEstimator(NeuralInference, ABC):
 
         validate_theta_and_x(theta, x)
         self._check_proposal(proposal)
+
+        if self._prior is None and proposal is not None:
+            raise ValueError(
+                "You had not passed a prior at initialization, but now you "
+                "passed a proposal. If you want to run multi-round SNPE, you have to "
+                "specify a prior (set the `.prior` argument or re-initialize the "
+                "object with a prior distribution). If the samples you passed to "
+                "`append_simulations()` were sampled from the prior, you can run "
+                "single-round inference with `append_simulations(..., proposal=None)`."
+            )
 
         if (
             proposal is None

--- a/sbi/inference/snpe/snpe_c.py
+++ b/sbi/inference/snpe/snpe_c.py
@@ -28,7 +28,7 @@ from sbi.utils import (
 class SNPE_C(PosteriorEstimator):
     def __init__(
         self,
-        prior,
+        prior: Optional[Any] = None,
         density_estimator: Union[str, Callable] = "maf",
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -113,7 +113,7 @@ def standardizing_net(batch_t: Tensor, min_std: float = 1e-7) -> nn.Module:
 @torch.no_grad()
 def sample_posterior_within_prior(
     posterior_nn: nn.Module,
-    prior,
+    prior: Optional[Any],
     x: Tensor,
     num_samples: int = 1,
     show_progress_bars: bool = False,
@@ -173,7 +173,13 @@ def sample_posterior_within_prior(
             .reshape(sampling_batch_size, -1)
             .cpu()  # Move to cpu to evaluate under prior.
         )
-        are_within_prior = torch.isfinite(prior.log_prob(candidates))
+
+        are_within_prior = (
+            torch.isfinite(prior.log_prob(candidates))
+            if prior is not None
+            else torch.ones(sampling_batch_size, dtype=torch.bool)
+        )
+
         samples = candidates[are_within_prior]
         accepted.append(samples)
 

--- a/tests/abc_test.py
+++ b/tests/abc_test.py
@@ -1,19 +1,21 @@
 import pytest
 from torch import eye, ones, zeros
+from torch.distributions import MultivariateNormal
 
+from sbi.inference import ABC, SMC
 from sbi.simulators.linear_gaussian import (
     linear_gaussian,
     true_posterior_linear_gaussian_mvn_prior,
 )
-
-from sbi.inference import ABC, SMC
-from torch.distributions import MultivariateNormal
 from tests.test_utils import check_c2st
 
 
 @pytest.mark.parametrize("num_dim", (1, 2))
 def test_mcabc_inference_on_linear_gaussian(
-    num_dim, lra=False, sass=False, sass_expansion_degree=1,
+    num_dim,
+    lra=False,
+    sass=False,
+    sass_expansion_degree=1,
 ):
     x_o = zeros((1, num_dim))
     num_samples = 1000
@@ -54,7 +56,10 @@ def test_mcabc_inference_on_linear_gaussian(
 def test_mcabc_sass_lra(lra, sass_expansion_degree, set_seed):
 
     test_mcabc_inference_on_linear_gaussian(
-        num_dim=2, lra=lra, sass=True, sass_expansion_degree=sass_expansion_degree,
+        num_dim=2,
+        lra=lra,
+        sass=True,
+        sass_expansion_degree=sass_expansion_degree,
     )
 
 
@@ -85,7 +90,7 @@ def test_smcabc_inference_on_linear_gaussian(
         num_particles=1000,
         num_initial_pop=5000,
         epsilon_decay=0.5,
-        num_simulations=100000,
+        num_simulations=110000,
         distance_based_decay=True,
         lra=lra,
         sass=sass,

--- a/tests/inference_with_NaN_simulator_test.py
+++ b/tests/inference_with_NaN_simulator_test.py
@@ -39,7 +39,11 @@ def test_handle_invalid_x(x_shape, set_seed):
 @pytest.mark.slow
 @pytest.mark.parametrize(
     ("method", "exclude_invalid_x", "percent_nans"),
-    ((SNPE_C, True, 0.05), (SNL, True, 0.05), (SRE, True, 0.05),),
+    (
+        (SNPE_C, True, 0.05),
+        (SNL, True, 0.05),
+        (SRE, True, 0.05),
+    ),
 )
 def test_inference_with_nan_simulator(
     method, exclude_invalid_x, percent_nans, set_seed
@@ -87,7 +91,7 @@ def test_inference_with_nan_simulator(
 
 
 @pytest.mark.slow
-def test_inference_with_rejection_estimator(set_seed):
+def test_inference_with_restriction_estimator(set_seed):
 
     # likelihood_mean will be likelihood_shift+theta
     num_dim = 3
@@ -121,7 +125,7 @@ def test_inference_with_rejection_estimator(set_seed):
     num_rounds = 2
 
     for r in range(num_rounds):
-        theta, x = simulate_for_sbi(simulator, proposals[-1], 550)
+        theta, x = simulate_for_sbi(simulator, proposals[-1], 1000)
         rejection_estimator.append_simulations(theta, x)
         if r < num_rounds - 1:
             _ = rejection_estimator.train()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,7 +25,7 @@ def kl_d_via_monte_carlo(
     q.
 
     Unlike torch.distributions.kl.kl_divergence(p, q), this function does not require p
-    and q to be `torch.Distribution` objects, but just to provide `sample()` and 
+    and q to be `torch.Distribution` objects, but just to provide `sample()` and
     `log_prob()` methods.
 
     For added flexibility, we squeeze the output of log_prob() and hence can handle
@@ -98,7 +98,9 @@ def get_prob_outside_uniform_prior(posterior: NeuralPosterior, num_dim: int) -> 
 
 
 def get_normalization_uniform_prior(
-    posterior: DirectPosterior, prior: Distribution, true_observation: Tensor,
+    posterior: DirectPosterior,
+    prior: Distribution,
+    true_observation: Tensor,
 ) -> Tuple[Tensor, Tensor, Tensor]:
     """
     Return the unnormalized posterior likelihood, the normalized posterior likelihood,


### PR DESCRIPTION
Closes #409 

Two options:

1) Always check `if prior is not None:` and build special cases for it
2) If `prior=None` is passed, then build an [empirical distribution](http://docs.pyro.ai/en/0.2.1-release/_modules/pyro/distributions/empirical.html) out of samples passed to `append_simulations`.

I implemented option (1) in the first commit. I kind of prefer option (2) though, so I implemented it in the second commit and we can revert to option (1) if we have trouble with (2).