### PR TITLE
within_prior instead of log_prob for support check.

### DIFF
--- a/sbi/inference/posteriors/direct_posterior.py
+++ b/sbi/inference/posteriors/direct_posterior.py
@@ -10,7 +10,7 @@ from torch import Tensor, log, nn
 from sbi import utils as utils
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.types import ScalarFloat, Shape
-from sbi.utils import del_entries
+from sbi.utils import del_entries, within_support
 from sbi.utils.torchutils import (
     batched_first_of_batch,
     ensure_theta_batched,
@@ -202,10 +202,10 @@ class DirectPosterior(NeuralPosterior):
             ).cpu()
 
             # Force probability to be zero outside prior support.
-            is_prior_finite = torch.isfinite(self._prior.log_prob(theta))
+            in_prior_support = within_support(self._prior, theta)
 
             masked_log_prob = torch.where(
-                is_prior_finite,
+                in_prior_support,
                 unnorm_log_prob,
                 torch.tensor(float("-inf"), dtype=torch.float32),
             )
@@ -509,7 +509,11 @@ class PotentialFunctionProvider:
     """
 
     def __call__(
-        self, prior, posterior_nn: nn.Module, x: Tensor, mcmc_method: str,
+        self,
+        prior,
+        posterior_nn: nn.Module,
+        x: Tensor,
+        mcmc_method: str,
     ) -> Callable:
         """Return potential function.
 
@@ -545,10 +549,11 @@ class PotentialFunctionProvider:
 
         with torch.set_grad_enabled(False):
             target_log_prob = self.posterior_nn.log_prob(
-                inputs=theta.to(self.x.device), context=x_repeated,
+                inputs=theta.to(self.x.device),
+                context=x_repeated,
             )
-            is_within_prior = torch.isfinite(self.prior.log_prob(theta))
-            target_log_prob[~is_within_prior] = -float("Inf")
+            in_prior_support = within_support(self.prior, theta)
+            target_log_prob[~in_prior_support] = -float("Inf")
 
         return target_log_prob
 
@@ -569,8 +574,11 @@ class PotentialFunctionProvider:
         log_prob_posterior = -self.posterior_nn.log_prob(
             inputs=theta.to(self.x.device), context=self.x
         ).cpu()
-        log_prob_prior = self.prior.log_prob(theta)
 
-        within_prior = torch.isfinite(log_prob_prior)
+        in_prior_support = within_support(self.prior, theta)
 
-        return torch.where(within_prior, log_prob_posterior, log_prob_prior)
+        return torch.where(
+            in_prior_support,
+            log_prob_posterior,
+            float("-inf") * torch.ones_like(log_prob_posterior),
+        )

--- a/tests/linearGaussian_snle_test.py
+++ b/tests/linearGaussian_snle_test.py
@@ -161,7 +161,7 @@ def test_c2st_snl_on_linearGaussian(num_dim: int, prior_str: str, set_seed):
     # TODO: density is not normalized, so KLd does not make sense.
     if prior_str == "uniform":
         # Check whether the returned probability outside of the support is zero.
