### PR TITLE
move dataloading to base class.

### DIFF
--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -284,6 +284,20 @@ class NeuralInference(ABC):
         resume_training: bool = False,
         dataloader_kwargs: Optional[dict] = None,
     ) -> Tuple[data.DataLoader, data.DataLoader]:
+        """Return dataloaders for training and validation.
+
+        Args:
+            dataset: holding all theta and x, optionally masks.
+            training_batch_size: training arg of inference methods.
+            resume_training: Whether the current call is resuming training so that no
+                new training and validation indices into the dataset have to be created.
+            dataloader_kwargs: Additional or updated kwargs to be passed to the training
+                and validation dataloaders (like, e.g., a collate_fn)
+
+        Returns:
+            Tuple of dataloaders for training and validation.
+
+        """
 
         # Get total number of training examples.
         num_examples = len(dataset)
@@ -299,7 +313,7 @@ class NeuralInference(ABC):
                 permuted_indices[num_training_examples:],
             )
 
-        # Create neural net and validation loaders using a subset sampler.
+        # Create training and validation loaders using a subset sampler.
         # Intentionally use dicts to define the default dataloader args
         # Then, use dataloader_kwargs to override (or add to) any of these defaults
         # https://stackoverflow.com/questions/44784577/in-method-call-args-how-to-override-keyword-argument-of-unpacked-dict

--- a/sbi/inference/snle/snle_a.py
+++ b/sbi/inference/snle/snle_a.py
@@ -97,8 +97,8 @@ class SNLE_A(LikelihoodEstimator):
                 estimator for the posterior from scratch each round.
             show_train_summary: Whether to print the number of epochs and validation
                 loss and leakage after the training.
-            dataloader_kwargs: Any additional kwargs to be passed to the training and
-                validation dataloaders (like, e.g., a collate_fn)
+            dataloader_kwargs: Additional or updated kwargs to be passed to the training
+                and validation dataloaders (like, e.g., a collate_fn)
 
         Returns:
             Density estimator that approximates the distribution $p(x|\theta)$.

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -144,8 +144,8 @@ class LikelihoodEstimator(NeuralInference, ABC):
                 estimator for the posterior from scratch each round.
             show_train_summary: Whether to print the number of epochs and validation
                 loss after the training.
-            dataloader_kwargs: Any additional kwargs to be passed to the training and
-                validation dataloaders (like, e.g., a collate_fn)
+            dataloader_kwargs: Additional or updated kwargs to be passed to the training
+                and validation dataloaders (like, e.g., a collate_fn)
 
         Returns:
             Density estimator that has learned the distribution $p(x|\theta)$.
@@ -229,7 +229,10 @@ class LikelihoodEstimator(NeuralInference, ABC):
                     # Evaluate on x with theta as context.
                     log_prob = self._neural_net.log_prob(x_batch, context=theta_batch)
                     log_prob_sum += log_prob.sum().item()
-            self._val_log_prob = log_prob_sum / len(val_loader)
+            # Take mean over all validation samples.
+            self._val_log_prob = log_prob_sum / (
+                len(val_loader) * val_loader.batch_size
+            )
             # Log validation log prob for every epoch.
             self._summary["validation_log_probs"].append(self._val_log_prob)
 

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -196,8 +196,8 @@ class PosteriorEstimator(NeuralInference, ABC):
                 estimator for the posterior from scratch each round.
             show_train_summary: Whether to print the number of epochs and validation
                 loss after the training.
-           dataloader_kwargs: Any additional kwargs to be passed to the training and
-                validation dataloaders (like, e.g., a collate_fn)
+            dataloader_kwargs: Additional or updated kwargs to be passed to the training
+                and validation dataloaders (like, e.g., a collate_fn)
 
         Returns:
             Density estimator that approximates the distribution $p(\theta|x)$.
@@ -303,7 +303,10 @@ class PosteriorEstimator(NeuralInference, ABC):
                     )
                     log_prob_sum += batch_log_prob.sum().item()
 
