### PR TITLE
add loop simulator to always enable sim batch size.

### DIFF
--- a/sbi/simulators/simutils.py
+++ b/sbi/simulators/simutils.py
@@ -29,7 +29,8 @@ def simulate_in_batches(
         simulator: Simulator callable (a function or a class with `__call__`).
         theta: All parameters $\theta$ sampled from prior or posterior.
         sim_batch_size: Number of simulations per batch. Default is to simulate
-            the entire theta in a single batch.
+            the entire theta in a single batch. When using multiple workers, increasing
+            this batch size can further speed up simulations by reducing overhead.
         num_workers: Number of workers for multiprocessing.
         show_progress_bars: Whether to show a progress bar during simulation.
 

--- a/tests/simulator_utils_test.py
+++ b/tests/simulator_utils_test.py
@@ -4,25 +4,24 @@
 from __future__ import annotations
 
 import pytest
-import torch
 from torch import ones, zeros
 
 from sbi.simulators.linear_gaussian import diagonal_linear_gaussian
 from sbi.simulators.simutils import simulate_in_batches
 from sbi.utils.torchutils import BoxUniform
+from sbi.utils.user_input_checks import prepare_for_sbi
 
 
 @pytest.mark.parametrize(
     "num_sims", (0, 100, 1000),
 )
 @pytest.mark.parametrize("batch_size", (1, 100, 1000))
+@pytest.mark.parametrize("simulator", (diagonal_linear_gaussian, lambda _: ones(2)))
 def test_simulate_in_batches(
-    num_sims,
-    batch_size,
-    simulator=diagonal_linear_gaussian,
-    prior=BoxUniform(zeros(5), ones(5)),
+    num_sims, batch_size, simulator, prior=BoxUniform(zeros(5), ones(5)),
 ):
     """Test combinations of num_sims and simulation_batch_size. """
 
+    simulator, prior = prepare_for_sbi(simulator, prior)
     theta = prior.sample((num_sims,))
     simulate_in_batches(simulator, theta, batch_size)

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -237,7 +237,7 @@ def test_prepare_sbi_problem(simulator: Callable, prior):
     simulator, prior = prepare_for_sbi(simulator, prior)
 
     # check batch sims and type
-    n_batch = 1
+    n_batch = 5
     assert simulator(prior.sample((n_batch,))).shape[0] == n_batch
     assert isinstance(simulator(prior.sample((1,))), Tensor)
     assert prior.sample().dtype == torch.float32


### PR DESCRIPTION
Up to now, when a user passed a simulator that wasn't able to handle batches of theta, we wrapped it to still return a batch dimension.

The wrapped simulator still was simulating just a single theta though.

When using multiprocessing, spawning workers for every single theta can create a lot of overhead, especially when single simulations are cheap.

With this PR, we are wrapping the un-batched user-simulator into a simulator that just loops over a batch of thetas. As a consequence one can now set sim_batch_size>1 in simulate_in_batches and reduce overhead to a minimum. This can result in 10x speed up for some problems!