### PR TITLE
Allow prior on gpu

### DIFF
--- a/docs/docs/faq/question_04.md
+++ b/docs/docs/faq/question_04.md
@@ -1,18 +1,23 @@
 
 # Can I use the GPU for training the density estimator?
 
-TLDR; Yes, by passing `device="cuda"`. But no speed-ups for default density estimators.
+TLDR; Yes, by passing `device="cuda"` and by passing a prior that lives on the device
+name your passed. But no speed-ups for default density estimators.
 
 Yes. When creating the inference object in the flexible interface, you can pass the
 `device` as an argument, e.g.,
 
 ```python
-inference = SNPE(simulator, prior, device="cuda", density_estimator="maf")
+inference = SNPE(prior, device="cuda", density_estimator="maf")
 ```
 
 The device is set to `"cpu"` by default, and it can be set to anything, as long as it
 maps to an existing PyTorch CUDA device. `sbi` will take care of copying the `net` and
 the training data to and from the `device`. 
+Note that the prior must be on the training device already, e.g., when passing `device="cuda:0"`,
+make sure to pass a prior object that was created on that device, e.g., 
+`prior = torch.distributions.MultivariateNormal(loc=torch.zeros(2, device="cuda:0"), 
+                                                covariance_matrix=torch.eye(2, device="cuda:0"))`.
 
 ## Performance
 

