### PR TITLE
 2nd try: Adding the ability to pass dataloader related kwargs in SNPE, SNRE and SNLE

### DIFF
--- a/sbi/inference/snle/snle_a.py
+++ b/sbi/inference/snle/snle_a.py
@@ -68,6 +68,7 @@ class SNLE_A(LikelihoodEstimator):
         discard_prior_samples: bool = False,
         retrain_from_scratch_each_round: bool = False,
         show_train_summary: bool = False,
+        dataloader_kwargs: Optional[Dict] = None,
     ) -> NeuralPosterior:
         r"""
         Return density estimator that approximates the distribution $p(x|\theta)$.
@@ -96,6 +97,8 @@ class SNLE_A(LikelihoodEstimator):
                 estimator for the posterior from scratch each round.
             show_train_summary: Whether to print the number of epochs and validation
                 loss and leakage after the training.
+            dataloader_kwargs: Any additional kwargs to be passed to the training and
+                validation dataloaders (like, e.g., a collate_fn)
 
         Returns:
             Density estimator that approximates the distribution $p(x|\theta)$.

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Dict, Optional, Union
 from warnings import warn
 
 import torch
+
 from torch import Tensor, ones, optim
 from torch.nn.utils import clip_grad_norm_
 from torch.utils import data
@@ -167,6 +168,7 @@ class PosteriorEstimator(NeuralInference, ABC):
         discard_prior_samples: bool = False,
         retrain_from_scratch_each_round: bool = False,
         show_train_summary: bool = False,
+        dataloader_kwargs: Optional[Dict] = None,
     ) -> DirectPosterior:
         r"""
         Return density estimator that approximates the distribution $p(\theta|x)$.
@@ -197,6 +199,8 @@ class PosteriorEstimator(NeuralInference, ABC):
                 estimator for the posterior from scratch each round.
             show_train_summary: Whether to print the number of epochs and validation
                 loss after the training.
+           dataloader_kwargs: Any additional kwargs to be passed to the training and
+                validation dataloaders (like, e.g., a collate_fn)
 
         Returns:
             Density estimator that approximates the distribution $p(\theta|x)$.
@@ -246,19 +250,32 @@ class PosteriorEstimator(NeuralInference, ABC):
         )
 
         # Create neural net and validation loaders using a subset sampler.
-        train_loader = data.DataLoader(
-            dataset,
-            batch_size=min(training_batch_size, num_training_examples),
-            drop_last=True,
-            sampler=SubsetRandomSampler(self.train_indices),
+        # Intentionally use dicts to define the default dataloader args
+        # Then, use dataloader_kwargs to override (or add to) any of these defaults
+        # https://stackoverflow.com/questions/44784577/in-method-call-args-how-to-override-keyword-argument-of-unpacked-dict
+        train_loader_kwargs = {
+            "batch_size": min(training_batch_size, num_training_examples),
+            "drop_last": True,
+            "sampler": SubsetRandomSampler(self.train_indices),
+        }
+        train_loader_kwargs = (
+            dict(train_loader_kwargs, **dataloader_kwargs)
+            if dataloader_kwargs is not None
+            else train_loader_kwargs
         )
-        val_loader = data.DataLoader(
-            dataset,
-            batch_size=min(training_batch_size, num_validation_examples),
-            shuffle=False,
-            drop_last=True,
-            sampler=SubsetRandomSampler(self.val_indices),
+        val_loader_kwargs = {
+            "batch_size": min(training_batch_size, num_validation_examples),
+            "shuffle": False,
+            "drop_last": True,
+            "sampler": SubsetRandomSampler(self.val_indices),
+        }
+        val_loader_kwargs = (
+            dict(val_loader_kwargs, **dataloader_kwargs)
+            if dataloader_kwargs is not None
+            else val_loader_kwargs
         )
+        train_loader = data.DataLoader(dataset, **train_loader_kwargs)
+        val_loader = data.DataLoader(dataset, **val_loader_kwargs)
 
         # First round or if retraining from scratch:
         # Call the `self._build_neural_net` with the rounds' thetas and xs as

--- a/sbi/inference/snpe/snpe_c.py
+++ b/sbi/inference/snpe/snpe_c.py
@@ -6,6 +6,7 @@ from math import pi
 from typing import Any, Callable, Dict, Optional, Union
 
 import torch
+
 from pyknos.mdn.mdn import MultivariateGaussianMDN as mdn
 from pyknos.nflows.transforms import CompositeTransform
 from torch import Tensor, eye, ones
@@ -106,6 +107,7 @@ class SNPE_C(PosteriorEstimator):
         use_combined_loss: bool = False,
         retrain_from_scratch_each_round: bool = False,
         show_train_summary: bool = False,
+        dataloader_kwargs: Optional[Dict] = None,
     ) -> DirectPosterior:
         r"""
         Return density estimator that approximates the distribution $p(\theta|x)$.
@@ -141,6 +143,8 @@ class SNPE_C(PosteriorEstimator):
                 estimator for the posterior from scratch each round.
             show_train_summary: Whether to print the number of epochs and validation
                 loss and leakage after the training.
+            dataloader_kwargs: Any additional kwargs to be passed to the training and
+                validation dataloaders (like, e.g., a collate_fn)
 
         Returns:
             Density estimator that approximates the distribution $p(\theta|x)$.

--- a/sbi/inference/snre/snre_a.py
+++ b/sbi/inference/snre/snre_a.py
@@ -1,6 +1,7 @@
 from typing import Any, Callable, Dict, Optional, Union
 
 import torch
+
 from torch import Tensor, nn, ones
 
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
@@ -65,6 +66,7 @@ class SNRE_A(RatioEstimator):
         discard_prior_samples: bool = False,
         retrain_from_scratch_each_round: bool = False,
         show_train_summary: bool = False,
+        dataloader_kwargs: Optional[Dict] = None,
     ) -> NeuralPosterior:
         r"""
         Return classifier that approximates the ratio $p(\theta,x)/p(\theta)p(x)$.
@@ -93,6 +95,8 @@ class SNRE_A(RatioEstimator):
                 estimator for the posterior from scratch each round.
             show_train_summary: Whether to print the number of epochs and validation
                 loss and leakage after the training.
+            dataloader_kwargs: Any additional kwargs to be passed to the training and
+                validation dataloaders (like, e.g., a collate_fn)
 
         Returns:
             Classifier that approximates the ratio $p(\theta,x)/p(\theta)p(x)$.

--- a/sbi/inference/snre/snre_b.py
+++ b/sbi/inference/snre/snre_b.py
@@ -1,6 +1,7 @@
 from typing import Any, Callable, Dict, Optional, Union
 
 import torch
+
 from torch import Tensor
 
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
@@ -66,6 +67,7 @@ class SNRE_B(RatioEstimator):
         discard_prior_samples: bool = False,
         retrain_from_scratch_each_round: bool = False,
         show_train_summary: bool = False,
+        dataloader_kwargs: Optional[Dict] = None,
     ) -> NeuralPosterior:
         r"""
         Return classifier that approximates the ratio $p(\theta,x)/p(\theta)p(x)$.
@@ -95,6 +97,8 @@ class SNRE_B(RatioEstimator):
                 estimator for the posterior from scratch each round.
             show_train_summary: Whether to print the number of epochs and validation
                 loss and leakage after the training.
+            dataloader_kwargs: Any additional kwargs to be passed to the training and
+                validation dataloaders (like, e.g., a collate_fn)
 
         Returns:
             Classifier that approximates the ratio $p(\theta,x)/p(\theta)p(x)$.

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from typing import Any, Callable, Dict, Optional, Union
 
 import torch
+
 from torch import Tensor, eye, ones, optim
 from torch.nn.utils import clip_grad_norm_
 from torch.utils import data
@@ -130,6 +131,7 @@ class RatioEstimator(NeuralInference, ABC):
         discard_prior_samples: bool = False,
         retrain_from_scratch_each_round: bool = False,
         show_train_summary: bool = False,
+        dataloader_kwargs: Optional[Dict] = None,
     ) -> RatioBasedPosterior:
         r"""
         Return classifier that approximates the ratio $p(\theta,x)/p(\theta)p(x)$.