-            self._val_log_prob = log_prob_sum / len(val_loader)
+            # Take mean over all validation samples.
+            self._val_log_prob = log_prob_sum / (
+                len(val_loader) * val_loader.batch_size
+            )
             # Log validation log prob for every epoch.
             self._summary["validation_log_probs"].append(self._val_log_prob)
 

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -85,10 +85,7 @@ class PosteriorEstimator(NeuralInference, ABC):
         self._summary.update({"rejection_sampling_acceptance_rates": []})  # type:ignore
 
     def append_simulations(
-        self,
-        theta: Tensor,
-        x: Tensor,
-        proposal: Optional[Any] = None,
+        self, theta: Tensor, x: Tensor, proposal: Optional[Any] = None,
     ) -> "PosteriorEstimator":
         r"""
         Store parameters and simulation outputs to use them for later training.
@@ -168,7 +165,7 @@ class PosteriorEstimator(NeuralInference, ABC):
         discard_prior_samples: bool = False,
         retrain_from_scratch_each_round: bool = False,
         show_train_summary: bool = False,
-        dataloader_kwargs: Optional[Dict] = None,
+        dataloader_kwargs: Optional[dict] = None,
     ) -> DirectPosterior:
         r"""
         Return density estimator that approximates the distribution $p(\theta|x)$.
@@ -212,9 +209,6 @@ class PosteriorEstimator(NeuralInference, ABC):
 
         max_num_epochs = 2 ** 31 - 1 if max_num_epochs is None else max_num_epochs
 
-        # Load data from most recent round.
-        theta, x, _ = self.get_simulations(self._round, exclude_invalid_x, False)
-
         # Starting index for the training set (1 = discard round-0 samples).
         start_idx = int(discard_prior_samples and self._round > 0)
 
@@ -222,7 +216,12 @@ class PosteriorEstimator(NeuralInference, ABC):
         if self.use_non_atomic_loss:
             start_idx = self._round
 
-        theta, x, prior_masks = self.get_simulations(start_idx, exclude_invalid_x)
+        theta, x, prior_masks = self.get_simulations(
+            start_idx, exclude_invalid_x, warn_on_invalid=True
+        )
+
+        # Dataset is shared for training and validation loaders.
+        dataset = data.TensorDataset(theta, x, prior_masks,)
 
         # Set the proposal to the last proposal that was passed by the user. For
         # atomic SNPE, it does not matter what the proposal is. For non-atomic
@@ -230,52 +229,13 @@ class PosteriorEstimator(NeuralInference, ABC):
         # last proposal.
         proposal = self._proposal_roundwise[-1]
 
-        # Select random neural net and validation splits from (theta, x) pairs.
-        num_total_examples = len(theta)
-        num_training_examples = int((1 - validation_fraction) * num_total_examples)
-        num_validation_examples = num_total_examples - num_training_examples
-
-        if not resume_training:
-            permuted_indices = torch.randperm(num_total_examples)
-            self.train_indices, self.val_indices = (
-                permuted_indices[:num_training_examples],
-                permuted_indices[num_training_examples:],
-            )
-
-        # Dataset is shared for training and validation loaders.
-        dataset = data.TensorDataset(
-            theta,
-            x,
-            prior_masks,
+        train_loader, val_loader = self.get_dataloaders(
+            dataset,
+            training_batch_size,
+            validation_fraction,
+            resume_training,
+            dataloader_kwargs=dataloader_kwargs,
         )
-
-        # Create neural net and validation loaders using a subset sampler.
-        # Intentionally use dicts to define the default dataloader args
-        # Then, use dataloader_kwargs to override (or add to) any of these defaults
-        # https://stackoverflow.com/questions/44784577/in-method-call-args-how-to-override-keyword-argument-of-unpacked-dict
-        train_loader_kwargs = {
-            "batch_size": min(training_batch_size, num_training_examples),
-            "drop_last": True,
-            "sampler": SubsetRandomSampler(self.train_indices),
-        }
-        train_loader_kwargs = (
-            dict(train_loader_kwargs, **dataloader_kwargs)
-            if dataloader_kwargs is not None
-            else train_loader_kwargs
-        )
-        val_loader_kwargs = {
-            "batch_size": min(training_batch_size, num_validation_examples),
-            "shuffle": False,
-            "drop_last": True,
-            "sampler": SubsetRandomSampler(self.val_indices),
-        }
-        val_loader_kwargs = (
-            dict(val_loader_kwargs, **dataloader_kwargs)
-            if dataloader_kwargs is not None
-            else val_loader_kwargs
-        )
-        train_loader = data.DataLoader(dataset, **train_loader_kwargs)
-        val_loader = data.DataLoader(dataset, **val_loader_kwargs)
 
         # First round or if retraining from scratch:
         # Call the `self._build_neural_net` with the rounds' thetas and xs as
@@ -294,8 +254,7 @@ class PosteriorEstimator(NeuralInference, ABC):
 
         if not resume_training:
             self.optimizer = optim.Adam(
-                list(self._neural_net.parameters()),
-                lr=learning_rate,
+                list(self._neural_net.parameters()), lr=learning_rate,
             )
             self.epoch, self._val_log_prob = 0, float("-Inf")
 
@@ -316,18 +275,13 @@ class PosteriorEstimator(NeuralInference, ABC):
 
                 batch_loss = torch.mean(
                     self._loss(
-                        theta_batch,
-                        x_batch,
-                        masks_batch,
-                        proposal,
-                        calibration_kernel,
+                        theta_batch, x_batch, masks_batch, proposal, calibration_kernel,
                     )
                 )
                 batch_loss.backward()
                 if clip_max_norm is not None:
                     clip_grad_norm_(
-                        self._neural_net.parameters(),
-                        max_norm=clip_max_norm,
+                        self._neural_net.parameters(), max_norm=clip_max_norm,
                     )
                 self.optimizer.step()
 
@@ -345,15 +299,11 @@ class PosteriorEstimator(NeuralInference, ABC):
                     )
                     # Take negative loss here to get validation log_prob.
                     batch_log_prob = -self._loss(
-                        theta_batch,
-                        x_batch,
-                        masks_batch,
-                        proposal,
-                        calibration_kernel,
+                        theta_batch, x_batch, masks_batch, proposal, calibration_kernel,
                     )
                     log_prob_sum += batch_log_prob.sum().item()
 
