### PR TITLE
Do not run slow tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
       run: |
         pip install torchtestcase
         pip install pytest pytest-cov
-        pytest -m "not slow" -m "not gpu" tests/ --cov=sbi --cov-report=xml
+        pytest -m "not slow and not gpu" tests/ --cov=sbi --cov-report=xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:


### PR DESCRIPTION
We ran slow tests at every commit. This is because:
```
pytest -m "not slow" -m "not gpu" tests/
```
will only consider the last argument passed to `-m`. Thus, only tests that used gpu were ignored, but slow tests were still run. The correct syntax is described here: https://github.com/pytest-dev/pytest/issues/6142