--- a/sbi/analysis/conditional_density.py
+++ b/sbi/analysis/conditional_density.py
@@ -46,8 +46,8 @@ def eval_conditional_density(
         eps_margins2: We will evaluate the posterior along `dim2` at
             `limits[0]+eps_margins` until `limits[1]-eps_margins`. This avoids
             evaluations potentially exactly at the prior bounds.
-	return_raw_log_prob: If `True`, return the log-probability evaluated on the·
-            grid. If `False`, return the probability, scaled down by the maximum value·
+        return_raw_log_prob: If `True`, return the log-probability evaluated on the
+            grid. If `False`, return the probability, scaled down by the maximum value
             on the grid for numerical stability (i.e. exp(log_prob - max_log_prob)).
 
     Returns: Conditional probabilities. If `dim1 == dim2`, this will have shape

--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -115,7 +115,7 @@ class NeuralInference(ABC):
                 0.14.0 is more mature, we will remove this argument.
         """
 
-        self._device = process_device(device)
+        self._device = process_device(device, prior=prior)
 
         if unused_args:
             warn(
@@ -381,9 +381,7 @@ class NeuralInference(ABC):
 
         method = self.__class__.__name__
         logdir = Path(
-            get_log_root(),
-            method,
-            datetime.now().isoformat().replace(":", "_"),
+            get_log_root(), method, datetime.now().isoformat().replace(":", "_")
         )
         return SummaryWriter(logdir)
 
@@ -437,11 +435,7 @@ class NeuralInference(ABC):
             )
 
     def _summarize(
-        self,
-        round_: int,
-        x_o: Union[Tensor, None],
-        theta_bank: Tensor,
-        x_bank: Tensor,
+        self, round_: int, x_o: Union[Tensor, None], theta_bank: Tensor, x_bank: Tensor
     ) -> None:
         """Update the summary_writer with statistics for a given round.
 
@@ -456,12 +450,7 @@ class NeuralInference(ABC):
         # Median |x - x0| for most recent round.
         if x_o is not None:
             median_observation_distance = torch.median(
-                torch.sqrt(
-                    torch.sum(
-                        (x_bank - x_o.reshape(1, -1)) ** 2,
-                        dim=-1,
-                    )
-                )
+                torch.sqrt(torch.sum((x_bank - x_o.reshape(1, -1)) ** 2, dim=-1))
             )
             self._summary["median_observation_distances"].append(
                 median_observation_distance.item()
@@ -558,11 +547,7 @@ def simulate_for_sbi(
     theta = proposal.sample((num_simulations,))
 
     x = simulate_in_batches(
-        simulator,
-        theta,
-        simulation_batch_size,
-        num_workers,
-        show_progress_bar,
+        simulator, theta, simulation_batch_size, num_workers, show_progress_bar
     )
 
     return theta, x

--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -363,7 +363,7 @@ class NeuralPosterior(ABC):
         return theta.to(self._device), x.to(self._device)
 
     def _prepare_for_sample(
-        self, x: Tensor, sample_shape: Optional[Tensor],
+        self, x: Tensor, sample_shape: Optional[Tensor]
     ) -> Tuple[Tensor, int]:
         r"""
         Return checked, reshaped, potentially default values for `x` and `sample_shape`.
@@ -723,8 +723,10 @@ class NeuralPosterior(ABC):
                 **mcmc_parameters,
             )
         elif sample_with == "rejection":
-            rejection_sampling_parameters = self._potentially_replace_rejection_parameters(
-                rejection_sampling_parameters
+            rejection_sampling_parameters = (
+                self._potentially_replace_rejection_parameters(
+                    rejection_sampling_parameters
+                )
             )
             if "proposal" not in rejection_sampling_parameters:
                 rejection_sampling_parameters[
@@ -833,7 +835,8 @@ class NeuralPosterior(ABC):
         def potential_fn(theta):
             return self.log_prob(theta, x=x, track_gradients=True, **log_prob_kwargs)
 
-        interruption_note = "The last estimate of the MAP can be accessed via the `posterior.map_` attribute."
+        interruption_note = """The last estimate of the MAP can be accessed via the
+                            `posterior.map_` attribute."""
 
         self.map_, _ = optimize_potential_fn(
             potential_fn=potential_fn,

--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -1175,7 +1175,7 @@ class ConditionalPotentialFunctionProvider:
         theta_condition = deepcopy(self.condition)
         theta_condition[:, self.dims_to_sample] = theta
 
-        return self.potential_fn_provider.np_potential(
+        return self.potential_fn_provider.posterior_potential(
             utils.tensor2numpy(theta_condition)
         )
 

--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -149,7 +149,9 @@ class NeuralPosterior(ABC):
         Returns:
             `NeuralPosterior` that will use a default `x` when not explicitly passed.
         """
-        self._x = process_x(x, self._x_shape, allow_iid_x=self._allow_iid_x)
+        self._x = process_x(x, self._x_shape, allow_iid_x=self._allow_iid_x).to(
+            self._device
+        )
         self._num_iid_trials = self._x.shape[0]
 
         return self
@@ -358,12 +360,10 @@ class NeuralPosterior(ABC):
             self._ensure_single_x(x)
         self._ensure_x_consistent_with_default_x(x)
 
-        return theta, x
+        return theta.to(self._device), x.to(self._device)
 
     def _prepare_for_sample(
-        self,
-        x: Tensor,
-        sample_shape: Optional[Tensor],
+        self, x: Tensor, sample_shape: Optional[Tensor],
     ) -> Tuple[Tensor, int]:
         r"""
         Return checked, reshaped, potentially default values for `x` and `sample_shape`.
@@ -723,10 +723,8 @@ class NeuralPosterior(ABC):
                 **mcmc_parameters,
             )
         elif sample_with == "rejection":
-            rejection_sampling_parameters = (
-                self._potentially_replace_rejection_parameters(
-                    rejection_sampling_parameters
-                )
+            rejection_sampling_parameters = self._potentially_replace_rejection_parameters(
+                rejection_sampling_parameters
             )
             if "proposal" not in rejection_sampling_parameters:
                 rejection_sampling_parameters[

--- a/sbi/inference/posteriors/direct_posterior.py
+++ b/sbi/inference/posteriors/direct_posterior.py
@@ -353,8 +353,10 @@ class DirectPosterior(NeuralPosterior):
                 **mcmc_parameters,
             )
         elif sample_with == "rejection":
-            rejection_sampling_parameters = self._potentially_replace_rejection_parameters(
-                rejection_sampling_parameters
+            rejection_sampling_parameters = (
+                self._potentially_replace_rejection_parameters(
+                    rejection_sampling_parameters
+                )
             )
             if "proposal" not in rejection_sampling_parameters:
                 assert (
@@ -549,7 +551,7 @@ class PotentialFunctionProvider:
     """
 
     def __call__(
-        self, prior, posterior_nn: nn.Module, x: Tensor, method: str,
+        self, prior, posterior_nn: nn.Module, x: Tensor, method: str
     ) -> Callable:
         """Return potential function.
 
@@ -591,7 +593,7 @@ class PotentialFunctionProvider:
 
         with torch.set_grad_enabled(track_gradients):
             target_log_prob = self.posterior_nn.log_prob(
-                inputs=theta.to(self.device), context=x_repeated,
+                inputs=theta.to(self.device), context=x_repeated
             )
             in_prior_support = within_support(self.prior, theta)
             target_log_prob[~in_prior_support] = -float("Inf")
@@ -616,7 +618,7 @@ class PotentialFunctionProvider:
             # Notice opposite sign to `posterior_potential`.
             # Move theta to device for evaluation.
             log_prob_posterior = -self.posterior_nn.log_prob(
-                inputs=theta.to(self.device), context=self.x,
+                inputs=theta.to(self.device), context=self.x
             )
 
         in_prior_support = within_support(self.prior, theta)

--- a/sbi/inference/posteriors/likelihood_based_posterior.py
+++ b/sbi/inference/posteriors/likelihood_based_posterior.py
@@ -194,8 +194,10 @@ class LikelihoodBasedPosterior(NeuralPosterior):
                 **mcmc_parameters,
             )
         elif sample_with == "rejection":
-            rejection_sampling_parameters = self._potentially_replace_rejection_parameters(
-                rejection_sampling_parameters
+            rejection_sampling_parameters = (
+                self._potentially_replace_rejection_parameters(
+                    rejection_sampling_parameters
+                )
             )
             if "proposal" not in rejection_sampling_parameters:
                 rejection_sampling_parameters["proposal"] = self._prior
@@ -353,7 +355,7 @@ class LikelihoodBasedPosterior(NeuralPosterior):
 
     @staticmethod
     def _log_likelihoods_over_trials(
-        x: Tensor, theta: Tensor, net: nn.Module, track_gradients: bool = False,
+        x: Tensor, theta: Tensor, net: nn.Module, track_gradients: bool = False
     ) -> Tensor:
         r"""Return log likelihoods summed over iid trials of `x`.
 
@@ -418,7 +420,7 @@ class PotentialFunctionProvider:
     """
 
     def __call__(
-        self, prior, likelihood_nn: nn.Module, x: Tensor, method: str,
+        self, prior, likelihood_nn: nn.Module, x: Tensor, method: str
     ) -> Callable:
         r"""Return potential function for posterior $p(\theta|x)$.
 

--- a/sbi/inference/posteriors/ratio_based_posterior.py
+++ b/sbi/inference/posteriors/ratio_based_posterior.py
@@ -202,8 +202,10 @@ class RatioBasedPosterior(NeuralPosterior):
                 **mcmc_parameters,
             )
         elif sample_with == "rejection":
-            rejection_sampling_parameters = self._potentially_replace_rejection_parameters(
-                rejection_sampling_parameters
+            rejection_sampling_parameters = (
+                self._potentially_replace_rejection_parameters(
+                    rejection_sampling_parameters
+                )
             )
             if "proposal" not in rejection_sampling_parameters:
                 rejection_sampling_parameters["proposal"] = self._prior

--- a/sbi/inference/posteriors/ratio_based_posterior.py
+++ b/sbi/inference/posteriors/ratio_based_posterior.py
@@ -117,7 +117,7 @@ class RatioBasedPosterior(NeuralPosterior):
             track_gradients=track_gradients,
         )
 
-        return log_ratio.cpu() + self._prior.log_prob(theta)
+        return log_ratio + self._prior.log_prob(theta)
 
     def _warn_log_prob_snre(self) -> None:
         if self._method_family == "snre_a":
@@ -202,10 +202,8 @@ class RatioBasedPosterior(NeuralPosterior):
                 **mcmc_parameters,
             )
         elif sample_with == "rejection":
-            rejection_sampling_parameters = (
-                self._potentially_replace_rejection_parameters(
-                    rejection_sampling_parameters
-                )
+            rejection_sampling_parameters = self._potentially_replace_rejection_parameters(
+                rejection_sampling_parameters
             )
             if "proposal" not in rejection_sampling_parameters:
                 rejection_sampling_parameters["proposal"] = self._prior
@@ -390,10 +388,7 @@ class RatioBasedPosterior(NeuralPosterior):
 
     @staticmethod
     def _log_ratios_over_trials(
-        x: Tensor,
-        theta: Tensor,
-        net: nn.Module,
-        track_gradients: bool = False,
+        x: Tensor, theta: Tensor, net: nn.Module, track_gradients: bool = False
     ) -> Tensor:
         r"""Return log ratios summed over iid trials of `x`.
 
@@ -453,11 +448,7 @@ class PotentialFunctionProvider:
     """
 
     def __call__(
-        self,
-        prior,
-        classifier: nn.Module,
-        x: Tensor,
-        method: str,
+        self, prior, classifier: nn.Module, x: Tensor, method: str
     ) -> Callable:
         r"""Return potential function for posterior $p(\theta|x)$.
 
@@ -514,7 +505,7 @@ class PotentialFunctionProvider:
         )
 
         # Notice opposite sign to pyro potential.
-        return log_ratio.cpu() + self.prior.log_prob(theta)
+        return log_ratio + self.prior.log_prob(theta.to(self.device))
 
     def pyro_potential(
         self, theta: Dict[str, Tensor], track_gradients: bool = False
@@ -544,4 +535,4 @@ class PotentialFunctionProvider:
             track_gradients=track_gradients,
         )
 
-        return -(log_ratio.cpu() + self.prior.log_prob(theta))
+        return -(log_ratio + self.prior.log_prob(theta))

--- a/sbi/inference/snpe/snpe_a.py
+++ b/sbi/inference/snpe/snpe_a.py
@@ -94,7 +94,8 @@ class SNPE_A(PosteriorEstimator):
         # continue. It's sneaky because we are using the object (self) as a namespace
         # to pass arguments between functions, and that's implicit state management.
         kwargs = utils.del_entries(
-            locals(), entries=("self", "__class__", "unused_args", "num_components",),
+            locals(),
+            entries=("self", "__class__", "unused_args", "num_components"),
         )
         super().__init__(**kwargs)
 
@@ -419,7 +420,7 @@ class SNPE_A_MDN(nn.Module):
 
             # Compute the log_prob of theta under the product.
             log_prob_proposal_posterior = utils.sbiutils.mog_log_prob(
-                theta, logits_pp, m_pp, prec_pp,
+                theta, logits_pp, m_pp, prec_pp
             )
             utils.assert_all_finite(
                 log_prob_proposal_posterior, "proposal posterior eval"
@@ -518,7 +519,7 @@ class SNPE_A_MDN(nn.Module):
 
         # Compute the MoG parameters of the posterior.
         logits_p, m_p, prec_p, cov_p = self._proposal_posterior_transformation(
-            logits_pp, m_pp, prec_pp, norm_logits_d, m_d, prec_d,
+            logits_pp, m_pp, prec_pp, norm_logits_d, m_d, prec_d
         )
         return logits_p, m_p, prec_p
 
@@ -561,7 +562,7 @@ class SNPE_A_MDN(nn.Module):
         )
 
         means_post = self._means_posterior(
-            covariances_post, means_pp, precisions_pp, means_d, precisions_d,
+            covariances_post, means_pp, precisions_pp, means_d, precisions_d
         )
 
         logits_post = SNPE_A_MDN._logits_posterior(

--- a/sbi/inference/snpe/snpe_a.py
+++ b/sbi/inference/snpe/snpe_a.py
@@ -94,13 +94,7 @@ class SNPE_A(PosteriorEstimator):
         # continue. It's sneaky because we are using the object (self) as a namespace
         # to pass arguments between functions, and that's implicit state management.
         kwargs = utils.del_entries(
-            locals(),
-            entries=(
-                "self",
-                "__class__",
-                "unused_args",
-                "num_components",
-            ),
+            locals(), entries=("self", "__class__", "unused_args", "num_components",),
         )
         super().__init__(**kwargs)
 
@@ -425,10 +419,7 @@ class SNPE_A_MDN(nn.Module):
 
             # Compute the log_prob of theta under the product.
             log_prob_proposal_posterior = utils.sbiutils.mog_log_prob(
-                theta,
-                logits_pp,
-                m_pp,
-                prec_pp,
+                theta, logits_pp, m_pp, prec_pp,
             )
             utils.assert_all_finite(
                 log_prob_proposal_posterior, "proposal posterior eval"
@@ -527,12 +518,7 @@ class SNPE_A_MDN(nn.Module):
 
         # Compute the MoG parameters of the posterior.
         logits_p, m_p, prec_p, cov_p = self._proposal_posterior_transformation(
-            logits_pp,
-            m_pp,
-            prec_pp,
-            norm_logits_d,
-            m_d,
-            prec_d,
+            logits_pp, m_pp, prec_pp, norm_logits_d, m_d, prec_d,
         )
         return logits_p, m_p, prec_p
 
@@ -575,11 +561,7 @@ class SNPE_A_MDN(nn.Module):
         )
 
         means_post = self._means_posterior(
-            covariances_post,
-            means_pp,
-            precisions_pp,
-            means_d,
-            precisions_d,
+            covariances_post, means_pp, precisions_pp, means_d, precisions_d,
         )
 
         logits_post = SNPE_A_MDN._logits_posterior(
@@ -645,9 +627,8 @@ class SNPE_A_MDN(nn.Module):
         prior will not be exactly have mean=0 and std=1.
         """
         if self.z_score_theta:
-            # Default to cpu to avoid mismatch with prior (always on cpu) below.
-            scale = self._neural_net._transform._transforms[0]._scale.cpu()
-            shift = self._neural_net._transform._transforms[0]._shift.cpu()
+            scale = self._neural_net._transform._transforms[0]._scale
+            shift = self._neural_net._transform._transforms[0]._shift
 
             # Following the definition of the linear transform in
             # `standardizing_transform` in `sbiutils.py`:

--- a/sbi/mcmc/slice.py
+++ b/sbi/mcmc/slice.py
@@ -154,17 +154,20 @@ class Slice(MCMCKernel):
                         )
                     ).unsqueeze(
                         0
-                    )  # TODO: The unsqueeze seems to give a speed up, figure out when this is the case exactly
+                    )  # TODO: The unsqueeze seems to give a speed up, figure out when
+                    # this is the case exactly
                 }
             )
 
         # Sample uniformly from slice
         log_height = _log_prob_d(params[self._site_name].view(-1)[dim]) + torch.log(
-            torch.rand(1)
+            torch.rand(1, device=params[self._site_name].device)
         )
 
         # Position the bracket randomly around the current sample
