### PR TITLE
fix error handling in support check.

### DIFF
--- a/sbi/utils/user_input_checks_utils.py
+++ b/sbi/utils/user_input_checks_utils.py
@@ -69,7 +69,8 @@ class CustomPytorchWrapper(Distribution):
                 ** 2
             )
             warnings.warn(
-                "Prior is lacking variance attribute, estimating prior variance from samples...",
+                """Prior is lacking variance attribute, estimating prior variance from
+                samples...""",
                 UserWarning,
             )
 
@@ -152,6 +153,10 @@ class PytorchReturnTypeWrapper(Distribution):
     @property
     def variance(self):
         return torch.as_tensor(self.prior.variance, dtype=self.return_type)
+
+    @property
+    def support(self):
+        return self.prior.support
 
 
 class MultipleIndependent(Distribution):

--- a/sbi/utils/user_input_checks_utils.py
+++ b/sbi/utils/user_input_checks_utils.py
@@ -318,6 +318,9 @@ class MultipleIndependentConstraints(Constraint):
     def check(self, value: Tensor) -> Tensor:
         """Returns a byte tensor of ``sample_shape + batch_shape`` indicating
         whether each event in value satisfies its corresponding constraint."""
+
+        if value.ndim < 2:
+            value = value.unsqueeze(0)
         result = torch.zeros((value.shape[0], len(self.constraints)))
         dim_idx = 0
         # For each constraint, select the corresponding values according to its

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -28,17 +28,10 @@ from tests.test_utils import (
 
 
 @pytest.mark.parametrize(
-    "num_dim, prior_str",
-    (
-        (2, "gaussian"),
-        (2, "uniform"),
-        (1, "gaussian"),
-    ),
+    "num_dim, prior_str", ((2, "gaussian"), (2, "uniform"), (1, "gaussian"),),
 )
 def test_c2st_snpe_on_linearGaussian(
-    num_dim: int,
-    prior_str: str,
-    set_seed,
+    num_dim: int, prior_str: str, set_seed,
 ):
     """Test whether SNPE C infers well a simple example with available ground truth.
 
@@ -48,6 +41,7 @@ def test_c2st_snpe_on_linearGaussian(
 
     x_o = zeros(1, num_dim)
     num_samples = 1000
+    num_simulations = 2500
 
     # likelihood_mean will be likelihood_shift+theta
     likelihood_shift = -1.0 * ones(num_dim)
@@ -71,12 +65,11 @@ def test_c2st_snpe_on_linearGaussian(
         return linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
     simulator, prior = prepare_for_sbi(simulator, prior)
-    inference = SNPE_C(
-        prior,
-        show_progress_bars=False,
-    )
+    inference = SNPE_C(prior, show_progress_bars=False,)
 
-    theta, x = simulate_for_sbi(simulator, prior, 2000, simulation_batch_size=1000)
+    theta, x = simulate_for_sbi(
+        simulator, prior, num_simulations, simulation_batch_size=1000
+    )
     _ = inference.append_simulations(theta, x).train(training_batch_size=100)
     posterior = inference.build_posterior().set_default_x(x_o)
     samples = posterior.sample((num_samples,))
@@ -195,8 +188,7 @@ def test_c2st_snpe_on_linearGaussian_different_dims(set_seed):
         pytest.param(
             "snpe_b",
             marks=pytest.mark.xfail(
-                raises=NotImplementedError,
-                reason="""SNPE-B not implemented""",
+                raises=NotImplementedError, reason="""SNPE-B not implemented""",
             ),
         ),
         "snpe_c",
@@ -366,11 +358,7 @@ def test_sample_conditional(set_seed):
     net = utils.posterior_nn("maf", hidden_features=20)
 
     simulator, prior = prepare_for_sbi(simulator, prior)
-    inference = SNPE_C(
-        prior,
-        density_estimator=net,
-        show_progress_bars=False,
-    )
+    inference = SNPE_C(prior, density_estimator=net, show_progress_bars=False,)
 
     # We need a pretty big dataset to properly model the bimodality.
     theta, x = simulate_for_sbi(simulator, prior, 10000)
@@ -396,16 +384,8 @@ def test_sample_conditional(set_seed):
     density = gaussian_kde(cond_samples.numpy().T, bw_method="scott")
 
     X, Y = np.meshgrid(
-        np.linspace(
-            limits[0][0],
-            limits[0][1],
-            50,
-        ),
-        np.linspace(
-            limits[1][0],
-            limits[1][1],
-            50,
-        ),
+        np.linspace(limits[0][0], limits[0][1], 50,),
+        np.linspace(limits[1][0], limits[1][1], 50,),
     )
     positions = np.vstack([X.ravel(), Y.ravel()])
     sample_kde_grid = np.reshape(density(positions).T, X.shape)
@@ -446,10 +426,7 @@ def example_posterior():
         return linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
     simulator, prior = prepare_for_sbi(simulator, prior)
-    inference = SNPE_C(
-        prior,
-        show_progress_bars=False,
-    )
+    inference = SNPE_C(prior, show_progress_bars=False,)
     theta, x = simulate_for_sbi(
         simulator, prior, 1000, simulation_batch_size=10, num_workers=6
     )


### PR DESCRIPTION
When the prior is wrapped and does not implement the abstract property `support`, checking for this attribute will result in a `NotImplementedError`. 

This is a quick fix that catches this error and instead performs the support check by evaluating the samples. 

Open for discussing for a better / more general fix. 

closes #463 