### PR TITLE
add required dim arg to logsumexp.

### DIFF
--- a/sbi/mcmc/init_strategy.py
+++ b/sbi/mcmc/init_strategy.py
@@ -63,7 +63,7 @@ def sir(
         init_param_candidates = torch.cat(init_param_candidates)
 
         # Norm weights in log space
-        log_weights -= torch.logsumexp(log_weights)
+        log_weights -= torch.logsumexp(log_weights, dim=0)
         probs = np.exp(log_weights.view(-1).numpy().astype(np.float64))
         probs[np.isnan(probs)] = 0.0
         probs[np.isinf(probs)] = 0.0

--- a/tests/linearGaussian_snle_test.py
+++ b/tests/linearGaussian_snle_test.py
@@ -244,7 +244,10 @@ def test_c2st_multi_round_snl_on_linearGaussian(num_trials: int, set_seed):
     "sampling_method",
     ("slice_np", "slice_np_vectorized", "slice", "nuts", "hmc", "rejection"),
 )
-def test_api_snl_sampling_methods(sampling_method: str, prior_str: str, set_seed):
+@pytest.mark.parametrize("init_strategy", ("prior", "sir"))
+def test_api_snl_sampling_methods(
+    sampling_method: str, prior_str: str, init_strategy: str, set_seed
+):
     """Runs SNL on linear Gaussian and tests sampling from posterior via mcmc.
 
     Args:
@@ -285,5 +288,9 @@ def test_api_snl_sampling_methods(sampling_method: str, prior_str: str, set_seed
     posterior.sample(
         sample_shape=(num_samples,),
         x=x_o,
-        mcmc_parameters={"thin": 3, "num_chains": num_chains},
+        mcmc_parameters={
+            "thin": 3,
+            "num_chains": num_chains,
+            "init_strategy": init_strategy,
+        },
     )


### PR DESCRIPTION
small fix for SIR init: `logsumexp` actually requires the dim arg. 