-        posterior_prob = get_prob_outside_uniform_prior(posterior, num_dim)
+        posterior_prob = get_prob_outside_uniform_prior(posterior, prior, num_dim)
         assert (
             posterior_prob == 0.0
         ), "The posterior probability outside of the prior support is not zero"

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -28,10 +28,17 @@ from tests.test_utils import (
 
 
 @pytest.mark.parametrize(
-    "num_dim, prior_str", ((2, "gaussian"), (2, "uniform"), (1, "gaussian"),),
+    "num_dim, prior_str",
+    (
+        (2, "gaussian"),
+        (2, "uniform"),
+        (1, "gaussian"),
+    ),
 )
 def test_c2st_snpe_on_linearGaussian(
-    num_dim: int, prior_str: str, set_seed,
+    num_dim: int,
+    prior_str: str,
+    set_seed,
 ):
     """Test whether SNPE C infers well a simple example with available ground truth.
 
@@ -65,7 +72,10 @@ def test_c2st_snpe_on_linearGaussian(
         return linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
     simulator, prior = prepare_for_sbi(simulator, prior)
-    inference = SNPE_C(prior, show_progress_bars=False,)
+    inference = SNPE_C(
+        prior,
+        show_progress_bars=False,
+    )
 
     theta, x = simulate_for_sbi(
         simulator, prior, num_simulations, simulation_batch_size=1000
@@ -96,7 +106,7 @@ def test_c2st_snpe_on_linearGaussian(
 
     elif prior_str == "uniform":
         # Check whether the returned probability outside of the support is zero.
-        posterior_prob = get_prob_outside_uniform_prior(posterior, num_dim)
+        posterior_prob = get_prob_outside_uniform_prior(posterior, prior, num_dim)
         assert (
             posterior_prob == 0.0
         ), "The posterior probability outside of the prior support is not zero"
@@ -188,7 +198,8 @@ def test_c2st_snpe_on_linearGaussian_different_dims(set_seed):
         pytest.param(
             "snpe_b",
             marks=pytest.mark.xfail(
-                raises=NotImplementedError, reason="""SNPE-B not implemented""",
+                raises=NotImplementedError,
+                reason="""SNPE-B not implemented""",
             ),
         ),
         "snpe_c",
@@ -358,7 +369,11 @@ def test_sample_conditional(set_seed):
     net = utils.posterior_nn("maf", hidden_features=20)
 
     simulator, prior = prepare_for_sbi(simulator, prior)
-    inference = SNPE_C(prior, density_estimator=net, show_progress_bars=False,)
+    inference = SNPE_C(
+        prior,
+        density_estimator=net,
+        show_progress_bars=False,
+    )
 
     # We need a pretty big dataset to properly model the bimodality.
     theta, x = simulate_for_sbi(simulator, prior, 10000)
@@ -384,8 +399,16 @@ def test_sample_conditional(set_seed):
     density = gaussian_kde(cond_samples.numpy().T, bw_method="scott")
 
     X, Y = np.meshgrid(
-        np.linspace(limits[0][0], limits[0][1], 50,),
-        np.linspace(limits[1][0], limits[1][1], 50,),
+        np.linspace(
+            limits[0][0],
+            limits[0][1],
+            50,
+        ),
+        np.linspace(
+            limits[1][0],
+            limits[1][1],
+            50,
+        ),
     )
     positions = np.vstack([X.ravel(), Y.ravel()])
     sample_kde_grid = np.reshape(density(positions).T, X.shape)
@@ -426,7 +449,10 @@ def example_posterior():
         return linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
     simulator, prior = prepare_for_sbi(simulator, prior)
-    inference = SNPE_C(prior, show_progress_bars=False,)
+    inference = SNPE_C(
+        prior,
+        show_progress_bars=False,
+    )
     theta, x = simulate_for_sbi(
         simulator, prior, 1000, simulation_batch_size=10, num_workers=6
     )

--- a/tests/linearGaussian_snre_test.py
+++ b/tests/linearGaussian_snre_test.py
@@ -37,7 +37,11 @@ def test_api_sre_on_linearGaussian(num_dim: int):
     prior = MultivariateNormal(loc=zeros(num_dim), covariance_matrix=eye(num_dim))
 
     simulator, prior = prepare_for_sbi(diagonal_linear_gaussian, prior)
-    inference = SRE(prior, classifier="resnet", show_progress_bars=False,)
+    inference = SRE(
+        prior,
+        classifier="resnet",
+        show_progress_bars=False,
+    )
 
     theta, x = simulate_for_sbi(simulator, prior, 1000, simulation_batch_size=50)
     _ = inference.append_simulations(theta, x).train(max_num_epochs=5)
@@ -87,7 +91,11 @@ def test_c2st_sre_on_linearGaussian_different_dims(set_seed):
         )
 
     simulator, prior = prepare_for_sbi(simulator, prior)
-    inference = SRE(prior, classifier="resnet", show_progress_bars=False,)
+    inference = SRE(
+        prior,
+        classifier="resnet",
+        show_progress_bars=False,
+    )
 
     theta, x = simulate_for_sbi(simulator, prior, 5000, simulation_batch_size=50)
     _ = inference.append_simulations(theta, x).train()
@@ -109,7 +117,10 @@ def test_c2st_sre_on_linearGaussian_different_dims(set_seed):
     ),
 )
 def test_c2st_sre_on_linearGaussian(
-    num_dim: int, prior_str: str, method_str: str, set_seed,
+    num_dim: int,
+    prior_str: str,
+    method_str: str,
+    set_seed,
 ):
     """Test c2st accuracy of inference with SRE on linear Gaussian model.
 
@@ -145,7 +156,11 @@ def test_c2st_sre_on_linearGaussian(
         return linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
     simulator, prior = prepare_for_sbi(simulator, prior)
-    kwargs = dict(prior=prior, classifier="resnet", show_progress_bars=False,)
+    kwargs = dict(
+        prior=prior,
+        classifier="resnet",
+        show_progress_bars=False,
+    )
 
     inference = SRE(**kwargs) if method_str == "sre" else AALR(**kwargs)
 
@@ -184,7 +199,7 @@ def test_c2st_sre_on_linearGaussian(
 
     if prior_str == "uniform":
         # Check whether the returned probability outside of the support is zero.
-        posterior_prob = get_prob_outside_uniform_prior(posterior, num_dim)
+        posterior_prob = get_prob_outside_uniform_prior(posterior, prior, num_dim)
         assert (
             posterior_prob == 0.0
         ), "The posterior probability outside of the prior support is not zero"
@@ -219,7 +234,11 @@ def test_api_sre_sampling_methods(mcmc_method: str, prior_str: str, set_seed):
         prior = utils.BoxUniform(low=-1.0 * ones(num_dim), high=ones(num_dim))
 
     simulator, prior = prepare_for_sbi(diagonal_linear_gaussian, prior)
-    inference = SRE(prior, classifier="resnet", show_progress_bars=False,)
+    inference = SRE(
+        prior,
+        classifier="resnet",
+        show_progress_bars=False,
+    )
 
     theta, x = simulate_for_sbi(simulator, prior, 200, simulation_batch_size=50)
     _ = inference.append_simulations(theta, x).train(max_num_epochs=5)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,7 @@ from torch.distributions import Distribution
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.inference.posteriors.direct_posterior import DirectPosterior
 from sbi.simulators.linear_gaussian import true_posterior_linear_gaussian_mvn_prior
+from sbi.utils import BoxUniform, within_support
 from sbi.utils.metrics import c2st
 
 
@@ -82,7 +83,9 @@ def get_dkl_gaussian_prior(
     return kl_d_via_monte_carlo(target_dist, posterior, num_samples=200)
 
 
-def get_prob_outside_uniform_prior(posterior: NeuralPosterior, num_dim: int) -> Tensor:
+def get_prob_outside_uniform_prior(
+    posterior: NeuralPosterior, prior: BoxUniform, num_dim: int
+) -> Tensor:
     """
     Return posterior probability for a parameter set outside of the prior support.
 
@@ -90,9 +93,12 @@ def get_prob_outside_uniform_prior(posterior: NeuralPosterior, num_dim: int) -> 
         posterior: estimated posterior
         num_dim: dimensionality of the problem
     """
-    # Test whether likelihood outside prior support is zero. Prior bounds are [-1, 1] in
-    # each dimension, so tensor of 2s will be out of bounds.
-    sample_outside_support = 2 * torch.ones(num_dim)
+    # Test whether likelihood outside prior support is zero.
+    assert isinstance(prior, BoxUniform)
+    sample_outside_support = 1.1 * prior.base_dist.low
+    assert not within_support(
+        prior, sample_outside_support
+    ).all(), "Samples must be outside of support."
 
     return torch.exp(posterior.log_prob(sample_outside_support))
 


### PR DESCRIPTION
in the context of `posterior.map()` we are still using `torch.isfinite(prior.log_prob(theta))` to check whether `theta` is in the support. This can result in `value must be in support` error in `PyTorch`.

This PR uses `within_support` instead to fix this. 