-            self._val_log_prob = log_prob_sum / num_validation_examples
+            self._val_log_prob = log_prob_sum / len(val_loader)
             # Log validation log prob for every epoch.
             self._summary["validation_log_probs"].append(self._val_log_prob)
 
@@ -367,10 +317,7 @@ class PosteriorEstimator(NeuralInference, ABC):
 
         # Update tensorboard and summary dict.
         self._summarize(
-            round_=self._round,
-            x_o=None,
-            theta_bank=theta,
-            x_bank=x,
+            round_=self._round, x_o=None, theta_bank=theta, x_bank=x,
         )
 
         # Update description for progress bar.

--- a/sbi/inference/snpe/snpe_c.py
+++ b/sbi/inference/snpe/snpe_c.py
@@ -143,8 +143,8 @@ class SNPE_C(PosteriorEstimator):
                 estimator for the posterior from scratch each round.
             show_train_summary: Whether to print the number of epochs and validation
                 loss and leakage after the training.
-            dataloader_kwargs: Any additional kwargs to be passed to the training and
-                validation dataloaders (like, e.g., a collate_fn)
+            dataloader_kwargs: Additional or updated kwargs to be passed to the training
+                and validation dataloaders (like, e.g., a collate_fn)
 
         Returns:
             Density estimator that approximates the distribution $p(\theta|x)$.
@@ -254,8 +254,7 @@ class SNPE_C(PosteriorEstimator):
 
             if isinstance(self._prior, MultivariateNormal):
                 self._maybe_z_scored_prior = MultivariateNormal(
-                    almost_zero_mean,
-                    torch.diag(almost_one_std),
+                    almost_zero_mean, torch.diag(almost_one_std),
                 )
             else:
                 range_ = torch.sqrt(almost_one_std * 3.0)
@@ -368,10 +367,7 @@ class SNPE_C(PosteriorEstimator):
         return log_prob_proposal_posterior
 
     def _log_prob_proposal_posterior_mog(
-        self,
-        theta: Tensor,
-        x: Tensor,
-        proposal: DirectPosterior,
+        self, theta: Tensor, x: Tensor, proposal: DirectPosterior,
     ) -> Tensor:
         """
         Return log-probability of the proposal posterior for MoG proposal.
@@ -419,21 +415,11 @@ class SNPE_C(PosteriorEstimator):
 
         # Compute the MoG parameters of the proposal posterior.
         logits_pp, m_pp, prec_pp, cov_pp = self._automatic_posterior_transformation(
-            norm_logits_p,
-            m_p,
-            prec_p,
-            norm_logits_d,
-            m_d,
-            prec_d,
+            norm_logits_p, m_p, prec_p, norm_logits_d, m_d, prec_d,
         )
 
         # Compute the log_prob of theta under the product.
-        log_prob_proposal_posterior = _mog_log_prob(
-            theta,
-            logits_pp,
-            m_pp,
-            prec_pp,
-        )
+        log_prob_proposal_posterior = _mog_log_prob(theta, logits_pp, m_pp, prec_pp,)
         self._assert_all_finite(log_prob_proposal_posterior, "proposal posterior eval")
 
         return log_prob_proposal_posterior
@@ -487,11 +473,7 @@ class SNPE_C(PosteriorEstimator):
         )
 
         means_pp = self._means_proposal_posterior(
-            covariances_pp,
-            means_p,
-            precisions_p,
-            means_d,
-            precisions_d,
+            covariances_pp, means_p, precisions_p, means_d, precisions_d,
         )
 
         logits_pp = self._logits_proposal_posterior(
@@ -509,9 +491,7 @@ class SNPE_C(PosteriorEstimator):
         return logits_pp, means_pp, precisions_pp, covariances_pp
 
     def _precisions_proposal_posterior(
-        self,
-        precisions_p: Tensor,
-        precisions_d: Tensor,
+        self, precisions_p: Tensor, precisions_d: Tensor,
     ):
         """
         Return the precisions and covariances of the proposal posterior.