@@ -147,6 +149,8 @@ class RatioEstimator(NeuralInference, ABC):
                 samples.
             retrain_from_scratch_each_round: Whether to retrain the conditional density
                 estimator for the posterior from scratch each round.
+            dataloader_kwargs: Any additional kwargs to be passed to the training and
+                validation dataloaders (like, eg., a collate_fn)
 
         Returns:
             Classifier that approximates the ratio $p(\theta,x)/p(\theta)p(x)$.
@@ -186,19 +190,32 @@ class RatioEstimator(NeuralInference, ABC):
         dataset = data.TensorDataset(theta, x)
 
         # Create neural net and validation loaders using a subset sampler.
-        train_loader = data.DataLoader(
-            dataset,
-            batch_size=clipped_batch_size,
-            drop_last=True,
-            sampler=SubsetRandomSampler(self.train_indices),
+        # Intentionally use dicts to define the default dataloader args
+        # Then, use dataloader_kwargs to override (or add to) any of these defaults
+        # https://stackoverflow.com/questions/44784577/in-method-call-args-how-to-override-keyword-argument-of-unpacked-dict
+        train_loader_kwargs = {
+            "batch_size": min(training_batch_size, num_training_examples),
+            "drop_last": True,
+            "sampler": SubsetRandomSampler(self.train_indices),
+        }
+        train_loader_kwargs = (
+            dict(train_loader_kwargs, **dataloader_kwargs)
+            if dataloader_kwargs is not None
+            else train_loader_kwargs
         )
-        val_loader = data.DataLoader(
-            dataset,
-            batch_size=clipped_batch_size,
-            shuffle=False,
-            drop_last=False,
-            sampler=SubsetRandomSampler(self.val_indices),
+        val_loader_kwargs = {
+            "batch_size": min(training_batch_size, num_validation_examples),
+            "shuffle": False,
+            "drop_last": True,
+            "sampler": SubsetRandomSampler(self.val_indices),
+        }
+        val_loader_kwargs = (
+            dict(val_loader_kwargs, **dataloader_kwargs)
+            if dataloader_kwargs is not None
+            else val_loader_kwargs
         )
+        train_loader = data.DataLoader(dataset, **train_loader_kwargs)
+        val_loader = data.DataLoader(dataset, **val_loader_kwargs)
 
         # First round or if retraining from scratch:
         # Call the `self._build_neural_net` with the rounds' thetas and xs as


### PR DESCRIPTION
Added dataloader_kwargs parameter to snle_a, snre_a, snre_b and snpe_c. These dataloader_kwargs are used to create the train and val dataloaders in snpe_base, snre_base and snle_base

@janfb I closed the previous MR, merged the current sbi main into my fork, and put the dataloader_kwargs related changes. I have avoided any formatting changes (that caused problems last time) - let me know if this looks ok :) 

Closing #415 