### PR TITLE
Allow to estimate 1D densities with NSF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Is it now optional to pass a prior distribution when using SNPE (#426)
 - Support loading of posteriors saved after `sbi v0.15.0` (#427, thanks @psteinb)
 - Neural network training can be resumed (#431)
+- Allow using NSF to estimate 1D distributions (#438)
 
 
 # v0.14.3

--- a/sbi/neural_nets/flow.py
+++ b/sbi/neural_nets/flow.py
@@ -149,6 +149,7 @@ def build_nsf(
     z_score_y: bool = True,
     hidden_features: int = 50,
     num_transforms: int = 5,
+    num_bins: int = 10,
     embedding_net: nn.Module = nn.Identity(),
     **kwargs,
 ) -> nn.Module:
@@ -161,6 +162,7 @@ def build_nsf(
         z_score_y: Whether to z-score ys passing into the network.
         hidden_features: Number of hidden features.
         num_transforms: Number of transforms.
+        num_bins: Number of bins used for the splines.
         embedding_net: Optional embedding network for y.
         kwargs: Additional arguments that are passed by the build function but are not
             relevant for maf and are therefore ignored.

--- a/sbi/utils/get_nn_models.py
+++ b/sbi/utils/get_nn_models.py
@@ -87,6 +87,7 @@ def likelihood_nn(
     z_score_x: bool = True,
     hidden_features: int = 50,
     num_transforms: int = 5,
+    num_bins: int = 10,
     embedding_net: nn.Module = nn.Identity(),
     num_components: int = 10,
 ) -> Callable:
@@ -107,6 +108,8 @@ def likelihood_nn(
         num_transforms: Number of transforms when a flow is used. Only relevant if
             density estimator is a normalizing flow (i.e. currently either a `maf` or a
             `nsf`). Ignored if density estimator is a `mdn` or `made`.
+        num_bins: Number of bins used for the splines in `nsf`. Ignored if density
+            estimator not `nsf`.
         embedding_net: Optional embedding network for parameters $\theta$.
         num_components: Number of mixture components for a mixture of Gaussians.
             Ignored if density estimator is not an mdn.
@@ -119,6 +122,7 @@ def likelihood_nn(
                 "z_score_y",
                 "hidden_features",
                 "num_transforms",
+                "num_bins",
                 "embedding_net",
                 "num_components",
             ),
@@ -127,6 +131,7 @@ def likelihood_nn(
                 z_score_theta,
                 hidden_features,
                 num_transforms,
+                num_bins,
                 embedding_net,
                 num_components,
             ),
@@ -154,6 +159,7 @@ def posterior_nn(
     z_score_x: bool = True,
     hidden_features: int = 50,
     num_transforms: int = 5,
+    num_bins: int = 10,
     embedding_net: nn.Module = nn.Identity(),
     num_components: int = 10,
 ) -> Callable:
@@ -174,6 +180,8 @@ def posterior_nn(
         num_transforms: Number of transforms when a flow is used. Only relevant if
             density estimator is a normalizing flow (i.e. currently either a `maf` or a
             `nsf`). Ignored if density estimator is a `mdn` or `made`.
+        num_bins: Number of bins used for the splines in `nsf`. Ignored if density
+            estimator not `nsf`.
         embedding_net: Optional embedding network for simulation outputs $x$. This
             embedding net allows to learn features from potentially high-dimensional
             simulation outputs.
@@ -188,6 +196,7 @@ def posterior_nn(
                 "z_score_y",
                 "hidden_features",
                 "num_transforms",
+                "num_bins",
                 "embedding_net",
                 "num_components",
             ),
@@ -196,6 +205,7 @@ def posterior_nn(
                 z_score_x,
                 hidden_features,
                 num_transforms,
+                num_bins,
                 embedding_net,
                 num_components,
             ),


### PR DESCRIPTION
In 1D, we have...
1) no conditioner
2) no "alternating masks" between layers
3) Due to no alternation, we also need only num_transforms=1. Warn if num_transforms > 1

In the second commit, we allow for `num_bins` to be settable in `posterior_nn` and `likelihood_nn`. I have found improved performance as I increased `num_bins` in several problems.