### PR TITLE
Num bins fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
+# v0.15.2
+
+- fixed unused argument `num_bins` when using `nsf` as density estimator (#465)
+
+
 # v0.15.1
 
 - add option to pass `torch.data.DataLoader` kwargs to all inference methods (thanks @narendramukherjee, #445)
 - fix bug due to release of `torch` `v1.8.0` (#451)
 - expose `leakage_correction` parameters for `log_prob` correction in unnormalized 
   posteriors (thanks @famura, #454)
+
 
 # v0.15.0
 

--- a/sbi/analysis/conditional_density.py
+++ b/sbi/analysis/conditional_density.py
@@ -18,12 +18,16 @@ def eval_conditional_density(
     resolution: int = 50,
     eps_margins1: Union[Tensor, float] = 1e-32,
     eps_margins2: Union[Tensor, float] = 1e-32,
+    return_raw_log_prob: bool = False,
 ) -> Tensor:
     r"""
     Return the unnormalized conditional along `dim1, dim2` given parameters `condition`.
 
     We compute the unnormalized conditional by evaluating the joint distribution:
         $p(x1 | x2) = p(x1, x2) / p(x2) \propto p(x1, x2)$
+
+    The joint distribution is evaluated on an evenly spaced grid defined by the
+    `limits`.
 
     Args:
         density: Probability density function with `.log_prob()` method.
@@ -42,6 +46,9 @@ def eval_conditional_density(
         eps_margins2: We will evaluate the posterior along `dim2` at
             `limits[0]+eps_margins` until `limits[1]-eps_margins`. This avoids
             evaluations potentially exactly at the prior bounds.
+	return_raw_log_prob: If `True`, return the log-probability evaluated on the·
+            grid. If `False`, return the probability, scaled down by the maximum value·
+            on the grid for numerical stability (i.e. exp(log_prob - max_log_prob)).
 
     Returns: Conditional probabilities. If `dim1 == dim2`, this will have shape
         (resolution). If `dim1 != dim2`, it will have shape (resolution, resolution).
@@ -55,6 +62,7 @@ def eval_conditional_density(
         resolution=resolution,
         eps_margins1=eps_margins1,
         eps_margins2=eps_margins2,
+        return_raw_log_prob=return_raw_log_prob,
         warn_about_deprecation=False,
     )
 

--- a/sbi/neural_nets/flow.py
+++ b/sbi/neural_nets/flow.py
@@ -270,7 +270,7 @@ def build_nsf(
                     transforms.PiecewiseRationalQuadraticCouplingTransform(
                         mask=mask_in_layer(i),
                         transform_net_create_fn=conditioner,
-                        num_bins=10,
+                        num_bins=num_bins,
                         tails="linear",
                         tail_bound=3.0,
                         apply_unconditional_transform=False,

--- a/sbi/utils/conditional_density.py
+++ b/sbi/utils/conditional_density.py
@@ -20,6 +20,7 @@ def eval_conditional_density(
     resolution: int = 50,
     eps_margins1: Union[Tensor, float] = 1e-32,
     eps_margins2: Union[Tensor, float] = 1e-32,
+    return_raw_log_prob: bool = False,
     warn_about_deprecation: bool = True,
 ) -> Tensor:
     r"""
@@ -27,6 +28,9 @@ def eval_conditional_density(
 
     We compute the unnormalized conditional by evaluating the joint distribution:
         $p(x1 | x2) = p(x1, x2) / p(x2) \propto p(x1, x2)$
+
+    The joint distribution is evaluated on an evenly spaced grid defined by the
+    `limits`.
 
     Args:
         density: Probability density function with `.log_prob()` method.
@@ -45,6 +49,9 @@ def eval_conditional_density(
         eps_margins2: We will evaluate the posterior along `dim2` at
             `limits[0]+eps_margins` until `limits[1]-eps_margins`. This avoids
             evaluations potentially exactly at the prior bounds.
+        return_raw_log_prob: If `True`, return the log-probability evaluated on the·
+            grid. If `False`, return the probability, scaled down by the maximum value·
+            on the grid for numerical stability (i.e. exp(log_prob - max_log_prob)).
         warn_about_deprecation: With sbi v0.15.0, we depracated the import of this
             function from `sbi.utils`. Instead, it should be imported from
             `sbi.analysis`.
@@ -88,8 +95,11 @@ def eval_conditional_density(
         log_probs_on_grid = density.log_prob(repeated_condition)
         log_probs_on_grid = torch.reshape(log_probs_on_grid, (resolution, resolution))
 
-    # Subtract maximum for numerical stability.
-    return torch.exp(log_probs_on_grid - torch.max(log_probs_on_grid))
+    if return_raw_log_prob:
+        return log_probs_on_grid
+    else:
+        # Subtract maximum for numerical stability
+        return torch.exp(log_probs_on_grid - torch.max(log_probs_on_grid))
 
 
 def conditional_corrcoeff(


### PR DESCRIPTION
Two independent things in these two commits:

1) the first commit adds the option to return the raw log-prob in `eval_conditional_density` (not documented in changelog because it's very specific)
2) bug fix: `num_bins` had not been used.