### PR TITLE
snre support for inference given batch of iid x

### DIFF
--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -93,7 +93,7 @@ class NeuralPosterior(ABC):
         self._x_shape = x_shape
         self._device = device
         # Methods capable of handling iid xo.
-        self._iid_methods = ["snle"]
+        self._iid_methods = ["snle", "snre_a", "snre_b"]
         self._allow_iid_x = method_family in self._iid_methods
 
         if not self._allow_iid_x:

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -1,6 +1,5 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
-import logging
 import time
 from abc import ABC, abstractmethod
 from copy import deepcopy
@@ -11,7 +10,6 @@ import torch
 from torch import Tensor, ones, optim
 from torch.nn.utils import clip_grad_norm_
 from torch.utils import data
-from torch.utils.data.sampler import SubsetRandomSampler
 from torch.utils.tensorboard import SummaryWriter
 
 from sbi import utils as utils

--- a/tests/linearGaussian_snre_test.py
+++ b/tests/linearGaussian_snre_test.py
@@ -8,7 +8,7 @@ from torch import eye, ones, zeros
 from torch.distributions import MultivariateNormal
 
 from sbi import utils as utils
-from sbi.inference import AALR, SRE, prepare_for_sbi, simulate_for_sbi
+from sbi.inference import AALR, SNRE_B, prepare_for_sbi, simulate_for_sbi
 from sbi.simulators.linear_gaussian import (
     diagonal_linear_gaussian,
     linear_gaussian,
@@ -33,11 +33,10 @@ def test_api_sre_on_linearGaussian(num_dim: int):
         num_dim: parameter dimension of the Gaussian model
     """
 
-    x_o = zeros(num_dim)
     prior = MultivariateNormal(loc=zeros(num_dim), covariance_matrix=eye(num_dim))
 
     simulator, prior = prepare_for_sbi(diagonal_linear_gaussian, prior)
-    inference = SRE(
+    inference = SNRE_B(
         prior,
         classifier="resnet",
         show_progress_bars=False,
@@ -47,10 +46,12 @@ def test_api_sre_on_linearGaussian(num_dim: int):
     _ = inference.append_simulations(theta, x).train(max_num_epochs=5)
     posterior = inference.build_posterior()
 
-    posterior.sample(sample_shape=(10,), x=x_o, mcmc_parameters={"num_chains": 2})
+    for num_trials in [1, 2]:
+        x_o = zeros(num_trials, num_dim)
+        posterior.sample(sample_shape=(10,), x=x_o, mcmc_parameters={"num_chains": 2})
 
 
-def test_c2st_sre_on_linearGaussian_different_dims(set_seed):
+def test_c2st_sre_on_linearGaussian(set_seed):
     """Test whether SRE infers well a simple example with available ground truth.
 
     This example has different number of parameters theta than number of x. This test
@@ -63,9 +64,8 @@ def test_c2st_sre_on_linearGaussian_different_dims(set_seed):
     theta_dim = 3
     x_dim = 2
     discard_dims = theta_dim - x_dim
-
-    x_o = ones(1, x_dim)
     num_samples = 1000
+    num_simulations = 1000
 
     likelihood_shift = -1.0 * ones(
         x_dim
@@ -75,8 +75,29 @@ def test_c2st_sre_on_linearGaussian_different_dims(set_seed):
     prior_mean = zeros(theta_dim)
     prior_cov = eye(theta_dim)
     prior = MultivariateNormal(loc=prior_mean, covariance_matrix=prior_cov)
+
+    simulator, prior = prepare_for_sbi(
+        lambda theta: linear_gaussian(
+            theta, likelihood_shift, likelihood_cov, num_discarded_dims=discard_dims
+        ),
+        prior,
+    )
+    inference = SNRE_B(
+        prior,
+        classifier="resnet",
+        show_progress_bars=False,
+    )
+
+    theta, x = simulate_for_sbi(
+        simulator, prior, num_simulations, simulation_batch_size=100
+    )
+    _ = inference.append_simulations(theta, x).train()
+    posterior = inference.build_posterior(mcmc_method="slice_np_vectorized")
+
+    num_trials = 1
+    x_o = zeros(num_trials, x_dim)
     target_samples = samples_true_posterior_linear_gaussian_mvn_prior_different_dims(
-        x_o[0],
+        x_o,
         likelihood_shift,
         likelihood_cov,
         prior_mean,
@@ -84,40 +105,29 @@ def test_c2st_sre_on_linearGaussian_different_dims(set_seed):
         num_discarded_dims=discard_dims,
         num_samples=num_samples,
     )
-
-    def simulator(theta):
-        return linear_gaussian(
-            theta, likelihood_shift, likelihood_cov, num_discarded_dims=discard_dims
-        )
-
-    simulator, prior = prepare_for_sbi(simulator, prior)
-    inference = SRE(
-        prior,
-        classifier="resnet",
-        show_progress_bars=False,
+    samples = posterior.sample(
+        (num_samples,),
+        x=x_o,
+        mcmc_parameters={"thin": 5, "num_chains": 2},
     )
 
-    theta, x = simulate_for_sbi(simulator, prior, 5000, simulation_batch_size=50)
-    _ = inference.append_simulations(theta, x).train()
-    posterior = inference.build_posterior()
-    samples = posterior.sample((num_samples,), x=x_o, mcmc_parameters={"thin": 3})
-
     # Compute the c2st and assert it is near chance level of 0.5.
-    check_c2st(samples, target_samples, alg="snpe_c")
+    check_c2st(samples, target_samples, alg=f"snre-{num_trials}trials")
 
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
-    "num_dim, prior_str, method_str",
+    "num_dim, num_trials, prior_str, method_str",
     (
-        (2, "gaussian", "sre"),
-        (1, "gaussian", "sre"),
-        (2, "uniform", "sre"),
-        (2, "gaussian", "aalr"),
+        (2, 5, "gaussian", "sre"),
+        (1, 1, "gaussian", "sre"),
+        (2, 1, "uniform", "sre"),
+        (2, 5, "gaussian", "aalr"),
     ),
 )
-def test_c2st_sre_on_linearGaussian(
+def test_c2st_sre_variants_on_linearGaussian(
     num_dim: int,
+    num_trials: int,
     prior_str: str,
     method_str: str,
     set_seed,
@@ -130,27 +140,20 @@ def test_c2st_sre_on_linearGaussian(
         set_seed: fixture for manual seeding
     """
 
-    x_o = zeros(1, num_dim)
+    x_o = zeros(num_trials, num_dim)
     num_samples = 500
-    num_simulations = 2500
+    num_simulations = 2500 if num_trials == 1 else 35000
 
     # `likelihood_mean` will be `likelihood_shift + theta`.
     likelihood_shift = -1.0 * ones(num_dim)
-    likelihood_cov = 0.3 * eye(num_dim)
+    likelihood_cov = 0.8 * eye(num_dim)
 
     if prior_str == "gaussian":
         prior_mean = zeros(num_dim)
         prior_cov = eye(num_dim)
         prior = MultivariateNormal(loc=prior_mean, covariance_matrix=prior_cov)
-        gt_posterior = true_posterior_linear_gaussian_mvn_prior(
-            x_o[0], likelihood_shift, likelihood_cov, prior_mean, prior_cov
-        )
-        target_samples = gt_posterior.sample((num_samples,))
     else:
         prior = utils.BoxUniform(-2.0 * ones(num_dim), 2.0 * ones(num_dim))
-        target_samples = samples_true_posterior_linear_gaussian_uniform_prior(
-            x_o, likelihood_shift, likelihood_cov, prior=prior, num_samples=num_samples
-        )
 
     def simulator(theta):
         return linear_gaussian(theta, likelihood_shift, likelihood_cov)
@@ -162,7 +165,7 @@ def test_c2st_sre_on_linearGaussian(
         show_progress_bars=False,
     )
 
-    inference = SRE(**kwargs) if method_str == "sre" else AALR(**kwargs)
+    inference = SNRE_B(**kwargs) if method_str == "sre" else AALR(**kwargs)
 
     # Should use default `num_atoms=10` for SRE; `num_atoms=2` for AALR
     theta, x = simulate_for_sbi(
@@ -171,10 +174,27 @@ def test_c2st_sre_on_linearGaussian(
     _ = inference.append_simulations(theta, x).train()
     posterior = inference.build_posterior().set_default_x(x_o)
 
-    samples = posterior.sample(sample_shape=(num_samples,), mcmc_parameters={"thin": 3})
+    samples = posterior.sample(
+        sample_shape=(num_samples,),
+        mcmc_method="slice_np_vectorized",
+        mcmc_parameters={"thin": 3, "num_chains": 5},
+    )
+
+    # Get posterior samples.
+    if prior_str == "gaussian":
+        gt_posterior = true_posterior_linear_gaussian_mvn_prior(
+            x_o, likelihood_shift, likelihood_cov, prior_mean, prior_cov
+        )
+        target_samples = gt_posterior.sample((num_samples,))
+    else:
+        target_samples = samples_true_posterior_linear_gaussian_uniform_prior(
+            x_o, likelihood_shift, likelihood_cov, prior=prior, num_samples=num_samples
+        )
 
     # Check performance based on c2st accuracy.
-    check_c2st(samples, target_samples, alg=f"sre-{prior_str}-{method_str}")
+    check_c2st(
+        samples, target_samples, alg=f"sre-{prior_str}-{method_str}-{num_trials}trials"
+    )
 
     map_ = posterior.map(num_init_samples=1_000, init_method="prior")
 
@@ -186,7 +206,7 @@ def test_c2st_sre_on_linearGaussian(
         # evaluation up to a constant.
         # For the Gaussian prior, we compute the KLd between ground truth and posterior
         dkl = get_dkl_gaussian_prior(
-            posterior, x_o[0], likelihood_shift, likelihood_cov, prior_mean, prior_cov
+            posterior, x_o, likelihood_shift, likelihood_cov, prior_mean, prior_cov
         )
 
         max_dkl = 0.15
@@ -234,7 +254,7 @@ def test_api_sre_sampling_methods(mcmc_method: str, prior_str: str, set_seed):
         prior = utils.BoxUniform(low=-1.0 * ones(num_dim), high=ones(num_dim))
 
     simulator, prior = prepare_for_sbi(diagonal_linear_gaussian, prior)
-    inference = SRE(
+    inference = SNRE_B(
         prior,
         classifier="resnet",
         show_progress_bars=False,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -147,4 +147,4 @@ def check_c2st(x: Tensor, y: Tensor, alg: str, tol: float = 0.1) -> None:
 
     assert (
         (0.5 - tol) <= score <= (0.5 + tol)
-    ), f"c2st={score:.2f} is too far from the desired near-chance performance."
+    ), f"{alg}'s c2st={score:.2f} is too far from the desired near-chance performance."


### PR DESCRIPTION
Analog to SNLE: rewrite log ratios to take the sum over the batch dimension of `x`, assuming it to contain `iid` trials. 
Adapt `log_prob` and potential functions accordingly to then use MCMC to infer the posterior given `iid` x. 
