### PR TITLE
Fix bug for warning on z-score

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix for embedding nets with `SNRE` (thanks @adittmann, #425)
 - Is it now optional to pass a prior distribution when using SNPE (#426)
 - Support loading of posteriors saved after `sbi v0.15.0` (#427, thanks @psteinb)
+- Neural network training can be resumed (#431)
 
 
 # v0.14.3

--- a/tests/inference_with_NaN_simulator_test.py
+++ b/tests/inference_with_NaN_simulator_test.py
@@ -36,6 +36,22 @@ def test_handle_invalid_x(x_shape, set_seed):
     assert torch.isfinite(x[x_is_valid]).all()
 
 
+def test_z_scoring_warning():
+
+    # Create data with large variance.
+    num_dim = 2
+    theta = torch.ones(100, num_dim)
+    x = torch.rand(100, num_dim)
+    x[:50] += 1e7
+
+    # Make sure a warning is raised because z-scoring will map these data to duplicate
+    # data points.
+    with pytest.warns(UserWarning, match="Z-scoring these simulation outputs"):
+        SNPE_C(utils.BoxUniform(zeros(num_dim), ones(num_dim))).append_simulations(
+            theta, x
+        ).train(max_num_epochs=1)
+
+
 @pytest.mark.slow
 @pytest.mark.parametrize(
     ("method", "exclude_invalid_x", "percent_nans"),
@@ -141,19 +157,3 @@ def test_inference_with_restriction_estimator(set_seed):
 
     # Compute the c2st and assert it is near chance level of 0.5.
     check_c2st(samples, target_samples, alg=f"{SNPE_C}")
-
-
-def test_z_scoring_warning():
-
-    # Create data with large variance.
-    num_dim = 2
-    theta = torch.ones(100, num_dim)
-    x = torch.rand(100, num_dim)
-    x[:50] += 1e7
-
-    # Make sure a warning is raised because z-scoring will map these data to duplicate
-    # data points.
-    with pytest.warns(UserWarning, match="Z-scoring these data will"):
-        SNPE_C(utils.BoxUniform(zeros(num_dim), ones(num_dim))).append_simulations(
-            theta, x
-        ).train(max_num_epochs=1)


### PR DESCRIPTION
Quick bugfix, it always warned because the `(1 - duplicate_tolerance)` was in the wrong place.