### PR TITLE
Fix for torch v1.8.0

### DIFF
--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -665,15 +665,23 @@ class NeuralPosterior(ABC):
             def tf_inv(theta_t):
                 return utils.expit(
                     theta_t,
-                    torch.as_tensor(boxuniform.support.lower_bound, dtype=float32),
-                    torch.as_tensor(boxuniform.support.upper_bound, dtype=float32),
+                    torch.as_tensor(
+                        boxuniform.support.base_constraint.lower_bound, dtype=float32
+                    ),
+                    torch.as_tensor(
+                        boxuniform.support.base_constraint.upper_bound, dtype=float32
+                    ),
                 )
 
             def tf(theta):
                 return utils.logit(
                     theta,
-                    torch.as_tensor(boxuniform.support.lower_bound, dtype=float32),
-                    torch.as_tensor(boxuniform.support.upper_bound, dtype=float32),
+                    torch.as_tensor(
+                        boxuniform.support.base_constraint.lower_bound, dtype=float32
+                    ),
+                    torch.as_tensor(
+                        boxuniform.support.base_constraint.upper_bound, dtype=float32
+                    ),
                 )
 
         else:

--- a/sbi/utils/__init__.py
+++ b/sbi/utils/__init__.py
@@ -24,6 +24,7 @@ from sbi.utils.sbiutils import (
     warn_if_zscoring_changes_data,
     warn_on_invalid_x,
     warn_on_invalid_x_for_snpec_leakage,
+    within_support,
     x_shape_from_simulation,
 )
 from sbi.utils.torchutils import (

--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -233,6 +233,7 @@ class BoxUniform(Independent):
             Uniform(
                 low=torch.as_tensor(low, dtype=torch.float32),
                 high=torch.as_tensor(high, dtype=torch.float32),
+                validate_args=False,
             ),
             reinterpreted_batch_ndims,
         )

--- a/sbi/utils/user_input_checks.py
+++ b/sbi/utils/user_input_checks.py
@@ -136,6 +136,10 @@ def process_pytorch_prior(prior: Distribution) -> Tuple[Distribution, int, bool]
         prior_returns_numpy: False.
     """
 
+    # Turn off validation of input arguments to allow `log_prob()` on samples outside
+    # of the support.
+    prior.set_default_validate_args(False)
+
     # Reject unwrapped scalar priors.
     # This will reject Uniform priors with dimension larger than 1.
     if prior.sample().ndim == 0:
@@ -154,7 +158,9 @@ def process_pytorch_prior(prior: Distribution) -> Tuple[Distribution, int, bool]
     check_prior_batch_dims(prior)
 
     if not prior.sample().dtype == float32:
-        prior = PytorchReturnTypeWrapper(prior, return_type=float32)
+        prior = PytorchReturnTypeWrapper(
+            prior, return_type=float32, validate_args=False
+        )
 
     # This will fail for float64 priors.
     check_prior_return_type(prior)


### PR DESCRIPTION
This fixes issues with torch version 1.8.0

1) if a torch distribution is passed, ensure that it has `validate_args=False`. This will allow calling `log_prob()` even when the samples are outside of the support.
2) Also ensure `validate_args=False` for `BoxUniform` and `PytorchReturnTypeWrapper`
3) whenever we check whether samples are inside the support: checks whether the `distribution` has a `support` attribute (as is the case for any `torch.distribution`). If it does not, it evaluates the log-probabilty and returns whether it is finite or not (this hanldes e.g. `NeuralPosterior`). Only checking whether the log-probabilty is not `-inf` should also work due to steps 1) and 2), but we are on the save side if the user does not run the prior through `prepare_for_sbi()`.

Note: for the core functionality of `sbi`, I ensured backwards compatibility with torch v1.6.0. However, `posterior.map()` and potentially other functions will break under older versions.

Closes #449 