### PR TITLE
Remove deprecation warning when correctly import conditional_pairplot

### DIFF
--- a/sbi/utils/conditional_density.py
+++ b/sbi/utils/conditional_density.py
@@ -157,6 +157,7 @@ def conditional_corrcoeff(
                             dim1=dim1,
                             dim2=dim2,
                             resolution=resolution,
+                            warn_about_deprecation=False,
                         ),
                         limits[[dim1, dim2]],
                     )

--- a/sbi/utils/plot.py
+++ b/sbi/utils/plot.py
@@ -473,6 +473,7 @@ def conditional_pairplot(
             resolution=resolution,
             eps_margins1=eps_margins[row],
             eps_margins2=eps_margins[row],
+            warn_about_deprecation=False,
         ).numpy()
         h = plt.plot(
             np.linspace(
@@ -494,6 +495,7 @@ def conditional_pairplot(
             resolution=resolution,
             eps_margins1=eps_margins[row],
             eps_margins2=eps_margins[col],
+            warn_about_deprecation=False,
         ).numpy()
         h = plt.imshow(
             p_image.T,


### PR DESCRIPTION
Quick bug-fix. It was warning even when doing the correct import:
```
from sbi.analysis import conditional_pairplot, conditional_corrcoeff
```