### PR TITLE
update prior device, direct posterior

### DIFF
--- a/sbi/inference/posteriors/direct_posterior.py
+++ b/sbi/inference/posteriors/direct_posterior.py
@@ -188,7 +188,7 @@ class DirectPosterior(NeuralPosterior):
             ).cpu()
 
             # Force probability to be zero outside prior support.
-            in_prior_support = within_support(self._prior, theta)
+            in_prior_support = within_support(self._prior, theta).cpu()
 
             masked_log_prob = torch.where(
                 in_prior_support,


### PR DESCRIPTION
If "in_prior_support" is on gpu, an error is raised during the "torch.where" instruction following. 