@@ -659,10 +639,7 @@ class SNPE_C(PosteriorEstimator):
 
 
 def _mog_log_prob(
-    theta: Tensor,
-    logits_pp: Tensor,
-    means_pp: Tensor,
-    precisions_pp: Tensor,
+    theta: Tensor, logits_pp: Tensor, means_pp: Tensor, precisions_pp: Tensor,
 ) -> Tensor:
     r"""
     Returns the log-probability of parameter sets $\theta$ under a mixture of Gaussians.

--- a/sbi/inference/snre/snre_a.py
+++ b/sbi/inference/snre/snre_a.py
@@ -95,8 +95,8 @@ class SNRE_A(RatioEstimator):
                 estimator for the posterior from scratch each round.
             show_train_summary: Whether to print the number of epochs and validation
                 loss and leakage after the training.
-            dataloader_kwargs: Any additional kwargs to be passed to the training and
-                validation dataloaders (like, e.g., a collate_fn)
+            dataloader_kwargs: Additional or updated kwargs to be passed to the training
+                and validation dataloaders (like, e.g., a collate_fn)
 
         Returns:
             Classifier that approximates the ratio $p(\theta,x)/p(\theta)p(x)$.

--- a/sbi/inference/snre/snre_b.py
+++ b/sbi/inference/snre/snre_b.py
@@ -97,8 +97,8 @@ class SNRE_B(RatioEstimator):
                 estimator for the posterior from scratch each round.
             show_train_summary: Whether to print the number of epochs and validation
                 loss and leakage after the training.
-            dataloader_kwargs: Any additional kwargs to be passed to the training and
-                validation dataloaders (like, e.g., a collate_fn)
+            dataloader_kwargs: Additional or updated kwargs to be passed to the training
+                and validation dataloaders (like, e.g., a collate_fn)
 
         Returns:
             Classifier that approximates the ratio $p(\theta,x)/p(\theta)p(x)$.

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -83,10 +83,7 @@ class RatioEstimator(NeuralInference, ABC):
         self._summary.update({"mcmc_times": []})  # type: ignore
 
     def append_simulations(
-        self,
-        theta: Tensor,
-        x: Tensor,
-        from_round: int = 0,
+        self, theta: Tensor, x: Tensor, from_round: int = 0,
     ) -> "RatioEstimator":
         r"""
         Store parameters and simulation outputs to use them for later training.
@@ -158,64 +155,30 @@ class RatioEstimator(NeuralInference, ABC):
 
         max_num_epochs = 2 ** 31 - 1 if max_num_epochs is None else max_num_epochs
 
-        # Load data from most recent round.
-        self._round = max(self._data_round_index)
-        theta, x, _ = self.get_simulations(self._round, exclude_invalid_x, False)
-
         # Starting index for the training set (1 = discard round-0 samples).
         start_idx = int(discard_prior_samples and self._round > 0)
