### PR TITLE
Add loop simulator

### DIFF
--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -44,6 +44,34 @@ def warn_if_zscoring_changes_data(x: Tensor, duplicate_tolerance: float = 0.1) -
         )
 
 
+def warn_if_zscoring_changes_data(x: Tensor, duplicate_tolerance: float = 0.1) -> None:
+    """Raise warning if z-scoring would create duplicate data points.
+    
+    Args:
+        x: data
+        duplicate_tolerance: tolerated proportion of duplicates after z-scoring.
+    """
+
+    # Count unique xs.
+    num_unique = torch.unique(x, dim=0).numel()
+
+    # z-score.
+    zx = (x - x.mean(0)) / x.std(0)
+
+    # Count again and warn on too many new duplicates.
+    num_unique_z = torch.unique(zx, dim=0).numel()
+
+    if (1 - duplicate_tolerance) * num_unique_z < num_unique:
+        warnings.warn(
+            """Z-scoring these data will result in many data points being mapped on the
+            same z-scored value. This can occur due to numerical inaccuracies when the
+            data covers a large range of values. Consider setting z_score_x=False if
+            you still want to run the inference and beware that large variance in the
+            data can be problematic for the underlying NN.""",
+            UserWarning,
+        )
+
+
 def x_shape_from_simulation(batch_x: Tensor) -> torch.Size:
     ndims = batch_x.ndim
     assert ndims >= 2, "Simulated data must be a batch with at least two dimensions."

--- a/sbi/utils/user_input_checks.py
+++ b/sbi/utils/user_input_checks.py
@@ -401,32 +401,29 @@ def ensure_batched_simulator(simulator: Callable, prior) -> Callable:
     is_batched_simulator = True
     try:
         batch_size = 2
-        simulator_batch_size, *_ = simulator(prior.sample((batch_size,))).shape
-
-        assert simulator_batch_size == batch_size
+        # The simulator must return a matching batch dimension and data.
+        output_shape = simulator(prior.sample((batch_size,))).shape
+        assert len(output_shape) > 1
+        assert output_shape[0] == batch_size
     except:
         is_batched_simulator = False
 
-    return simulator if is_batched_simulator else get_batch_dim_simulator(simulator)
+    return simulator if is_batched_simulator else get_batch_loop_simulator(simulator)
 
 
-def get_batch_dim_simulator(simulator: Callable) -> Callable:
+def get_batch_loop_simulator(simulator: Callable) -> Callable:
     """Return simulator wrapped with `map` to handle batches of parameters.
 
     Note: this batches the simulator only syntactically, there are no performance
     benefits as with true vectorization."""
 
-    def batch_dim_simulator(theta: Tensor) -> Tensor:
-        batch_shape, *_ = theta.shape
-        assert (
-            batch_shape == 1
-        ), f"This simulator can handle one single thetas, theta.shape={theta.shape}."
-        # Remove possible singleton dimensions in the user simulator.
-        simulation = simulator(theta.squeeze()).squeeze()
-        # Return with leading batch dimension.
-        return simulation.unsqueeze(0)
+    def batch_loop_simulator(theta: Tensor) -> Tensor:
+        """Return a batch of simulations by looping of a batch of parameters."""
+        assert theta.ndim > 1, "Theta must have a batch dimension."
+        xs = list(map(simulator, theta))
+        return torch.cat(xs, dim=0).reshape(theta.shape[0], -1)
 
-    return batch_dim_simulator
+    return batch_loop_simulator
 
 
 def process_x(x: Tensor, x_shape: torch.Size) -> Tensor:

--- a/tests/simulator_utils_test.py
+++ b/tests/simulator_utils_test.py
@@ -4,25 +4,24 @@
 from __future__ import annotations
 
 import pytest
-import torch
 from torch import ones, zeros
 
 from sbi.simulators.linear_gaussian import diagonal_linear_gaussian
 from sbi.simulators.simutils import simulate_in_batches
 from sbi.utils.torchutils import BoxUniform
+from sbi.user_input.user_input_checks import prepare_for_sbi
 
 
 @pytest.mark.parametrize(
     "num_sims", (0, 100, 1000),
 )
 @pytest.mark.parametrize("batch_size", (1, 100, 1000))
+@pytest.mark.parametrize("simulator", (diagonal_linear_gaussian, lambda _: ones(2)))
 def test_simulate_in_batches(
-    num_sims,
-    batch_size,
-    simulator=diagonal_linear_gaussian,
-    prior=BoxUniform(zeros(5), ones(5)),
+    num_sims, batch_size, simulator, prior=BoxUniform(zeros(5), ones(5)),
 ):
     """Test combinations of num_sims and simulation_batch_size. """
 
+    simulator, prior = prepare_for_sbi(simulator, prior)
     theta = prior.sample((num_sims,))
     simulate_in_batches(simulator, theta, batch_size)

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -237,7 +237,7 @@ def test_prepare_sbi_problem(simulator: Callable, prior):
     simulator, prior = prepare_for_sbi(simulator, prior)
 
     # check batch sims and type
-    n_batch = 1
+    n_batch = 5
     assert simulator(prior.sample((n_batch,))).shape[0] == n_batch
     assert isinstance(simulator(prior.sample((1,))), Tensor)
     assert prior.sample().dtype == torch.float32


### PR DESCRIPTION
Up to now, when a user passed a simulator that wasn't able to handle batches of theta, we wrapped it to still return a batch dimension. 

The wrapped simulator still was simulating just a single theta though. 

When using multiprocessing, spawning workers for every single theta can create a lot of overhead, especially when single simulations are cheap. 

With this PR, we are wrapping the un-batched user-simulator into a simulator that just loops over a batch of thetas. As a consequence one can now set `sim_batch_size>1` in `simulate_in_batches` and reduce overhead to a minimum. This can result in 10x speed up for some problems! 