### PR TITLE
Pickling the posterior across sbi versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Depend on new `joblib=1.0.0` and fix progress bar updates for multiprocessing (#421).
 - Fix for embedding nets with `SNRE` (thanks @adittmann, #425)
 - Is it now optional to pass a prior distribution when using SNPE (#426)
+- Support loading of posteriors saved after `sbi v0.13.0` under newer versions (#427)
 
 
 # v0.14.3

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -7,3 +7,5 @@
 [When using multiple workers, I get a pickling error. Can I still use multiprocessing?](faq/question_03.md)
 
 [Can I use the GPU for training the density estimator?](faq/question_04.md)
+
+[How should I save and load objects in sbi?](faq/question_05.md)

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -8,4 +8,4 @@
 
 [Can I use the GPU for training the density estimator?](faq/question_04.md)
 
-[How should I save and load objects in sbi?](faq/question_05.md)
+[How should I save and load objects in `sbi`?](faq/question_05.md)

--- a/docs/docs/faq/question_05.md
+++ b/docs/docs/faq/question_05.md
@@ -8,21 +8,21 @@ import pickle
 # ... run inference
 posterior = inference.build_posterior()
 
-with open("my_path.pkl", "wb"):
-    pickle.dump(posterior)
+with open("/path/to/my_posterior.pkl", "wb") as handle:
+    pickle.dump(posterior, handle)
 ```
 
 `NeuralInference` objects are not picklable. There are two workarounds:
 
-- Pickle with `dill` (has to be installed with `pip install dill` first)
+- Pickle with [`dill`](https://pypi.org/project/dill/) (has to be installed with `pip install dill` first)
 ```python
-import dill as pickle
+import dill
 
 inference = SNPE(prior)
 # ... run inference
 
-with open("my_path.pkl", "wb"):
-    pickle.dump(inference)
+with open("path/to/my_inference.pkl", "wb") as handle:
+    dill.dump(inference)
 ```
 
 - Delete un-picklable attributes and serialize with pickle. Using this option, you will not be able to use the `retrain_from_scratch` feature and you can only use the default `SummaryWriter`.
@@ -35,12 +35,12 @@ inference = SNPE(prior)
 posterior = inference.build_posterior()
 inference._summary_writer = None
 inference._build_neural_net = None
-with open("my_path.pkl", "wb") as handle:
+with open("/path/to/my_inference.pkl", "wb") as handle:
     pickle.dump(inference, handle)
 ```
 Then, to load:
 ```python
-with open("my_path.pkl", "rb") as handle:
-    inference = pickle.load(handle)
-inference._summary_writer = inference._default_summary_writer()
+with open("/path/to/my_inference.pkl", "rb") as handle:
+    inference_from_disk = pickle.load(handle)
+inference_from_disk._summary_writer = inference_from_disk._default_summary_writer()
 ```

--- a/docs/docs/faq/question_05.md
+++ b/docs/docs/faq/question_05.md
@@ -1,0 +1,46 @@
+
+# How should I save and load objects in `sbi`?
+
+`NeuralPosterior` objects are picklable.
+```python
+import pickle
+
+# ... run inference
+posterior = inference.build_posterior()
+
+with open("my_path.pkl", "wb"):
+    pickle.dump(posterior)
+```
+
+`NeuralInference` objects are not picklable. There are two workarounds:
+
+- Pickle with `dill` (has to be installed with `pip install dill` first)
+```python
+import dill as pickle
+
+inference = SNPE(prior)
+# ... run inference
+
+with open("my_path.pkl", "wb"):
+    pickle.dump(inference)
+```
+
+- Delete un-picklable attributes and serialize with pickle. Using this option, you will not be able to use the `retrain_from_scratch` feature and you can only use the default `SummaryWriter`.
+```python
+import pickle
+
+inference = SNPE(prior)
+# ... run inference
+
+posterior = inference.build_posterior()
+inference._summary_writer = None
+inference._build_neural_net = None
+with open("my_path.pkl", "wb") as handle:
+    pickle.dump(inference, handle)
+```
+Then, to load:
+```python
+with open("my_path.pkl", "rb") as handle:
+    inference = pickle.load(handle)
+inference._summary_writer = inference._default_summary_writer()
+```

--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -941,6 +941,31 @@ class NeuralPosterior(ABC):
 
         return desc
 
+    def __getstate__(self) -> Dict:
+        """
+        Returns the state of the object that is supposed to be pickled.
+
+        Returns:
+            Dictionary containing the state.
+        """
+        return self.__dict__
+
+    def __setstate__(self, state_dict: Dict):
+        """
+        Sets the state when being loaded from pickle.
+
+        Args:
+            state_dict: State to be restored.
+        """
+        if "_device" not in state_dict.keys():
+            state_dict["_device"] = "cpu"
+            warn(
+                "You had saved the posterior under an older version of `sbi`. To make "
+                "the loaded version comply with the version you are using right now, "
+                "we had to set `self._device = 'cpu'`"
+            )
+        self.__dict__ = state_dict
+
 
 class ConditionalPotentialFunctionProvider:
     """

--- a/tests/inference_with_NaN_simulator_test.py
+++ b/tests/inference_with_NaN_simulator_test.py
@@ -99,7 +99,6 @@ def test_inference_with_restriction_estimator(set_seed):
     likelihood_cov = 0.3 * eye(num_dim)
     x_o = zeros(1, num_dim)
     num_samples = 500
-    num_simulations = 2000
 
     def linear_gaussian_nan(
         theta, likelihood_shift=likelihood_shift, likelihood_cov=likelihood_cov


### PR DESCRIPTION
For posteriors saved after `sbi v0.13.0`, we now support loading them under newer versions. Saving and loading should be done with pickle. If we add new attributes to the posterior class, we have to add them to the `__setstate__` method.

Fixes #386