### PR TITLE
let abc return particles or kde, adapt tests.

### DIFF
--- a/sbi/types.py
+++ b/sbi/types.py
@@ -2,7 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 
-from typing import NewType, Sequence, Tuple, TypeVar, Union
+from typing import NewType, Optional, Sequence, Tuple, TypeVar, Union
 
 import numpy as np
 import torch
@@ -17,6 +17,13 @@ OneOrMore = Union[T, Sequence[T]]
 
 ScalarFloat = Union[torch.Tensor, float]
 
+transform_types = Optional[
+    Union[
+        torch.distributions.transforms.Transform,
+        torch.distributions.transforms.ComposeTransform,
+    ]
+]
+
 # Define alias types because otherwise, the documentation by mkdocs became very long and
 # made the website look ugly.
 TensorboardSummaryWriter = NewType("Writer", SummaryWriter)
@@ -29,4 +36,5 @@ __all__ = [
     "ScalarFloat",
     "TensorboardSummaryWriter",
     "TorchModule",
+    "transform_types",
 ]

--- a/sbi/utils/__init__.py
+++ b/sbi/utils/__init__.py
@@ -5,6 +5,7 @@ from sbi.utils.conditional_density import (
 )
 from sbi.utils.get_nn_models import classifier_nn, likelihood_nn, posterior_nn
 from sbi.utils.io import get_data_root, get_log_root, get_project_root
