### PR TITLE
Changed the default value of component_perturbation

### DIFF
--- a/sbi/inference/snpe/snpe_a.py
+++ b/sbi/inference/snpe/snpe_a.py
@@ -119,7 +119,7 @@ class SNPE_A(PosteriorEstimator):
         retrain_from_scratch_each_round: bool = False,
         show_train_summary: bool = False,
         dataloader_kwargs: Optional[Dict] = None,
-        component_perturbation: float = 1e-5,
+        component_perturbation: float = 5e-3,
     ) -> DirectPosterior:
         r"""
         Return density estimator that approximates the proposal posterior $\tilde{p}(\theta|x)$.
@@ -162,7 +162,8 @@ class SNPE_A(PosteriorEstimator):
                 and validation dataloaders (like, e.g., a collate_fn)
             component_perturbation: The standard deviation applied to all weights and
                 biases when, in the last round, the Mixture of Gaussians is build from
-                a single Gaussian.
+                a single Gaussian. This value can be problem-specific and also depends
+                on the number of mixture components.
         Returns:
             Density estimator that approximates the distribution $p(\theta|x)$.
         """


### PR DESCRIPTION
In #478, I said that a default value for `component_perturbation` of `1e-2` is way larger than in the original paper.  Well, after doing some experiments with SNPE-A, I noticed that for small values in the rage of [1e-6, 1e-4] the perturbation is (at least in the cases I looked at) too small. Thus, the x = 2,...,10 components stayed right where the one component after running Algorithm 1 ended up. Therefore I suggest raising this value.

Moreover, I noticed that the "optimal" `component_perturbation``value also depended on the number of components. As a rule of thumb, more components required a bigger value. But please take this information with a grain of salt.