### PR TITLE
testing assumptions of type checks

### DIFF
--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -4,6 +4,7 @@
 
 from abc import ABC, abstractmethod
 from copy import deepcopy
+import time
 from typing import Any, Callable, Dict, Optional, Union
 from warnings import warn
 
@@ -286,6 +287,7 @@ class PosteriorEstimator(NeuralInference, ABC):
             self.epoch, stop_after_epochs
         ):
 
+            epoch_start = time.time()
             # Train for a single epoch.
             self._neural_net.train()
             for batch in train_loader:
@@ -315,6 +317,7 @@ class PosteriorEstimator(NeuralInference, ABC):
                 self.optimizer.step()
 
             self.epoch += 1
+            self._summary["training_time_per_epoch_sec"].append(time.time() - epoch_start)
 
             # Calculate validation performance.
             self._neural_net.eval()

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -4,7 +4,6 @@
 
 from abc import ABC, abstractmethod
 from copy import deepcopy
-import time
 from typing import Any, Callable, Dict, Optional, Union
 from warnings import warn
 
@@ -287,7 +286,6 @@ class PosteriorEstimator(NeuralInference, ABC):
             self.epoch, stop_after_epochs
         ):
 
-            epoch_start = time.time()
             # Train for a single epoch.
             self._neural_net.train()
             for batch in train_loader:
@@ -317,7 +315,6 @@ class PosteriorEstimator(NeuralInference, ABC):
                 self.optimizer.step()
 
             self.epoch += 1
-            self._summary["training_time_per_epoch_sec"].append(time.time() - epoch_start)
 
             # Calculate validation performance.
             self._neural_net.eval()

--- a/sbi/utils/user_input_checks.py
+++ b/sbi/utils/user_input_checks.py
@@ -530,7 +530,7 @@ def check_estimator_arg(estimator: Union[str, Callable]) -> None:
     )
 
 
-def validate_theta_and_x(theta: Any, x: Any) -> bool:
+def validate_theta_and_x(theta: Any, x: Any) -> None:
     r"""
     Checks if the passed $(\theta, x)$ are valid.
 
@@ -560,7 +560,6 @@ def validate_theta_and_x(theta: Any, x: Any) -> bool:
     assert theta.dtype == float32, "Type of parameters must be float32."
     assert x.dtype == float32, "Type of simulator outputs must be float32."
 
-    return True
 
 def test_posterior_net_for_multi_d_x(net: nn.Module, theta: Tensor, x: Tensor) -> None:
     """Test log prob method of the net.

--- a/sbi/utils/user_input_checks.py
+++ b/sbi/utils/user_input_checks.py
@@ -530,12 +530,12 @@ def check_estimator_arg(estimator: Union[str, Callable]) -> None:
     )
 
 
-def validate_theta_and_x(theta: Any, x: Any) -> None:
+def validate_theta_and_x(theta: Any, x: Any) -> bool:
     r"""
     Checks if the passed $(\theta, x)$ are valid.
 
     Specifically, we check:
-    1) If they are tensors.
+    1) If they are (torch) tensors.
     2) If they have the same batchsize.
     3) If they are of `dtype=float32`.
 
@@ -543,8 +543,8 @@ def validate_theta_and_x(theta: Any, x: Any) -> None:
         theta: Parameters.
         x: Simulation outputs.
     """
