### PR TITLE
Allow to stop and resume neural network training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Depend on new `joblib=1.0.0` and fix progress bar updates for multiprocessing (#421).
 - Fix for embedding nets with `SNRE` (thanks @adittmann, #425)
 - Is it now optional to pass a prior distribution when using SNPE (#426)
-- Support loading of posteriors saved after `sbi v0.13.0` under newer versions (#427, thanks @psteinb)
+- Support loading of posteriors saved after `sbi v0.15.0` (#427, thanks @psteinb)
 
 
 # v0.14.3

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -9,3 +9,5 @@
 [Can I use the GPU for training the density estimator?](faq/question_04.md)
 
 [How should I save and load objects in `sbi`?](faq/question_05.md)
+
+[Can I stop neural network training and resume it later?](faq/question_06.md)

--- a/docs/docs/faq/question_05.md
+++ b/docs/docs/faq/question_05.md
@@ -12,6 +12,16 @@ with open("/path/to/my_posterior.pkl", "wb") as handle:
     pickle.dump(posterior, handle)
 ```
 
+Note: if you try to load a posterior that was saved under `sbi v0.14.x` or earlier under `sbi v0.15.0` or later, you have to add:
+```python
+import sys
+from sbi.utils import user_input_checks_utils
+
+sys.modules["sbi.user_input.user_input_checks_utils"] = user_input_checks_utils
+```
+to your script before loading the posterior.
+
+
 `NeuralInference` objects are not picklable. There are two workarounds:
 
 - Pickle with [`dill`](https://pypi.org/project/dill/) (has to be installed with `pip install dill` first)

--- a/docs/docs/faq/question_06.md
+++ b/docs/docs/faq/question_06.md
@@ -1,0 +1,21 @@
+
+# Can I stop neural network training and resume it later?
+
+Many clusters have a time limit and `sbi` might exceed this limit. You can circumvent this problem by using the [flexible interface](https://www.mackelab.org/sbi/tutorial/02_flexible_interface/). After simulations are finished, `sbi` trains a neural network. If this process takes too long, you can stop training and resume it later. The syntax is:
+
+```python
+inference = SNPE(prior=prior)
+inference = inference.append_simulations(theta, x)
+inference.train(max_num_epochs=300)  # Pick `max_num_epochs` such that it does not exceed the runtime.
+
+with open("path/to/my/inference.pkl", "wb") as handle:
+    dill.dump(inference, handle)
+
+# To resume training:
+with open("path/to/my/inference.pkl", "rb") as handle:
+    inference_from_disk = dill.load(handle)
+inference_from_disk.train(resume_training=True, max_num_epochs=600)  # Run epochs 301 until 600 (or stop early).
+posterior = inference_from_disk.build_posterior()
+```
+
+Note that the inference object can not be saved with `pickle`. To save it, you will have to install and use [dill](https://pypi.org/project/dill/). Another solution is described [here](https://www.mackelab.org/sbi/faq/question_04/).

--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -6,7 +6,7 @@
     rendering:
       show_root_heading: true
 
-::: sbi.user_input.user_input_checks.prepare_for_sbi
+::: sbi.utils.user_input_checks.prepare_for_sbi
     rendering:
       show_root_heading: true
       

--- a/sbi/inference/snle/snle_a.py
+++ b/sbi/inference/snle/snle_a.py
@@ -64,6 +64,7 @@ class SNLE_A(LikelihoodEstimator):
         max_num_epochs: Optional[int] = None,
         clip_max_norm: Optional[float] = 5.0,
         exclude_invalid_x: bool = True,
+        resume_training: bool = False,
         discard_prior_samples: bool = False,
         retrain_from_scratch_each_round: bool = False,
         show_train_summary: bool = False,
@@ -84,6 +85,10 @@ class SNLE_A(LikelihoodEstimator):
                 prevent exploding gradients. Use None for no clipping.
             exclude_invalid_x: Whether to exclude simulation outputs `x=NaN` or `x=±∞`
                 during training. Expect errors, silent or explicit, when `False`.
+            resume_training: Can be used in case training time is limited, e.g. on a
+                cluster. If `True`, the split between train and validation set, the
+                optimizer, the number of epochs, and the best validation log-prob will
+                be restored from the last time `.train()` was called.
             discard_prior_samples: Whether to discard samples simulated in round 1, i.e.
                 from the prior. Training may be sped up by ignoring such less targeted
                 samples.

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -79,7 +79,10 @@ class LikelihoodEstimator(NeuralInference, ABC):
         self._summary.update({"mcmc_times": []})  # type: ignore
 
     def append_simulations(
-        self, theta: Tensor, x: Tensor, from_round: int = 0,
+        self,
+        theta: Tensor,
+        x: Tensor,
+        from_round: int = 0,
     ) -> "LikelihoodEstimator":
         r"""
         Store parameters and simulation outputs to use them for later training.
@@ -120,6 +123,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
         max_num_epochs: Optional[int] = None,
         clip_max_norm: Optional[float] = 5.0,
         exclude_invalid_x: bool = True,
+        resume_training: bool = False,
         discard_prior_samples: bool = False,
         retrain_from_scratch_each_round: bool = False,
         show_train_summary: bool = False,
@@ -130,6 +134,10 @@ class LikelihoodEstimator(NeuralInference, ABC):
         Args:
             exclude_invalid_x: Whether to exclude simulation outputs `x=NaN` or `x=±∞`
                 during training. Expect errors, silent or explicit, when `False`.
+            resume_training: Can be used in case training time is limited, e.g. on a
+                cluster. If `True`, the split between train and validation set, the
+                optimizer, the number of epochs, and the best validation log-prob will
+                be restored from the last time `.train()` was called.
             discard_prior_samples: Whether to discard samples simulated in round 1, i.e.
                 from the prior. Training may be sped up by ignoring such less targeted
                 samples.
@@ -156,13 +164,15 @@ class LikelihoodEstimator(NeuralInference, ABC):
         num_examples = len(theta)
 
         # Select random train and validation splits from (theta, x) pairs.
-        permuted_indices = torch.randperm(num_examples)
         num_training_examples = int((1 - validation_fraction) * num_examples)
         num_validation_examples = num_examples - num_training_examples
-        train_indices, val_indices = (
-            permuted_indices[:num_training_examples],
-            permuted_indices[num_training_examples:],
-        )
+
+        if not resume_training:
+            permuted_indices = torch.randperm(num_examples)
+            self.train_indices, self.val_indices = (
+                permuted_indices[:num_training_examples],
+                permuted_indices[num_training_examples:],
+            )
 
         # Dataset is shared for training and validation loaders.
         dataset = data.TensorDataset(theta, x)
@@ -172,14 +182,14 @@ class LikelihoodEstimator(NeuralInference, ABC):
             dataset,
             batch_size=min(training_batch_size, num_training_examples),
             drop_last=True,
-            sampler=SubsetRandomSampler(train_indices),
+            sampler=SubsetRandomSampler(self.train_indices),
         )
         val_loader = data.DataLoader(
             dataset,
             batch_size=min(training_batch_size, num_validation_examples),
             shuffle=False,
             drop_last=False,
-            sampler=SubsetRandomSampler(val_indices),
+            sampler=SubsetRandomSampler(self.val_indices),
         )
 
         # First round or if retraining from scratch:
@@ -189,7 +199,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
         # can `sample()` and `log_prob()`. The network is accessible via `.net`.
         if self._neural_net is None or retrain_from_scratch_each_round:
             self._neural_net = self._build_neural_net(
-                theta[train_indices], x[train_indices]
+                theta[self.train_indices], x[self.train_indices]
             )
             self._x_shape = x_shape_from_simulation(x)
             assert (
@@ -197,15 +207,21 @@ class LikelihoodEstimator(NeuralInference, ABC):
             ), "SNLE cannot handle multi-dimensional simulator output."
 
         self._neural_net.to(self._device)
-        optimizer = optim.Adam(list(self._neural_net.parameters()), lr=learning_rate,)
+        if not resume_training:
+            self.optimizer = optim.Adam(
+                list(self._neural_net.parameters()),
+                lr=learning_rate,
+            )
+            self.epoch, self._val_log_prob = 0, float("-Inf")
 
-        epoch, self._val_log_prob = 0, float("-Inf")
-        while epoch <= max_num_epochs and not self._converged(epoch, stop_after_epochs):
+        while self.epoch <= max_num_epochs and not self._converged(
+            self.epoch, stop_after_epochs
+        ):
 
             # Train for a single epoch.
             self._neural_net.train()
             for batch in train_loader:
-                optimizer.zero_grad()
+                self.optimizer.zero_grad()
                 theta_batch, x_batch = (
                     batch[0].to(self._device),
                     batch[1].to(self._device),
@@ -216,11 +232,12 @@ class LikelihoodEstimator(NeuralInference, ABC):
                 loss.backward()
                 if clip_max_norm is not None:
                     clip_grad_norm_(
-                        self._neural_net.parameters(), max_norm=clip_max_norm,
+                        self._neural_net.parameters(),
+                        max_norm=clip_max_norm,
                     )
-                optimizer.step()
+                self.optimizer.step()
 
-            epoch += 1
+            self.epoch += 1
 
             # Calculate validation performance.
             self._neural_net.eval()
@@ -238,17 +255,20 @@ class LikelihoodEstimator(NeuralInference, ABC):
             # Log validation log prob for every epoch.
             self._summary["validation_log_probs"].append(self._val_log_prob)
 
-            self._maybe_show_progress(self._show_progress_bars, epoch)
+            self._maybe_show_progress(self._show_progress_bars, self.epoch)
 
-        self._report_convergence_at_end(epoch, stop_after_epochs, max_num_epochs)
+        self._report_convergence_at_end(self.epoch, stop_after_epochs, max_num_epochs)
 
         # Update summary.
-        self._summary["epochs"].append(epoch)
+        self._summary["epochs"].append(self.epoch)
         self._summary["best_validation_log_probs"].append(self._best_val_log_prob)
 
         # Update TensorBoard and summary dict.
         self._summarize(
-            round_=self._round, x_o=None, theta_bank=theta, x_bank=x,
+            round_=self._round,
+            x_o=None,
+            theta_bank=theta,
+            x_bank=x,
         )
 
         # Update description for progress bar.

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -163,6 +163,7 @@ class PosteriorEstimator(NeuralInference, ABC):
         clip_max_norm: Optional[float] = 5.0,
         calibration_kernel: Optional[Callable] = None,
         exclude_invalid_x: bool = True,
+        resume_training: bool = False,
         discard_prior_samples: bool = False,
         retrain_from_scratch_each_round: bool = False,
         show_train_summary: bool = False,
@@ -185,6 +186,10 @@ class PosteriorEstimator(NeuralInference, ABC):
                 simulations `x`. See Lueckmann, Gonçalves et al., NeurIPS 2017.
             exclude_invalid_x: Whether to exclude simulation outputs `x=NaN` or `x=±∞`
                 during training. Expect errors, silent or explicit, when `False`.
+            resume_training: Can be used in case training time is limited, e.g. on a
+                cluster. If `True`, the split between train and validation set, the
+                optimizer, the number of epochs, and the best validation log-prob will
+                be restored from the last time `.train()` was called.
             discard_prior_samples: Whether to discard samples simulated in round 1, i.e.
                 from the prior. Training may be sped up by ignoring such less targeted
                 samples.
@@ -223,13 +228,15 @@ class PosteriorEstimator(NeuralInference, ABC):
 
         # Select random neural net and validation splits from (theta, x) pairs.
         num_total_examples = len(theta)
-        permuted_indices = torch.randperm(num_total_examples)
         num_training_examples = int((1 - validation_fraction) * num_total_examples)
         num_validation_examples = num_total_examples - num_training_examples
-        train_indices, val_indices = (
-            permuted_indices[:num_training_examples],
-            permuted_indices[num_training_examples:],
-        )
+
+        if not resume_training:
+            permuted_indices = torch.randperm(num_total_examples)
+            self.train_indices, self.val_indices = (
+                permuted_indices[:num_training_examples],
+                permuted_indices[num_training_examples:],
+            )
 
         # Dataset is shared for training and validation loaders.
         dataset = data.TensorDataset(
@@ -243,14 +250,14 @@ class PosteriorEstimator(NeuralInference, ABC):
             dataset,
             batch_size=min(training_batch_size, num_training_examples),
             drop_last=True,
-            sampler=SubsetRandomSampler(train_indices),
+            sampler=SubsetRandomSampler(self.train_indices),
         )
         val_loader = data.DataLoader(
             dataset,
             batch_size=min(training_batch_size, num_validation_examples),
             shuffle=False,
             drop_last=True,
-            sampler=SubsetRandomSampler(val_indices),
+            sampler=SubsetRandomSampler(self.val_indices),
         )
 
         # First round or if retraining from scratch:
@@ -260,25 +267,29 @@ class PosteriorEstimator(NeuralInference, ABC):
         # can `sample()` and `log_prob()`. The network is accessible via `.net`.
         if self._neural_net is None or retrain_from_scratch_each_round:
             self._neural_net = self._build_neural_net(
-                theta[train_indices], x[train_indices]
+                theta[self.train_indices], x[self.train_indices]
             )
             test_posterior_net_for_multi_d_x(self._neural_net, theta, x)
             self._x_shape = x_shape_from_simulation(x)
 
         # Move entire net to device for training.
         self._neural_net.to(self._device)
-        optimizer = optim.Adam(
-            list(self._neural_net.parameters()),
-            lr=learning_rate,
-        )
 
-        epoch, self._val_log_prob = 0, float("-Inf")
-        while epoch <= max_num_epochs and not self._converged(epoch, stop_after_epochs):
+        if not resume_training:
+            self.optimizer = optim.Adam(
+                list(self._neural_net.parameters()),
+                lr=learning_rate,
+            )
+            self.epoch, self._val_log_prob = 0, float("-Inf")
+
+        while self.epoch <= max_num_epochs and not self._converged(
+            self.epoch, stop_after_epochs
+        ):
 
             # Train for a single epoch.
             self._neural_net.train()
             for batch in train_loader:
-                optimizer.zero_grad()
+                self.optimizer.zero_grad()
                 # Get batches on current device.
                 theta_batch, x_batch, masks_batch = (
                     batch[0].to(self._device),
@@ -301,9 +312,9 @@ class PosteriorEstimator(NeuralInference, ABC):
                         self._neural_net.parameters(),
                         max_norm=clip_max_norm,
                     )
-                optimizer.step()
+                self.optimizer.step()
 
-            epoch += 1
+            self.epoch += 1
 
             # Calculate validation performance.
             self._neural_net.eval()
@@ -329,12 +340,12 @@ class PosteriorEstimator(NeuralInference, ABC):
             # Log validation log prob for every epoch.
             self._summary["validation_log_probs"].append(self._val_log_prob)
 
-            self._maybe_show_progress(self._show_progress_bars, epoch)
+            self._maybe_show_progress(self._show_progress_bars, self.epoch)
 
-        self._report_convergence_at_end(epoch, stop_after_epochs, max_num_epochs)
+        self._report_convergence_at_end(self.epoch, stop_after_epochs, max_num_epochs)
 
         # Update summary.
-        self._summary["epochs"].append(epoch)
+        self._summary["epochs"].append(self.epoch)
         self._summary["best_validation_log_probs"].append(self._best_val_log_prob)
 
         # Update tensorboard and summary dict.

--- a/sbi/inference/snpe/snpe_c.py
+++ b/sbi/inference/snpe/snpe_c.py
@@ -101,6 +101,7 @@ class SNPE_C(PosteriorEstimator):
         clip_max_norm: Optional[float] = 5.0,
         calibration_kernel: Optional[Callable] = None,
         exclude_invalid_x: bool = True,
+        resume_training: bool = False,
         discard_prior_samples: bool = False,
         use_combined_loss: bool = False,
         retrain_from_scratch_each_round: bool = False,
@@ -125,6 +126,10 @@ class SNPE_C(PosteriorEstimator):
                 simulations `x`. See Lueckmann, Gonçalves et al., NeurIPS 2017.
             exclude_invalid_x: Whether to exclude simulation outputs `x=NaN` or `x=±∞`
                 during training. Expect errors, silent or explicit, when `False`.
+            resume_training: Can be used in case training time is limited, e.g. on a
+                cluster. If `True`, the split between train and validation set, the
+                optimizer, the number of epochs, and the best validation log-prob will
+                be restored from the last time `.train()` was called.
             discard_prior_samples: Whether to discard samples simulated in round 1, i.e.
                 from the prior. Training may be sped up by ignoring such less targeted
                 samples.

--- a/sbi/inference/snre/snre_a.py
+++ b/sbi/inference/snre/snre_a.py
@@ -61,6 +61,7 @@ class SNRE_A(RatioEstimator):
         max_num_epochs: Optional[int] = None,
         clip_max_norm: Optional[float] = 5.0,
         exclude_invalid_x: bool = True,
+        resume_training: bool = False,
         discard_prior_samples: bool = False,
         retrain_from_scratch_each_round: bool = False,
         show_train_summary: bool = False,
@@ -81,6 +82,10 @@ class SNRE_A(RatioEstimator):
                 prevent exploding gradients. Use None for no clipping.
             exclude_invalid_x: Whether to exclude simulation outputs `x=NaN` or `x=±∞`
                 during training. Expect errors, silent or explicit, when `False`.
+            resume_training: Can be used in case training time is limited, e.g. on a
+                cluster. If `True`, the split between train and validation set, the
+                optimizer, the number of epochs, and the best validation log-prob will
+                be restored from the last time `.train()` was called.
             discard_prior_samples: Whether to discard samples simulated in round 1, i.e.
                 from the prior. Training may be sped up by ignoring such less targeted
                 samples.

--- a/sbi/inference/snre/snre_b.py
+++ b/sbi/inference/snre/snre_b.py
@@ -62,6 +62,7 @@ class SNRE_B(RatioEstimator):
         max_num_epochs: Optional[int] = None,
         clip_max_norm: Optional[float] = 5.0,
         exclude_invalid_x: bool = True,
+        resume_training: bool = False,
         discard_prior_samples: bool = False,
         retrain_from_scratch_each_round: bool = False,
         show_train_summary: bool = False,
@@ -83,6 +84,10 @@ class SNRE_B(RatioEstimator):
                 prevent exploding gradients. Use None for no clipping.
             exclude_invalid_x: Whether to exclude simulation outputs `x=NaN` or `x=±∞`
                 during training. Expect errors, silent or explicit, when `False`.
+            resume_training: Can be used in case training time is limited, e.g. on a
+                cluster. If `True`, the split between train and validation set, the
+                optimizer, the number of epochs, and the best validation log-prob will
+                be restored from the last time `.train()` was called.
             discard_prior_samples: Whether to discard samples simulated in round 1, i.e.
                 from the prior. Training may be sped up by ignoring such less targeted
                 samples.

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -82,7 +82,10 @@ class RatioEstimator(NeuralInference, ABC):
         self._summary.update({"mcmc_times": []})  # type: ignore
 
     def append_simulations(
-        self, theta: Tensor, x: Tensor, from_round: int = 0,
+        self,
+        theta: Tensor,
+        x: Tensor,
+        from_round: int = 0,
     ) -> "RatioEstimator":
         r"""
         Store parameters and simulation outputs to use them for later training.
@@ -123,6 +126,7 @@ class RatioEstimator(NeuralInference, ABC):
         max_num_epochs: Optional[int] = None,
         clip_max_norm: Optional[float] = 5.0,
         exclude_invalid_x: bool = True,
+        resume_training: bool = False,
         discard_prior_samples: bool = False,
         retrain_from_scratch_each_round: bool = False,
         show_train_summary: bool = False,
@@ -134,6 +138,10 @@ class RatioEstimator(NeuralInference, ABC):
             num_atoms: Number of atoms to use for classification.
             exclude_invalid_x: Whether to exclude simulation outputs `x=NaN` or `x=±∞`
                 during training. Expect errors, silent or explicit, when `False`.
+            resume_training: Can be used in case training time is limited, e.g. on a
+                cluster. If `True`, the split between train and validation set, the
+                optimizer, the number of epochs, and the best validation log-prob will
+                be restored from the last time `.train()` was called.
             discard_prior_samples: Whether to discard samples simulated in round 1, i.e.
                 from the prior. Training may be sped up by ignoring such less targeted
                 samples.
@@ -158,13 +166,15 @@ class RatioEstimator(NeuralInference, ABC):
         num_examples = len(theta)
 
         # Select random train and validation splits from (theta, x) pairs.
-        permuted_indices = torch.randperm(num_examples)
         num_training_examples = int((1 - validation_fraction) * num_examples)
         num_validation_examples = num_examples - num_training_examples
-        train_indices, val_indices = (
-            permuted_indices[:num_training_examples],
-            permuted_indices[num_training_examples:],
-        )
+
+        if not resume_training:
+            permuted_indices = torch.randperm(num_examples)
+            self.train_indices, self.val_indices = (
+                permuted_indices[:num_training_examples],
+                permuted_indices[num_training_examples:],
+            )
 
         clipped_batch_size = min(training_batch_size, num_validation_examples)
 
@@ -180,14 +190,14 @@ class RatioEstimator(NeuralInference, ABC):
             dataset,
             batch_size=clipped_batch_size,
             drop_last=True,
-            sampler=SubsetRandomSampler(train_indices),
+            sampler=SubsetRandomSampler(self.train_indices),
         )
         val_loader = data.DataLoader(
             dataset,
             batch_size=clipped_batch_size,
             shuffle=False,
             drop_last=False,
-            sampler=SubsetRandomSampler(val_indices),
+            sampler=SubsetRandomSampler(self.val_indices),
         )
 
         # First round or if retraining from scratch:
@@ -197,21 +207,27 @@ class RatioEstimator(NeuralInference, ABC):
         # can `sample()` and `log_prob()`. The network is accessible via `.net`.
         if self._neural_net is None or retrain_from_scratch_each_round:
             self._neural_net = self._build_neural_net(
-                theta[train_indices], x[train_indices]
+                theta[self.train_indices], x[self.train_indices]
             )
             self._x_shape = x_shape_from_simulation(x)
 
         self._neural_net.to(self._device)
-        optimizer = optim.Adam(list(self._neural_net.parameters()), lr=learning_rate,)
 
-        epoch, self._val_log_prob = 0, float("-Inf")
+        if not resume_training:
+            self.optimizer = optim.Adam(
+                list(self._neural_net.parameters()),
+                lr=learning_rate,
+            )
+            self.epoch, self._val_log_prob = 0, float("-Inf")
 
-        while epoch <= max_num_epochs and not self._converged(epoch, stop_after_epochs):
+        while self.epoch <= max_num_epochs and not self._converged(
+            self.epoch, stop_after_epochs
+        ):
 
             # Train for a single epoch.
             self._neural_net.train()
             for batch in train_loader:
-                optimizer.zero_grad()
+                self.optimizer.zero_grad()
                 theta_batch, x_batch = (
                     batch[0].to(self._device),
                     batch[1].to(self._device),
@@ -220,11 +236,12 @@ class RatioEstimator(NeuralInference, ABC):
                 loss.backward()
                 if clip_max_norm is not None:
                     clip_grad_norm_(
-                        self._neural_net.parameters(), max_norm=clip_max_norm,
+                        self._neural_net.parameters(),
+                        max_norm=clip_max_norm,
                     )
-                optimizer.step()
+                self.optimizer.step()
 
-            epoch += 1
+            self.epoch += 1
 
             # Calculate validation performance.
             self._neural_net.eval()
@@ -241,17 +258,20 @@ class RatioEstimator(NeuralInference, ABC):
                 # Log validation log prob for every epoch.
                 self._summary["validation_log_probs"].append(self._val_log_prob)
 
-            self._maybe_show_progress(self._show_progress_bars, epoch)
+            self._maybe_show_progress(self._show_progress_bars, self.epoch)
 
-        self._report_convergence_at_end(epoch, stop_after_epochs, max_num_epochs)
+        self._report_convergence_at_end(self.epoch, stop_after_epochs, max_num_epochs)
 
         # Update summary.
-        self._summary["epochs"].append(epoch)
+        self._summary["epochs"].append(self.epoch)
         self._summary["best_validation_log_probs"].append(self._best_val_log_prob)
 
         # Update TensorBoard and summary dict.
         self._summarize(
-            round_=self._round, x_o=None, theta_bank=theta, x_bank=x,
+            round_=self._round,
+            x_o=None,
+            theta_bank=theta,
+            x_bank=x,
         )
 
         # Update description for progress bar.

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -133,7 +133,8 @@ def test_c2st_snpe_on_linearGaussian_different_dims(set_seed):
     """Test whether SNPE B/C infer well a simple example with available ground truth.
 
     This example has different number of parameters theta than number of x. Also
-    this implicitly tests simulation_batch_size=1.
+    this implicitly tests simulation_batch_size=1. It also impleictly tests whether the
+    prior can be `None` and whether we can stop and resume training.
 
     Args:
         set_seed: fixture for manual seeding
@@ -170,13 +171,15 @@ def test_c2st_snpe_on_linearGaussian_different_dims(set_seed):
 
     simulator, prior = prepare_for_sbi(simulator, prior)
     inference = SNPE_C(
-        prior,
+        prior=None,  # Test whether prior can be `None`.
         density_estimator="maf",
         show_progress_bars=False,
     )
 
     theta, x = simulate_for_sbi(simulator, prior, 2000, simulation_batch_size=1)  # type: ignore
-    _ = inference.append_simulations(theta, x).train()
+    inference = inference.append_simulations(theta, x)
+    _ = inference.train(max_num_epochs=10)  # Test whether we can stop and resume.
+    _ = inference.train(resume_training=True)
     posterior = inference.build_posterior()
     samples = posterior.sample((num_samples,), x=x_o)
 


### PR DESCRIPTION
Fixes #309 

This PR introduces the argument `resume_training` to `.train()`. If `True`, the split between train and validation set, the optimizer,  the number of epochs, and the best validation log-prob will be restored from the last time `.train()` was called.

Syntax is:
```python
inference = SNPE(prior=prior)
inference = inference.append_simulations(theta, x)
inference.train(max_num_epochs=300)  # Pick `max_num_epochs` such that it does not exceed the runtime.

# Save `inference` and load it...

inference.train(resume_training=True, max_num_epochs=600)  # Run epochs 301 until 600.
posterior = inference.build_posterior()
```

Using the above syntax will be identical up to seeding to:
```python
inference = SNPE(prior=prior)
_ = inference.append_simulations(theta, x).train()
posterior = inference.build_posterior()
```