-        lower = params[self._site_name].view(-1)[dim] - self._width[dim] * torch.rand(1)
+        lower = params[self._site_name].view(-1)[dim] - self._width[dim] * torch.rand(
+            1, device=params[self._site_name].device
+        )
         upper = lower + self._width[dim]
 
         # Find lower bracket end
@@ -182,7 +185,9 @@ class Slice(MCMCKernel):
             upper += self._width[dim]
 
         # Sample uniformly from bracket
-        new_parameter = (upper - lower) * torch.rand(1) + lower
+        new_parameter = (upper - lower) * torch.rand(
+            1, device=params[self._site_name].device
+        ) + lower
 
         # If outside slice, reject sample and shrink bracket
         while _log_prob_d(new_parameter) < log_height:
@@ -190,6 +195,8 @@ class Slice(MCMCKernel):
                 lower = new_parameter
             else:
                 upper = new_parameter
-            new_parameter = (upper - lower) * torch.rand(1) + lower
+            new_parameter = (upper - lower) * torch.rand(
+                1, device=params[self._site_name].device
+            ) + lower
 
         return new_parameter, upper - lower

--- a/sbi/utils/metrics.py
+++ b/sbi/utils/metrics.py
@@ -61,7 +61,7 @@ def c2st(
     )
 
     data = np.concatenate((X, Y))