-    assert isinstance(theta, Tensor), "Parameters theta must be a `Tensor`."
-    assert isinstance(x, Tensor), "Simulator output must be a `Tensor`."
+    assert isinstance(theta, Tensor), "Parameters theta must be a `torch.Tensor`."
+    assert isinstance(x, Tensor), "Simulator output must be a `torch.Tensor`."
 
     assert theta.shape[0] == x.shape[0], (
         f"Number of parameter sets (={theta.shape[0]} must match the number of "
@@ -553,9 +553,10 @@ def validate_theta_and_x(theta: Any, x: Any) -> None:
 
     # I did not fuse these asserts with the `isinstance(x, Tensor)` asserts in order
     # to give more explicit errors.
-    assert theta.dtype == torch.float32, "Type of parameters must be float32."
-    assert x.dtype == torch.float32, "Type of simulator outputs must be float32."
+    assert theta.dtype == float32, "Type of parameters must be float32."
+    assert x.dtype == float32, "Type of simulator outputs must be float32."
 
+    return True
 
 def test_posterior_net_for_multi_d_x(net: nn.Module, theta: Tensor, x: Tensor) -> None:
     """Test log prob method of the net.

--- a/sbi/utils/user_input_checks.py
+++ b/sbi/utils/user_input_checks.py
@@ -539,6 +539,10 @@ def validate_theta_and_x(theta: Any, x: Any) -> bool:
     2) If they have the same batchsize.
     3) If they are of `dtype=float32`.
 
+    Raises:
+        AssertionError: If theta or x are not torch.Tensor-like,
+        do not yield the same batchsize and do not have dtype==float32.
+
     Args:
         theta: Parameters.
         x: Simulation outputs.

--- a/sbi/utils/user_input_checks.py
+++ b/sbi/utils/user_input_checks.py
@@ -553,10 +553,8 @@ def validate_theta_and_x(theta: Any, x: Any) -> None:
 
     # I did not fuse these asserts with the `isinstance(x, Tensor)` asserts in order
     # to give more explicit errors.
-    assert isinstance(theta, torch.FloatTensor), "Type of parameters must be float32."
-    assert isinstance(
-        x, torch.FloatTensor
-    ), "Type of simulator outputs must be float32."
+    assert theta.dtype == torch.float32, "Type of parameters must be float32."
+    assert x.dtype == torch.float32, "Type of simulator outputs must be float32."
 
 
 def test_posterior_net_for_multi_d_x(net: nn.Module, theta: Tensor, x: Tensor) -> None:

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -460,6 +460,9 @@ def test_validate_theta_and_x():
         validate_theta_and_x(theta, x.to(torch.float64))
 
     # test on gpu if available
+    if not torch.cuda.is_available():
+        pytest.skip("no GPU found, so rest of this test does not apply")
+
     theta = torch.ones((32,8), dtype=torch.float32).to(gpu_if_present)
     x = torch.zeros((32,100), dtype=torch.float32).to(gpu_if_present)
 

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -472,9 +472,9 @@ def test_validate_theta_and_x_gpu():
     # A gpu based torch.tensor is NOT an instance of torch.FloatTensor,
     # but rather of torch.cuda.FloatTensor, still
     # tensor.dtype returns torch.float32.
-    assert isinstance(theta, torch.Tensor)
-    assert theta.dtype == torch.float32
-    assert not isinstance(theta, torch.FloatTensor)
+    assert isinstance(theta, torch.Tensor), "gpu based torch.tensor is not an instance of torch.Tensor"
+    assert theta.dtype == torch.float32, f"gpu based torch.tensor(dtype=torch.float32) yields unexpected dtype {theta.dtype}."
+    assert not isinstance(theta, torch.FloatTensor), "gpu based torch.tensor(dtype=torch.float32) is FloatTensor, even though it shouldn't be."
 
     validate_theta_and_x(theta, x)
 

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -469,9 +469,6 @@ def test_validate_theta_and_x_gpu():
     theta = torch.ones((32,8), dtype=torch.float32).to(gpu_if_present)
     x = torch.zeros((32,100), dtype=torch.float32).to(gpu_if_present)
 
-    # A gpu based torch.tensor is NOT an instance of torch.FloatTensor,
-    # but rather of torch.cuda.FloatTensor, still
-    # tensor.dtype returns torch.float32.
     assert isinstance(theta, torch.Tensor), "gpu based torch.tensor is not an instance of torch.Tensor"
     assert theta.dtype == torch.float32, f"gpu based torch.tensor(dtype=torch.float32) yields unexpected dtype {theta.dtype}."
     assert not isinstance(theta, torch.FloatTensor), "gpu based torch.tensor(dtype=torch.float32) is FloatTensor, even though it shouldn't be."

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -450,7 +450,7 @@ def test_validate_theta_and_x_cpu():
     # A cpu based torch.tensor is an instance of torch.FloatTensor,
     # both of torch.FloatTensor and torch.tensor expose dtype==float32.
     assert isinstance(theta, torch.Tensor), "theta must be torch.Tensor."
-    assert theta.dtype == torch.float32
+    assert theta.dtype == torch.float32, "theta must be of type torch.float32"
     assert isinstance(theta, torch.FloatTensor)
     assert otheta.dtype == torch.float32
 

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -454,7 +454,7 @@ def test_validate_theta_and_x():
     # test on cpu
     validate_theta_and_x(theta, x)
 
-    with pytest.raises as exc:
+    with pytest.raises(AssertionError) as exc:
         validate_theta_and_x(theta, x.to(torch.float64))
 
     # test on gpu if available
@@ -463,5 +463,5 @@ def test_validate_theta_and_x():
 
     validate_theta_and_x(theta, x)
 
-    with pytest.raises as exc:
+    with pytest.raises(AssertionError) as exc:
         validate_theta_and_x(theta, x.to(torch.float64))

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -449,7 +449,7 @@ def test_validate_theta_and_x_cpu():
     # Check assumptions in implementation:
     # A cpu based torch.tensor is an instance of torch.FloatTensor,
     # both of torch.FloatTensor and torch.tensor expose dtype==float32.
-    assert isinstance(theta, torch.Tensor)
+    assert isinstance(theta, torch.Tensor), "theta must be torch.Tensor."
     assert theta.dtype == torch.float32
     assert isinstance(theta, torch.FloatTensor)
     assert otheta.dtype == torch.float32

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -435,3 +435,32 @@ def test_passing_custom_density_estimator(arg):
         density_estimator = arg
     prior = MultivariateNormal(torch.zeros(2), torch.eye(2))
     _ = SNPE_C(prior=prior, density_estimator=density_estimator)
+
+
+def test_validate_theta_and_x():
+
+    gpu_device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
+    cpu_device = torch.device('cpu')
+
+    theta = torch.ones((32,8), dtype=torch.float32).to(cpu_device)
+    x = torch.zeros((32,100), dtype=torch.float32).to(cpu_device)
+
+    #check assumptions in implementation
+    assert isinstance(theta, torch.Tensor)
+    assert theta.dtype == torch.float32
+    assert isinstance(theta, torch.FloatTensor)
+
+    # test on cpu
+    validate_theta_and_x(theta, x)
+
+    with pytest.raises as exc:
+        validate_theta_and_x(theta, x.to(torch.float64))
+
+    # test on gpu if available
+    theta = torch.ones((32,8), dtype=torch.float32).to(gpu_device)
+    x = torch.zeros((32,100), dtype=torch.float32).to(gpu_device)
+
+    validate_theta_and_x(theta, x)
+
+    with pytest.raises as exc:
+        validate_theta_and_x(theta, x.to(torch.float64))

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -440,16 +440,18 @@ def test_passing_custom_density_estimator(arg):
 
 def test_validate_theta_and_x():
 
-    gpu_device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
+    gpu_if_present = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
     cpu_device = torch.device('cpu')
 
     theta = torch.ones((32,8), dtype=torch.float32).to(cpu_device)
     x = torch.zeros((32,100), dtype=torch.float32).to(cpu_device)
+    otheta = torch.FloatTensor((32,8)) #using an explicit type
 
     #check assumptions in implementation
     assert isinstance(theta, torch.Tensor)
     assert theta.dtype == torch.float32
     assert isinstance(theta, torch.FloatTensor)
+    assert otheta.dtype == torch.float32
 
     # test on cpu
     validate_theta_and_x(theta, x)
@@ -458,8 +460,8 @@ def test_validate_theta_and_x():
         validate_theta_and_x(theta, x.to(torch.float64))
 
     # test on gpu if available
-    theta = torch.ones((32,8), dtype=torch.float32).to(gpu_device)
-    x = torch.zeros((32,100), dtype=torch.float32).to(gpu_device)
+    theta = torch.ones((32,8), dtype=torch.float32).to(gpu_if_present)
+    x = torch.zeros((32,100), dtype=torch.float32).to(gpu_if_present)
 
     validate_theta_and_x(theta, x)
 

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -444,15 +444,12 @@ def test_validate_theta_and_x_cpu():
 
     theta = torch.ones((32,8), dtype=torch.float32).to(cpu_device)
     x = torch.zeros((32,100), dtype=torch.float32).to(cpu_device)
-    otheta = torch.FloatTensor((32,8)) #using an explicit type
+    plain_ft = torch.FloatTensor((32,8)) #using an explicit type
 
-    # Check assumptions in implementation:
-    # A cpu based torch.tensor is an instance of torch.FloatTensor,
-    # both of torch.FloatTensor and torch.tensor expose dtype==float32.
-    assert isinstance(theta, torch.Tensor), "theta must be torch.Tensor."
-    assert theta.dtype == torch.float32, "theta must be of type torch.float32"
-    assert isinstance(theta, torch.FloatTensor)
-    assert otheta.dtype == torch.float32
+    assert isinstance(theta, torch.Tensor), "cpu based torch.tensor is not an instance of torch.Tensor"
+    assert theta.dtype == torch.float32, f"cpu based torch.tensor(dtype=torch.float32) yields unexpected dtype {theta.dtype}."
+    assert isinstance(theta, torch.FloatTensor), "cpu based torch.tensor(dtype=torch.float32) is no FloatTensor."
+    assert plain_ft.dtype == torch.float32, "FloatTensor does not expose float32 dtype."
 
     # test on cpu
     validate_theta_and_x(theta, x)

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -466,7 +466,7 @@ def test_validate_theta_and_x():
     # beware not to test for FloatTensor on the GPU
     assert isinstance(theta, torch.Tensor)
     assert theta.dtype == torch.float32
-    assert isinstance(theta, torch.FloatTensor)
+    assert not isinstance(theta, torch.FloatTensor)
     assert otheta.dtype == torch.float32
 
     validate_theta_and_x(theta, x)

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -32,6 +32,7 @@ from sbi.utils.user_input_checks import (
     process_prior,
     process_simulator,
     process_x,
+    validate_theta_and_x
 )
 from sbi.utils.user_input_checks_utils import (
     CustomPytorchWrapper,

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -446,7 +446,9 @@ def test_validate_theta_and_x_cpu():
     x = torch.zeros((32,100), dtype=torch.float32).to(cpu_device)
     otheta = torch.FloatTensor((32,8)) #using an explicit type
 
-    #check assumptions in implementation
+    # Check assumptions in implementation:
+    # A cpu based torch.tensor is an instance of torch.FloatTensor,
+    # both of torch.FloatTensor and torch.tensor expose dtype==float32.
     assert isinstance(theta, torch.Tensor)
     assert theta.dtype == torch.float32
     assert isinstance(theta, torch.FloatTensor)
@@ -467,7 +469,9 @@ def test_validate_theta_and_x_gpu():
     theta = torch.ones((32,8), dtype=torch.float32).to(gpu_if_present)
     x = torch.zeros((32,100), dtype=torch.float32).to(gpu_if_present)
 
-    # beware not to test for FloatTensor on the GPU
+    # A gpu based torch.tensor is NOT an instance of torch.FloatTensor,
+    # but rather of torch.cuda.FloatTensor, still
+    # tensor.dtype returns torch.float32.
     assert isinstance(theta, torch.Tensor)
     assert theta.dtype == torch.float32
     assert not isinstance(theta, torch.FloatTensor)

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -463,6 +463,12 @@ def test_validate_theta_and_x():
     theta = torch.ones((32,8), dtype=torch.float32).to(gpu_if_present)
     x = torch.zeros((32,100), dtype=torch.float32).to(gpu_if_present)
 
+    # beware not to test for FloatTensor on the GPU
+    assert isinstance(theta, torch.Tensor)
+    assert theta.dtype == torch.float32
+    assert isinstance(theta, torch.FloatTensor)
+    assert otheta.dtype == torch.float32
+
     validate_theta_and_x(theta, x)
 
     with pytest.raises(AssertionError) as exc:

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -438,9 +438,8 @@ def test_passing_custom_density_estimator(arg):
     _ = SNPE_C(prior=prior, density_estimator=density_estimator)
 
 
-def test_validate_theta_and_x():
+def test_validate_theta_and_x_cpu():
 
-    gpu_if_present = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
     cpu_device = torch.device('cpu')
 
     theta = torch.ones((32,8), dtype=torch.float32).to(cpu_device)
@@ -459,9 +458,11 @@ def test_validate_theta_and_x():
     with pytest.raises(AssertionError) as exc:
         validate_theta_and_x(theta, x.to(torch.float64))
 
-    # test on gpu if available
-    if not torch.cuda.is_available():
-        pytest.skip("no GPU found, so rest of this test does not apply")
+
+@pytest.mark.gpu
+def test_validate_theta_and_x_gpu():
+
+    gpu_if_present = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
 
     theta = torch.ones((32,8), dtype=torch.float32).to(gpu_if_present)
     x = torch.zeros((32,100), dtype=torch.float32).to(gpu_if_present)
@@ -470,7 +471,6 @@ def test_validate_theta_and_x():
     assert isinstance(theta, torch.Tensor)
     assert theta.dtype == torch.float32
     assert not isinstance(theta, torch.FloatTensor)
-    assert otheta.dtype == torch.float32
 
     validate_theta_and_x(theta, x)
 


### PR DESCRIPTION
This unittest documents a "bug" in `utils/user_input_checks.py` that happens only when using the GPU but not on the CPU for me.

I can submit a fix, if needed.

Some details about my environment:
```
$ uname -a
Linux ga001.cluster 3.10.0-1160.6.1.el7.x86_64
$ python -V
Python 3.8.0
$ python -c 'import torch;print(torch.__version__)'
1.7.1
$ python -c 'import sbi;print(sbi.__version__)'
0.14.2
$ nvcc --version
#...
Cuda compilation tools, release 11.1, V11.1.105
Build cuda_11.1.TC455_06.29190527_0
```