### PR TITLE
add independent constraints for support attribute.

### DIFF
--- a/sbi/utils/user_input_checks_utils.py
+++ b/sbi/utils/user_input_checks_utils.py
@@ -10,6 +10,7 @@ from scipy.stats._distn_infrastructure import rv_frozen
 from scipy.stats._multivariate import multi_rv_frozen
 from torch import Tensor, float32
 from torch.distributions import Distribution
+from torch.distributions.constraints import Constraint
 
 
 class CustomPytorchWrapper(Distribution):
@@ -169,9 +170,7 @@ class MultipleIndependent(Distribution):
     """
 
     def __init__(
-        self,
-        dists: Sequence[Distribution],
-        validate_args=None,
+        self, dists: Sequence[Distribution], validate_args=None,
     ):
         self._check_distributions(dists)
 
@@ -285,3 +284,47 @@ class MultipleIndependent(Distribution):
     @property
     def variance(self) -> Tensor:
         return torch.cat([d.variance for d in self.dists])
+
+    @property
+    def support(self):
+        # return independent constraints for each distribution.
+        return MultipleIndependentConstraints(
+            constraints=[d.support for d in self.dists],
+            dims_per_constraint=self.dims_per_dist,
+        )
+
+
+class MultipleIndependentConstraints(Constraint):
+    def __init__(self, constraints: Sequence[Constraint], dims_per_constraint: list):
+        """Define multiple independent constraints to check support of independent
+        joint distributions.
+
+        Args:
+            constraints: List of constraints, one for each distribution.
+            dims_per_constraint: List of event dimensions for each distribution, needed
+                to match values to constraints.
+        """
+
+        for c in constraints:
+            assert isinstance(c, Constraint)
+        self.constraints = constraints
+        self.dims_per_constraint = dims_per_constraint
+
+    def check(self, value: Tensor) -> Tensor:
+        """Returns a byte tensor of ``sample_shape + batch_shape`` indicating
+        whether each event in value satisfies its corresponding constraint."""
+        result = torch.zeros((value.shape[0], len(self.constraints)))
+        dim_idx = 0
+        # For each constraint, select the corresponding values according to its
+        # event dim.
+        for idx, c in enumerate(self.constraints):
+            # reshape and squeeze needed to accommodate different types of
+            # distributions.
+            result[:, idx] = c.check(
+                value[:, dim_idx : (dim_idx + self.dims_per_constraint[idx])].reshape(
+                    -1, self.dims_per_constraint[idx]
+                )
+            ).squeeze()
+            dim_idx += self.dims_per_constraint[idx]
+        # Return check across all independent constraints.
+        return result.all(-1)

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -90,10 +90,7 @@ def matrix_simulator(theta):
 @pytest.mark.parametrize(
     "wrapper, prior",
     (
-        (
-            CustomPytorchWrapper,
-            UserNumpyUniform(zeros(3), ones(3), return_numpy=True),
-        ),
+        (CustomPytorchWrapper, UserNumpyUniform(zeros(3), ones(3), return_numpy=True),),
         (ScipyPytorchWrapper, multivariate_normal()),
         (ScipyPytorchWrapper, uniform()),
         (ScipyPytorchWrapper, beta(a=1, b=1)),
@@ -143,8 +140,7 @@ def test_reinterpreted_batch_dim_prior():
             Uniform(zeros((1, 3)), ones((1, 3))), marks=pytest.mark.xfail
         ),  # batch shape > 1.
         pytest.param(
-            MultivariateNormal(zeros(3, 3), eye(3)),
-            marks=pytest.mark.xfail,
+            MultivariateNormal(zeros(3, 3), eye(3)), marks=pytest.mark.xfail,
         ),  # batch shape > 1.
         pytest.param(
             Uniform(zeros(3), ones(3)), marks=pytest.mark.xfail
@@ -172,11 +168,7 @@ def test_process_prior(prior):
 
 
 @pytest.mark.parametrize(
-    "x, x_shape",
-    (
-        (ones(3), torch.Size([1, 3])),
-        (ones(1, 3), torch.Size([1, 3])),
-    ),
+    "x, x_shape", ((ones(3), torch.Size([1, 3])), (ones(1, 3), torch.Size([1, 3])),),
 )
 def test_process_x(x, x_shape):
     process_x(x, x_shape)
@@ -189,10 +181,7 @@ def test_process_x(x, x_shape):
         (diagonal_linear_gaussian, BoxUniform(zeros(2), ones(2))),
         (numpy_linear_gaussian, UserNumpyUniform(zeros(2), ones(2), True)),
         (linear_gaussian_no_batch, BoxUniform(zeros(2), ones(2))),
-        pytest.param(
-            list_simulator,
-            BoxUniform(zeros(2), ones(2)),
-        ),
+        pytest.param(list_simulator, BoxUniform(zeros(2), ones(2)),),
     ),
 )
 def test_process_simulator(simulator: Callable, prior: Distribution):
@@ -212,10 +201,7 @@ def test_process_simulator(simulator: Callable, prior: Distribution):
 @pytest.mark.parametrize(
     "simulator, prior",
     (
-        (
-            linear_gaussian_no_batch,
-            BoxUniform(zeros(3), ones(3)),
-        ),
+        (linear_gaussian_no_batch, BoxUniform(zeros(3), ones(3)),),
         (
             numpy_linear_gaussian,
             UserNumpyUniform(zeros(3), ones(3), return_numpy=True),
@@ -237,10 +223,7 @@ def test_process_simulator(simulator: Callable, prior: Distribution):
                 MultivariateNormal(zeros(2), eye(2)),
             ],
         ),
-        pytest.param(
-            list_simulator,
-            BoxUniform(zeros(3), ones(3)),
-        ),
+        pytest.param(list_simulator, BoxUniform(zeros(3), ones(3)),),
     ),
 )
 def test_prepare_sbi_problem(simulator: Callable, prior):
@@ -296,11 +279,7 @@ def test_inference_with_user_sbi_problems(user_simulator: Callable, user_prior):
     """
 
     simulator, prior = prepare_for_sbi(user_simulator, user_prior)
-    inference = SNPE_C(
-        prior,
-        density_estimator="maf",
-        show_progress_bars=False,
-    )
+    inference = SNPE_C(prior, density_estimator="maf", show_progress_bars=False,)
 
     # Run inference.
     theta, x = simulate_for_sbi(simulator, prior, 100)
@@ -383,6 +362,10 @@ def test_independent_joint_shapes_and_samples(dists):
     # Check whether independent joint sample equal individual samples.
     assert (true_samples == samples).all()
     assert (true_log_probs == log_probs).all()
+
+    # Check support attribute.
+    within_support = joint.support.check(true_samples)
+    assert within_support.all()
 
 
 def test_invalid_inputs():


### PR DESCRIPTION
Since the new PyTorch version distributions have the `support` property. We are using this property, e.g., when checking that the posterior samples lie within the prior support. 

For priors that are independent we implemented a new distribution `MultipleIndependent(Distribution)` to sample and evaluate a sequence of independent PyTorch distributions. However, this new class doesn't implement the `support` property yet and this results in an error when using this joint prior feature. 

This PR does that by implementing a new `Constraint` class that holds a list of independent `Constraints`, one for each independent prior distribution, and checks the support for each of them, taking into account the corresponding event dimension. 