-    target = np.concatenate((np.zeros((X.shape[0],)), np.ones((Y.shape[0],)),))
+    target = np.concatenate((np.zeros((X.shape[0],)), np.ones((Y.shape[0],))))
 
     shuffle = KFold(n_splits=n_folds, shuffle=True, random_state=seed)
     scores = cross_val_score(clf, data, target, cv=shuffle, scoring=scoring)

--- a/sbi/utils/metrics.py
+++ b/sbi/utils/metrics.py
@@ -9,6 +9,8 @@ from sklearn.model_selection import KFold, cross_val_score
 from sklearn.neural_network import MLPClassifier
 from torch import Tensor
 
+from sbi.utils import tensor2numpy
+
 
 def c2st(
     X: Tensor,
@@ -45,8 +47,8 @@ def c2st(
         X += noise_scale * torch.randn(X.shape)
         Y += noise_scale * torch.randn(Y.shape)
 
-    X = X.cpu().numpy()
-    Y = Y.cpu().numpy()
+    X = tensor2numpy(X)
+    Y = tensor2numpy(Y)
 
     ndim = X.shape[1]
 
@@ -59,12 +61,7 @@ def c2st(
     )
 
     data = np.concatenate((X, Y))
-    target = np.concatenate(
-        (
-            np.zeros((X.shape[0],)),
-            np.ones((Y.shape[0],)),
-        )
-    )
+    target = np.concatenate((np.zeros((X.shape[0],)), np.ones((Y.shape[0],)),))
 
     shuffle = KFold(n_splits=n_folds, shuffle=True, random_state=seed)
     scores = cross_val_score(clf, data, target, cv=shuffle, scoring=scoring)

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -546,7 +546,7 @@ def check_warn_and_setstate(
 
 
 def get_simulations_since_round(
-    data: List, data_round_indices: List, starting_round_index: int,
+    data: List, data_round_indices: List, starting_round_index: int
 ) -> Tensor:
     """
     Returns tensor with all data coming from a round >= `starting_round`.
@@ -912,7 +912,7 @@ class ImproperEmpirical(Empirical):
 
 
 def mog_log_prob(
-    theta: Tensor, logits_pp: Tensor, means_pp: Tensor, precisions_pp: Tensor,
+    theta: Tensor, logits_pp: Tensor, means_pp: Tensor, precisions_pp: Tensor
 ) -> Tensor:
     r"""
     Returns the log-probability of parameter sets $\theta$ under a mixture of Gaussians.

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -217,10 +217,8 @@ def rejection_sample_posterior_within_prior(
     while num_remaining > 0:
 
         # Sample and reject.
-        candidates = (
-            posterior_nn.sample(sampling_batch_size, context=x)
-            .reshape(sampling_batch_size, -1)
-            .cpu()
+        candidates = posterior_nn.sample(sampling_batch_size, context=x).reshape(
+            sampling_batch_size, -1
         )
 
         # SNPE-style rejection-sampling when the proposal is the neural net.
@@ -332,7 +330,7 @@ def rejection_sample(
 
     # Define a potential as the ratio between target distribution and proposal.
     def potential_over_proposal(theta):
-        return potential_fn(theta) - proposal.log_prob(theta).cpu()
+        return potential_fn(theta) - proposal.log_prob(theta)
 
     # Search for the maximum of the ratio.
     _, max_log_ratio = optimize_potential_fn(
@@ -398,14 +396,11 @@ def rejection_sample(
                 sampling_batch_size, -1
             )
 
-            # `candidates` will lie on CPU if the proposal is the prior and
-            # possibly on the GPU if the proposal is a neural net. Everything returned
-            # by the `potential_fn` will lie on the CPU.
             target_proposal_ratio = torch.exp(
-                potential_fn(candidates) - proposal.log_prob(candidates).cpu()
+                potential_fn(candidates) - proposal.log_prob(candidates)
             )
             uniform_rand = torch.rand(target_proposal_ratio.shape)
-            samples = candidates.cpu()[target_proposal_ratio > uniform_rand]
+            samples = candidates[target_proposal_ratio > uniform_rand]
 
             accepted.append(samples)
 
@@ -551,9 +546,7 @@ def check_warn_and_setstate(
 
 
 def get_simulations_since_round(
-    data: List,
-    data_round_indices: List,
-    starting_round_index: int,
+    data: List, data_round_indices: List, starting_round_index: int,
 ) -> Tensor:
     """
     Returns tensor with all data coming from a round >= `starting_round`.
@@ -919,10 +912,7 @@ class ImproperEmpirical(Empirical):
 
 
 def mog_log_prob(
-    theta: Tensor,
-    logits_pp: Tensor,
-    means_pp: Tensor,
-    precisions_pp: Tensor,
+    theta: Tensor, logits_pp: Tensor, means_pp: Tensor, precisions_pp: Tensor,
 ) -> Tensor:
     r"""
     Returns the log-probability of parameter sets $\theta$ under a mixture of Gaussians.

--- a/sbi/utils/user_input_checks_utils.py
+++ b/sbi/utils/user_input_checks_utils.py
@@ -58,7 +58,7 @@ class CustomPytorchWrapper(Distribution):
                 torch.as_tensor(self.custom_prior.sample((1000,))), dim=0
             )
             warnings.warn(
-                "Prior is lacking mean attribute, estimating prior mean from samples...",
+                "Prior is lacking mean attribute, estimating prior mean from samples.",
                 UserWarning,
             )
         if hasattr(self.custom_prior, "variance"):
@@ -174,9 +174,7 @@ class MultipleIndependent(Distribution):
             Uniform(torch.ones(1), 2.0 * torch.ones(1))]
     """
 
-    def __init__(
-        self, dists: Sequence[Distribution], validate_args=None,
-    ):
+    def __init__(self, dists: Sequence[Distribution], validate_args=None):
         self._check_distributions(dists)
 
         self.dists = dists

--- a/tests/abc_test.py
+++ b/tests/abc_test.py
@@ -14,10 +14,7 @@ from tests.test_utils import check_c2st
 
 @pytest.mark.parametrize("num_dim", (1, 2))
 def test_mcabc_inference_on_linear_gaussian(
-    num_dim,
-    lra=False,
-    sass=False,
-    sass_expansion_degree=1,
+    num_dim, lra=False, sass=False, sass_expansion_degree=1,
 ):
     x_o = zeros((1, num_dim))
     num_samples = 1000
@@ -58,10 +55,7 @@ def test_mcabc_inference_on_linear_gaussian(
 def test_mcabc_sass_lra(lra, sass_expansion_degree, set_seed):
 
     test_mcabc_inference_on_linear_gaussian(
-        num_dim=2,
-        lra=lra,
-        sass=True,
-        sass_expansion_degree=sass_expansion_degree,
+        num_dim=2, lra=lra, sass=True, sass_expansion_degree=sass_expansion_degree,
     )
 
 
@@ -86,11 +80,7 @@ def test_smcabc_inference_on_linear_gaussian(
     elif prior_type == "uniform":
         prior = BoxUniform(-ones(num_dim), ones(num_dim))
         target_samples = samples_true_posterior_linear_gaussian_uniform_prior(
-            x_o[0],
-            likelihood_shift,
-            likelihood_cov,
-            prior,
-            num_samples,
+            x_o[0], likelihood_shift, likelihood_cov, prior, num_samples,
         )
     else:
         raise ValueError("Wrong prior string.")
@@ -124,5 +114,9 @@ def test_smcabc_inference_on_linear_gaussian(
 def test_smcabc_sass_lra(lra, sass_expansion_degree, set_seed):
 
     test_smcabc_inference_on_linear_gaussian(
-        num_dim=2, lra=lra, sass=True, sass_expansion_degree=sass_expansion_degree
+        num_dim=2,
+        lra=lra,
+        sass=True,
+        sass_expansion_degree=sass_expansion_degree,
+        prior_type="gaussian",
     )

--- a/tests/abc_test.py
+++ b/tests/abc_test.py
@@ -14,7 +14,7 @@ from tests.test_utils import check_c2st
 
 @pytest.mark.parametrize("num_dim", (1, 2))
 def test_mcabc_inference_on_linear_gaussian(
-    num_dim, lra=False, sass=False, sass_expansion_degree=1,
+    num_dim, lra=False, sass=False, sass_expansion_degree=1
 ):
     x_o = zeros((1, num_dim))
     num_samples = 1000
@@ -55,7 +55,7 @@ def test_mcabc_inference_on_linear_gaussian(
 def test_mcabc_sass_lra(lra, sass_expansion_degree, set_seed):
 
     test_mcabc_inference_on_linear_gaussian(
-        num_dim=2, lra=lra, sass=True, sass_expansion_degree=sass_expansion_degree,
+        num_dim=2, lra=lra, sass=True, sass_expansion_degree=sass_expansion_degree
     )
 
 
@@ -80,7 +80,7 @@ def test_smcabc_inference_on_linear_gaussian(
     elif prior_type == "uniform":
         prior = BoxUniform(-ones(num_dim), ones(num_dim))
         target_samples = samples_true_posterior_linear_gaussian_uniform_prior(
-            x_o[0], likelihood_shift, likelihood_cov, prior, num_samples,
+            x_o[0], likelihood_shift, likelihood_cov, prior, num_samples
         )
     else:
         raise ValueError("Wrong prior string.")

--- a/tests/inference_on_device_test.py
+++ b/tests/inference_on_device_test.py
@@ -17,26 +17,34 @@ from sbi.utils.torchutils import process_device
 @pytest.mark.slow
 @pytest.mark.gpu
 @pytest.mark.parametrize(
-    "method, model",
+    "method, model, mcmc_method",
     [
-        (SNPE_A, "mdn_snpe_a"),
-        (SNPE_C, "mdn"),
-        (SNPE_C, "maf"),
-        (SNLE, "maf"),
-        (SNLE, "nsf"),
-        (SNRE_A, "mlp"),
-        (SNRE_B, "resnet"),
+        (SNPE_C, "mdn", "rejection"),
+        (SNPE_C, "maf", "rejection"),
+        (SNLE, "maf", "slice"),
+        (SNLE, "nsf", "slice_np"),
+        (SNRE_A, "mlp", "slice_np_vectorized"),
+        (SNRE_B, "resnet", "nuts"),
     ],
 )
 @pytest.mark.parametrize("data_device", ("cpu", "cuda:0"))
-@pytest.mark.parametrize("training_device", ("cpu", "cuda:0"))
-def test_training_and_mcmc_on_device(method, model, data_device, training_device):
+@pytest.mark.parametrize(
+    "training_device, prior_device",
+    [
+        pytest.param("cpu", "cuda", marks=pytest.mark.xfail),
+        pytest.param("cuda:0", "cpu", marks=pytest.mark.xfail),
+        ("cuda:0", "cuda:0"),
+        ("cpu", "cpu"),
+    ],
+)
+def test_training_and_mcmc_on_device(
+    method, model, data_device, mcmc_method, training_device, prior_device
+):
     """Test training on devices.
 
     This test does not check training speeds.
 
     """
-    training_device = process_device(training_device)
 
     num_dim = 2
     num_samples = 10
@@ -44,41 +52,31 @@ def test_training_and_mcmc_on_device(method, model, data_device, training_device
     max_num_epochs = 5
 
     x_o = zeros(1, num_dim).to(data_device)
-    likelihood_shift = -1.0 * ones(num_dim)
-    likelihood_cov = 0.3 * eye(num_dim)
+    likelihood_shift = -1.0 * ones(num_dim).to(prior_device)
+    likelihood_cov = 0.3 * eye(num_dim).to(prior_device)
 
-    prior_mean = zeros(num_dim)
-    prior_cov = eye(num_dim)
+    prior_mean = zeros(num_dim).to(prior_device)
+    prior_cov = eye(num_dim).to(prior_device)
     prior = MultivariateNormal(loc=prior_mean, covariance_matrix=prior_cov)
 
     def simulator(theta):
         return linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
+    training_device = process_device(training_device, prior)
+
     if method in [SNPE_A, SNPE_C]:
-        kwargs = dict(
-            density_estimator=utils.posterior_nn(model=model),
-        )
+        kwargs = dict(density_estimator=utils.posterior_nn(model=model))
         mcmc_kwargs = (
-            dict(
-                sample_with="mcmc",
-                mcmc_method="slice_np",
-            )
+            dict(sample_with="rejection", mcmc_method=mcmc_method)
             if method == SNPE_C
             else {}
         )
     elif method == SNLE:
-        kwargs = dict(
-            density_estimator=utils.likelihood_nn(model=model),
-        )
-        mcmc_kwargs = dict(sample_with="mcmc", mcmc_method="slice")
+        kwargs = dict(density_estimator=utils.likelihood_nn(model=model))
+        mcmc_kwargs = dict(sample_with="mcmc", mcmc_method=mcmc_method)
     elif method in (SNRE_A, SNRE_B):
-        kwargs = dict(
-            classifier=utils.classifier_nn(model=model),
-        )
-        mcmc_kwargs = dict(
-            sample_with="mcmc",
-            mcmc_method="slice_np_vectorized",
-        )
+        kwargs = dict(classifier=utils.classifier_nn(model=model))
+        mcmc_kwargs = dict(sample_with="mcmc", mcmc_method=mcmc_method)
     else:
         raise ValueError()
 

--- a/tests/linearGaussian_snre_test.py
+++ b/tests/linearGaussian_snre_test.py
@@ -228,10 +228,19 @@ def test_c2st_sre_variants_on_linearGaussian(
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize("prior_str", ("gaussian", "uniform"))
 @pytest.mark.parametrize(
-    "sampling_method",
-    ("slice_np", "slice_np_vectorized", "slice", "nuts", "hmc", "rejection"),
+    "sampling_method, prior_str",
+    (
+        ("slice_np", "gaussian"),
+        ("slice_np", "uniform"),
+        ("slice_np_vectorized", "gaussian"),
+        ("slice_np_vectorized", "uniform"),
+        ("slice", "gaussian"),
+        ("slice", "uniform"),
+        ("nuts", "gaussian"),
+        ("nuts", "uniform"),
+        ("hmc", "gaussian"),
+    ),
 )
 def test_api_sre_sampling_methods(sampling_method: str, prior_str: str, set_seed):
     """Test leakage correction both for MCMC and rejection sampling.
@@ -244,8 +253,7 @@ def test_api_sre_sampling_methods(sampling_method: str, prior_str: str, set_seed
     num_dim = 2
     num_samples = 10
     num_trials = 2
-    # HMC with uniform prior needs good likelihood.
-    num_simulations = 10000 if sampling_method == "hmc" else 1000
+    num_simulations = 1000
     x_o = zeros((num_trials, num_dim))
     # Test for multiple chains is cheap when vectorized.
     num_chains = 3 if sampling_method == "slice_np_vectorized" else 1

--- a/tests/linearGaussian_snre_test.py
+++ b/tests/linearGaussian_snre_test.py
@@ -142,7 +142,7 @@ def test_c2st_sre_variants_on_linearGaussian(
 
     x_o = zeros(num_trials, num_dim)
     num_samples = 500
-    num_simulations = 2500 if num_trials == 1 else 35000
+    num_simulations = 2500 if num_trials == 1 else 40000
 
     # `likelihood_mean` will be `likelihood_shift + theta`.
     likelihood_shift = -1.0 * ones(num_dim)

--- a/tests/mcmc_test.py
+++ b/tests/mcmc_test.py
@@ -8,6 +8,8 @@ import pytest
 import torch
 from torch import eye, ones, zeros
 
+from sbi import utils
+from sbi.inference import SNLE, SNPE, SNRE, prepare_for_sbi, simulate_for_sbi
 from sbi.mcmc.slice_numpy import SliceSampler
 from sbi.mcmc.slice_numpy_vectorized import SliceSamplerVectorized
 from sbi.simulators.linear_gaussian import true_posterior_linear_gaussian_mvn_prior

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -516,7 +516,8 @@ def test_train_with_different_data_and_training_device(
 
     # simulator, prior = prepare_for_sbi(user_simulator, user_prior)
     prior_ = MultivariateNormal(
-        loc=torch.zeros(num_dim), covariance_matrix=torch.eye(num_dim)
+        loc=torch.zeros(num_dim).to(training_device),
+        covariance_matrix=torch.eye(num_dim).to(training_device),
     )
     simulator, prior = prepare_for_sbi(diagonal_linear_gaussian, prior_)
 


### PR DESCRIPTION
Relates to #515 

Up to now we assumed the prior live on the `cpu` and we moved samples to `.cpu()` whenever combining `log_probs` from the `prior` and the `net`. 

This PR now allows the prior to live on the `GPU`, and it `asserts` that the prior lives on the same device as the passed `device` for training

Pro: we don't need to move to `.cpu()` all the time
Con: 
- all the `numpy` based MCMC methods naturally happen on the `cpu`. when evaluating the `theta` on the prior, we now have to move it to the `prior` device (instead of doing `net.logprob(theta).cpu()`)
- now the user will get an `AssertionError` when the prior was not on initialised on the `device`. This was not the case before. **Alternatively**, we could introduce or deduce `prior_device` and take care of moving things around internally.  Any opinions on that? 

I haven't profiled it, but I think this way of doing it is faster than the old way because we move things less. And if we one day implement the vectorized MCMC in `torch`, we might get speed ups when running that on the GPU then. 

closes #515 