-        theta, x, _ = self.get_simulations(start_idx, exclude_invalid_x)
-
-        # Get total number of training examples.
-        num_examples = len(theta)
-
-        # Select random train and validation splits from (theta, x) pairs.
-        num_training_examples = int((1 - validation_fraction) * num_examples)
-        num_validation_examples = num_examples - num_training_examples
-
-        if not resume_training:
-            permuted_indices = torch.randperm(num_examples)
-            self.train_indices, self.val_indices = (
-                permuted_indices[:num_training_examples],
-                permuted_indices[num_training_examples:],
-            )
-
-        clipped_batch_size = min(training_batch_size, num_validation_examples)
-
-        num_atoms = clamp_and_warn(
-            "num_atoms", num_atoms, min_val=2, max_val=clipped_batch_size
+        # Load data from most recent round.
+        self._round = max(self._data_round_index)
+        theta, x, _ = self.get_simulations(
+            start_idx, exclude_invalid_x, warn_on_invalid=True
         )
 
         # Dataset is shared for training and validation loaders.
         dataset = data.TensorDataset(theta, x)
 
-        # Create neural net and validation loaders using a subset sampler.
-        # Intentionally use dicts to define the default dataloader args
-        # Then, use dataloader_kwargs to override (or add to) any of these defaults
-        # https://stackoverflow.com/questions/44784577/in-method-call-args-how-to-override-keyword-argument-of-unpacked-dict
-        train_loader_kwargs = {
-            "batch_size": min(training_batch_size, num_training_examples),
-            "drop_last": True,
-            "sampler": SubsetRandomSampler(self.train_indices),
-        }
-        train_loader_kwargs = (
-            dict(train_loader_kwargs, **dataloader_kwargs)
-            if dataloader_kwargs is not None
-            else train_loader_kwargs
+        train_loader, val_loader = self.get_dataloaders(
+            dataset,
+            training_batch_size,
+            validation_fraction,
+            resume_training,
+            dataloader_kwargs=dataloader_kwargs,
         )
-        val_loader_kwargs = {
-            "batch_size": min(training_batch_size, num_validation_examples),
-            "shuffle": False,
-            "drop_last": True,
-            "sampler": SubsetRandomSampler(self.val_indices),
-        }
-        val_loader_kwargs = (
-            dict(val_loader_kwargs, **dataloader_kwargs)
-            if dataloader_kwargs is not None
-            else val_loader_kwargs
+
+        clipped_batch_size = min(training_batch_size, len(val_loader))
+
+        num_atoms = clamp_and_warn(
+            "num_atoms", num_atoms, min_val=2, max_val=clipped_batch_size
         )
-        train_loader = data.DataLoader(dataset, **train_loader_kwargs)
-        val_loader = data.DataLoader(dataset, **val_loader_kwargs)
 
         # First round or if retraining from scratch:
         # Call the `self._build_neural_net` with the rounds' thetas and xs as
@@ -232,8 +195,7 @@ class RatioEstimator(NeuralInference, ABC):
 
         if not resume_training:
             self.optimizer = optim.Adam(
-                list(self._neural_net.parameters()),
-                lr=learning_rate,
+                list(self._neural_net.parameters()), lr=learning_rate,
             )
             self.epoch, self._val_log_prob = 0, float("-Inf")
 
@@ -253,8 +215,7 @@ class RatioEstimator(NeuralInference, ABC):
                 loss.backward()
                 if clip_max_norm is not None:
                     clip_grad_norm_(
-                        self._neural_net.parameters(),
-                        max_norm=clip_max_norm,
+                        self._neural_net.parameters(), max_norm=clip_max_norm,
                     )
                 self.optimizer.step()
 
@@ -271,7 +232,7 @@ class RatioEstimator(NeuralInference, ABC):
                     )
                     log_prob = self._loss(theta_batch, x_batch, num_atoms)
                     log_prob_sum -= log_prob.sum().item()
-                self._val_log_prob = log_prob_sum / num_validation_examples
+                self._val_log_prob = log_prob_sum / len(val_loader)
                 # Log validation log prob for every epoch.
                 self._summary["validation_log_probs"].append(self._val_log_prob)
 
@@ -285,10 +246,7 @@ class RatioEstimator(NeuralInference, ABC):
 
         # Update TensorBoard and summary dict.
         self._summarize(
-            round_=self._round,
-            x_o=None,
-            theta_bank=theta,
-            x_bank=x,
+            round_=self._round, x_o=None, theta_bank=theta, x_bank=x,
         )
 
         # Update description for progress bar.

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -1,0 +1,24 @@
+import pytest
+import torch
+from torch.utils.data import TensorDataset
+
+from sbi.inference import SNPE
+
+
+@pytest.mark.parametrize("training_batch_size", (1, 10, 100))
+def test_get_dataloaders(training_batch_size):
+
+    N = 1000
+    validation_fraction = 0.1
+
+    dataset = TensorDataset(torch.ones(N), torch.zeros(N))
+
+    inferer = SNPE()
+
+    _, val_loader = inferer.get_dataloaders(
+        dataset,
+        training_batch_size=training_batch_size,
+        validation_fraction=validation_fraction,
+    )
+
+    assert len(val_loader) * val_loader.batch_size == int(validation_fraction * N)


### PR DESCRIPTION
moving creation of data loader to `base.py` to reduce code repetition for creating the data loader in each inference base class separately. 

see #415 and #445 

TODO: 
- [x] add docstrings and comments. 