+from sbi.utils.kde import KDEWrapper, get_kde
 from sbi.utils.plot import conditional_pairplot, pairplot
 from sbi.utils.restriction_estimator import RestrictedPrior, RestrictionEstimator
 from sbi.utils.sbiutils import (
@@ -61,6 +62,7 @@ from sbi.utils.typechecks import (
 )
 from sbi.utils.user_input_checks import (
     check_estimator_arg,
+    process_x,
     test_posterior_net_for_multi_d_x,
     validate_theta_and_x,
 )

--- a/sbi/utils/kde.py
+++ b/sbi/utils/kde.py
@@ -1,0 +1,159 @@
+from typing import Optional, Union
+
+import numpy as np
+import torch
+from sklearn.model_selection import GridSearchCV
+from sklearn.neighbors import KernelDensity
+from torch import Tensor
+from torch.distributions.transforms import identity_transform
+
+from sbi.types import transform_types
+
+
+# The implementation of KDE was adapted from
+# https://github.com/sbi-benchmark/sbibm/blob/main/sbibm/utils/kde.py
+def get_kde(
+    samples: Tensor,
+    bandwidth: Union[float, str] = "cv",
+    transform: transform_types = None,
+    sample_weights: Optional[np.ndarray] = None,
+    num_cv_partitions: int = 20,
+    num_cv_repetitions: int = 5,
+) -> KernelDensity:
+    """Get KDE estimator with selected bandwidth.
+
+    Args:
+        samples: Samples to perfrom KDE on
+        bandwidth: Bandwidth method, 'silvermann' or 'scott' heuristics, or 'cv' for a
+            tailored cross validation to find the best bandwidth for passed samples.
+        transform: Optional transform applied before running kde.
+        sample_weights: Sample weights attached to the samples, used to perform weighted
+            KDE.
+        num_cv_partitions: number of partitions for cross validation
+        num_cv_repetitions: how many times to repeat the cross validation to zoom into
+            the hyperparameter grid.
+
+    References:
+    [1]: https://github.com/scikit-learn/scikit-learn/blob/
+         0303fca35e32add9d7346dcb2e0e697d4e68706f/sklearn/neighbors/kde.py
+    """
+    if transform is None or not transform:
+        transform = identity_transform
+    if isinstance(bandwidth, str):
+        assert bandwidth in ["cv", "scott", "silvermann"], "invalid kde bandwidth name."
+
+    transformed_samples = transform(samples).numpy()
+    num_samples, dim_samples = transformed_samples.shape
+
+    algorithm = "auto"
+    kernel = "gaussian"
+    metric = "euclidean"
+    atol = 0
+    rtol = 0
+    breadth_first = True
+    leaf_size = 40
+    metric_params = None
+
+    if bandwidth == "scott":
+        bandwidth_selected = num_samples ** (-1.0 / (dim_samples + 4))
+    elif bandwidth == "silvermann":
+        bandwidth_selected = (num_samples * (dim_samples + 2) / 4.0) ** (
+            -1.0 / (dim_samples + 4)
+        )
+    elif bandwidth == "cv":
+        _std = transformed_samples.std()
+        steps = 10
+        lower = 0.1 * _std
+        upper = 0.5 * _std
+        current_best = -10000000
+
+        # Run cv multiple times and to "zoom in" to better bandwidths.
+        for _ in range(num_cv_repetitions):
+            bandwidth_range = np.linspace(lower, upper, steps)
+            grid = GridSearchCV(
+                KernelDensity(
+                    kernel=kernel,
+                    algorithm=algorithm,
+                    metric=metric,
+                    atol=atol,
+                    rtol=rtol,
+                    breadth_first=breadth_first,
+                    leaf_size=leaf_size,
+                    metric_params=metric_params,
+                ),
+                {"bandwidth": bandwidth_range},
+                cv=num_cv_partitions,
+            )
+            grid.fit(transformed_samples)
+
+            # If new best score, update and zoom in.
+            if abs(current_best - grid.best_score_) > 0.001:
+                current_best = grid.best_score_
+            else:
+                break
+
+            second_best_index = list(grid.cv_results_["rank_test_score"]).index(2)
+
+            if (grid.best_index_ == 0) or (grid.best_index_ == steps):
+                diff = (lower - upper) / steps
+                lower = grid.best_index_ - diff
+                upper = grid.best_index_ + diff
+            else:
+                upper = bandwidth_range[second_best_index]
+                lower = bandwidth_range[grid.best_index_]
+
+                if upper < lower:
+                    upper, lower = lower, upper
+
+        bandwidth_selected = grid.best_params_["bandwidth"]
+    elif float(bandwidth) > 0:
+        bandwidth_selected = float(bandwidth)
+    else:
+        raise ValueError("bandwidth must be positive, 'scott', 'silvermann' or 'cv'")
+
+    # Run final fit with selected bandwidth.
+    kde = KernelDensity(
+        kernel=kernel,
+        algorithm=algorithm,
+        metric=metric,
+        atol=atol,
+        rtol=rtol,
+        breadth_first=breadth_first,
+        leaf_size=leaf_size,
+        metric_params=metric_params,
+        bandwidth=bandwidth_selected,
+    )
+    kde.fit(transformed_samples, sample_weight=sample_weights)
+
+    return KDEWrapper(kde, transform)
+
+
+class KDEWrapper:
+    """Wrapper class to enable sampling and evaluation with a kde object fitted on
+    transformed parameters.
+
+    Applies inverse transforms on samples and log abs det Jacobian on log prob.
+    """
+
+    def __init__(self, kde, transform):
+        self.kde = kde
+        self.transform = transform
+
+    def sample(self, *args, **kwargs):
+        Y = torch.from_numpy(self.kde.sample(*args, **kwargs).astype(np.float32))
+        return self.transform.inv(Y)
+
+    def log_prob(self, parameters_constrained):
+        parameters_unconstrained = self.transform(parameters_constrained)
+        log_probs = torch.from_numpy(
+            self.kde.score_samples(parameters_unconstrained.numpy()).astype(np.float32)
+        )
+        # Sum over event dimension of parameters returned by log abs det jacobian.
+        log_probs += self.transform.log_abs_det_jacobian(
+            parameters_constrained, parameters_unconstrained
+        )
+        assert (
+            log_probs.numel() == parameters_constrained.shape[0]
+        ), """batch shape mismatch, log_abs_det_jacobian not summing over event
+              dimensions?"""
+        return log_probs

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -11,9 +11,8 @@ import pyknos.nflows.transforms as transforms
 from pyro.distributions import Empirical
 from torch import Tensor, as_tensor, float32
 from torch import nn as nn
-from torch import ones, optim, zeros, sqrt, tensor
-from torch.distributions import Independent, biject_to
-from torch.distributions.distribution import Distribution
+from torch import ones, optim, zeros
+from torch.distributions import Distribution, Independent, biject_to
 import torch.distributions.transforms as torch_tf
 from tqdm.auto import tqdm
 

--- a/tests/abc_test.py
+++ b/tests/abc_test.py
@@ -1,8 +1,8 @@
 import pytest
 from torch import eye, ones, zeros
-from torch.distributions import MultivariateNormal
+from torch.distributions import MultivariateNormal, biject_to
 
-from sbi.inference import ABC, SMC
+from sbi.inference import MCABC, SMC
 from sbi.simulators.linear_gaussian import (
     linear_gaussian,
     samples_true_posterior_linear_gaussian_uniform_prior,
@@ -14,7 +14,12 @@ from tests.test_utils import check_c2st
 
 @pytest.mark.parametrize("num_dim", (1, 2))
 def test_mcabc_inference_on_linear_gaussian(
-    num_dim, lra=False, sass=False, sass_expansion_degree=1
+    num_dim,
+    lra=False,
+    sass=False,
+    sass_expansion_degree=1,
+    kde=False,
+    kde_bandwidth="cv",
 ):
     x_o = zeros((1, num_dim))
     num_samples = 1000
@@ -34,9 +39,9 @@ def test_mcabc_inference_on_linear_gaussian(
     def simulator(theta):
         return linear_gaussian(theta, likelihood_shift, likelihood_cov)
 
-    infer = ABC(simulator, prior, simulation_batch_size=10000)
+    inferer = MCABC(simulator, prior, simulation_batch_size=10000)
 
-    phat = infer(
+    phat = inferer(
         x_o,
         100000,
         quantile=0.01,
@@ -44,9 +49,16 @@ def test_mcabc_inference_on_linear_gaussian(
         sass=sass,
         sass_expansion_degree=sass_expansion_degree,
         sass_fraction=0.33,
+        kde=kde,
+        kde_kwargs=dict(bandwidth=kde_bandwidth),
+        return_summary=False,
     )
 
-    check_c2st(phat.sample((num_samples,)), target_samples, alg="MCABC")
+    check_c2st(
+        phat.sample((num_samples,)) if kde else phat,
+        target_samples,
+        alg=f"MCABC_lra{lra}_sass{sass}_kde{kde}_{kde_bandwidth}",
+    )
 
 
 @pytest.mark.slow
@@ -62,10 +74,18 @@ def test_mcabc_sass_lra(lra, sass_expansion_degree, set_seed):
 @pytest.mark.parametrize("num_dim", (1, 2))
 @pytest.mark.parametrize("prior_type", ("uniform", "gaussian"))
 def test_smcabc_inference_on_linear_gaussian(
-    num_dim, prior_type: str, lra=False, sass=False, sass_expansion_degree=1
+    num_dim,
+    prior_type: str,
+    lra=False,
+    sass=False,
+    sass_expansion_degree=1,
+    kde=False,
+    kde_bandwidth="cv",
+    transform=False,
 ):
     x_o = zeros((1, num_dim))
     num_samples = 1000
+    num_simulations = 100000
     likelihood_shift = -1.0 * ones(num_dim)
     likelihood_cov = 0.3 * eye(num_dim)
 
@@ -95,17 +115,29 @@ def test_smcabc_inference_on_linear_gaussian(
         num_particles=1000,
         num_initial_pop=5000,
         epsilon_decay=0.5,
-        num_simulations=110000,
+        num_simulations=num_simulations,
         distance_based_decay=True,
+        return_summary=False,
         lra=lra,
         sass=sass,
         sass_fraction=0.5,
         sass_expansion_degree=sass_expansion_degree,
+        kde=kde,
+        kde_kwargs=dict(
+            bandwidth=kde_bandwidth,
+            transform=biject_to(prior.support) if transform else None,
+        ),
     )
 
     check_c2st(
-        phat.sample((num_samples,)), target_samples, alg=f"SMCABC-{prior_type}-prior"
+        phat.sample((num_samples,)) if kde else phat,
+        target_samples,
+        alg=f"SMCABC-{prior_type}prior-lra{lra}-sass{sass}-kde{kde}-{kde_bandwidth}",
     )
+
+    if kde:
+        samples = phat.sample((10,))
+        phat.log_prob(samples)
 
 
 @pytest.mark.slow
@@ -119,4 +151,25 @@ def test_smcabc_sass_lra(lra, sass_expansion_degree, set_seed):
         sass=True,
         sass_expansion_degree=sass_expansion_degree,
         prior_type="gaussian",
+    )
+
+
+@pytest.mark.parametrize("kde_bandwidth", ("cv", "silvermann", "scott", 0.1))
+def test_mcabc_kde(kde_bandwidth, set_seed):
+    test_mcabc_inference_on_linear_gaussian(
+        num_dim=2, kde=True, kde_bandwidth=kde_bandwidth
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("kde_bandwidth", ("cv",))
+def test_smcabc_kde(kde_bandwidth, set_seed):
+    test_smcabc_inference_on_linear_gaussian(
+        num_dim=2,
+        lra=False,
+        sass=False,
+        prior_type="uniform",
+        kde=True,
+        kde_bandwidth=kde_bandwidth,
+        transform=True,
     )


### PR DESCRIPTION
see #523 for details. 

`ABC` methods now return either the final set of accepted particles (and a summary `dict` containing the corresponding distances, data and weights), or a KDE object fitted on those particles (and the summary `dict`). The KDE object can be used for sampling and evaluating the approximate posterior. 

closes #523 