### PR TITLE
Conda packaging

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -61,7 +61,7 @@ about:
   home: https://github.com/mackelab/sbi
   license: GNU Affero General Public v3 or later (AGPLv3+)
   license_family: AGPL
-  license_file: 
+  license_file: https://github.com/mackelab/sbi/blob/main/LICENSE.txt
   summary: Simulation-based inference.
   doc_url: https://www.mackelab.org/sbi/
   dev_url: 

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,0 +1,71 @@
+{% set name = "sbi" %}
+{% set version = "0.16.0" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 10535ae83d5b27e1b9cfe7cc2de780af67e206c557545df806698806e03af618
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
+
+requirements:
+  host:
+    - joblib >=1.0.0
+    - matplotlib
+    - numpy
+    - pillow
+    - pip
+    # - pyknos >=0.14.2
+    # - pyro-ppl # >=1.3.1
+    - python
+    - scikit-learn
+    - scipy
+    - tensorboard
+    - pytorch # >=1.8.0
+    - tqdm
+  run:
+    - joblib >=1.0.0
+    - matplotlib
+    - numpy
+    - pillow
+    # - pyknos >=0.14.2
+    # - pyro-ppl # >=1.3.1
+    - python
+    - scikit-learn
+    - scipy
+    - tensorboard
+    - pytorch # >=1.8.0
+    - tqdm
+
+test:
+  imports:
+    - sbi
+    # - sbi.inference
+    # - sbi.inference.base
+    # - sbi.inference.abc
+    # - sbi.inference.posteriors
+    # - sbi.inference.snle
+    # - sbi.inference.snpe
+    # - sbi.inference.snre
+    # - sbi.mcmc
+    # - sbi.neural_nets
+    # - sbi.simulators
+    # - sbi.utils
+
+about:
+  home: https://github.com/mackelab/sbi
+  license: GNU Affero General Public v3 or later (AGPLv3+)
+  license_family: AGPL
+  license_file: 
+  summary: Simulation-based inference.
+  doc_url: 
+  dev_url: 
+
+extra:
+  recipe-maintainers:
+    - your-github-id-here

--- a/meta.yaml
+++ b/meta.yaml
@@ -63,7 +63,7 @@ about:
   license_family: AGPL
   license_file: 
   summary: Simulation-based inference.
-  doc_url: 
+  doc_url: https://www.mackelab.org/sbi/
   dev_url: 
 
 extra:


### PR DESCRIPTION
- Make `sbi` installable through `conda`
- Based on existing [PyPI](https://pypi.org/project/sbi/)