### PR TITLE
improve docs for device handling.

### DIFF
--- a/sbi/inference/posteriors/base_posterior.py
+++ b/sbi/inference/posteriors/base_posterior.py
@@ -37,6 +37,7 @@ from sbi.utils.torchutils import (
     ScalarFloat,
     atleast_2d_float32_tensor,
     ensure_theta_batched,
+    process_device,
 )
 from sbi.utils.user_input_checks import check_for_possibly_batched_x_shape, process_x
 
@@ -91,12 +92,16 @@ class NeuralPosterior(ABC):
                 `potential_fn / proposal` ratio. `num_iter_to_find_max` as the number
                 of gradient ascent iterations to find the maximum of that ratio. `m` as
                 multiplier to that ratio.
-            device: Training device, e.g., cpu or cuda.
+            device: Training device, e.g., "cpu", "gpu" or "cuda:0". Defaults to "cuda"
+                when "gpu" is passed.
         """
         if method_family in ("snpe", "snle", "snre_a", "snre_b"):
             self._method_family = method_family
         else:
             raise ValueError(f"Method family '{method_family}' unsupported.")
+
+        # Ensure device string.
+        device = process_device(device)
 
         self.net = neural_net
 
@@ -112,6 +117,7 @@ class NeuralPosterior(ABC):
         self._x = None
         self._num_iid_trials = None
         self._x_shape = x_shape
+
         self._device = device
         # Methods capable of handling iid xo.
         self._iid_methods = ["snle", "snre_a", "snre_b"]

--- a/sbi/inference/posteriors/likelihood_based_posterior.py
+++ b/sbi/inference/posteriors/likelihood_based_posterior.py
@@ -72,7 +72,8 @@ class LikelihoodBasedPosterior(NeuralPosterior):
                 `potential_fn / proposal` ratio. `num_iter_to_find_max` as the number
                 of gradient ascent iterations to find the maximum of that ratio. `m` as
                 multiplier to that ratio.
-            device: Training device, e.g., cpu or cuda:0.
+            device: Training device, e.g., "cpu", "gpu" or "cuda:0". Defaults to "cuda"
+                when "gpu" is passed.
         """
 
         kwargs = del_entries(locals(), entries=("self", "__class__"))

--- a/sbi/inference/posteriors/ratio_based_posterior.py
+++ b/sbi/inference/posteriors/ratio_based_posterior.py
@@ -76,7 +76,8 @@ class RatioBasedPosterior(NeuralPosterior):
                 `potential_fn / proposal` ratio. `num_iter_to_find_max` as the number
                 of gradient ascent iterations to find the maximum of that ratio. `m` as
                 multiplier to that ratio.
-            device: Training device, e.g., cpu or cuda:0.
+            device: Training device, e.g., "cpu", "gpu" or "cuda:0". Defaults to "cuda"
+                when "gpu" is passed.
         """
         kwargs = del_entries(locals(), entries=("self", "__class__"))
         super().__init__(**kwargs)

--- a/sbi/inference/snle/snle_a.py
+++ b/sbi/inference/snle/snle_a.py
@@ -40,7 +40,8 @@ class SNLE_A(LikelihoodEstimator):
                 needs to return a PyTorch `nn.Module` implementing the density
                 estimator. The density estimator needs to provide the methods
                 `.log_prob` and `.sample()`.
-            device: torch device on which to compute, e.g. gpu, cpu.
+            device: Training device, e.g., "cpu", "gpu" or "cuda:0". Defaults to "cuda"
+                when "gpu" is passed.
             logging_level: Minimum severity of messages to log. One of the strings
                 INFO, WARNING, DEBUG, ERROR and CRITICAL.
             summary_writer: A tensorboard `SummaryWriter` to control, among others, log

--- a/sbi/inference/snpe/snpe_a.py
+++ b/sbi/inference/snpe/snpe_a.py
@@ -67,7 +67,8 @@ class SNPE_A(PosteriorEstimator):
             num_components: Number of components of the mixture of Gaussians in the
                 last round. This overrides the `num_components` value passed to
                 `posterior_nn()`.
-            device: torch device on which to compute, e.g. gpu, cpu.
+            device: Training device, e.g., "cpu", "gpu" or "cuda:0". Defaults to "cuda"
+                when "gpu" is passed.
             logging_level: Minimum severity of messages to log. One of the strings
                 INFO, WARNING, DEBUG, ERROR and CRITICAL.
             summary_writer: A tensorboard `SummaryWriter` to control, among others, log

--- a/sbi/inference/snpe/snpe_c.py
+++ b/sbi/inference/snpe/snpe_c.py
@@ -75,7 +75,8 @@ class SNPE_C(PosteriorEstimator):
                 needs to return a PyTorch `nn.Module` implementing the density
                 estimator. The density estimator needs to provide the methods
                 `.log_prob` and `.sample()`.
-            device: torch device on which to compute, e.g. gpu, cpu.
+            device: Training device, e.g., "cpu", "gpu" or "cuda:0". Defaults to "cuda"
+                when "gpu" is passed.
             logging_level: Minimum severity of messages to log. One of the strings
                 INFO, WARNING, DEBUG, ERROR and CRITICAL.
             summary_writer: A tensorboard `SummaryWriter` to control, among others, log

--- a/sbi/inference/snre/snre_a.py
+++ b/sbi/inference/snre/snre_a.py
@@ -37,7 +37,8 @@ class SNRE_A(RatioEstimator):
                 first batch of simulations (theta, x), which can thus be used for shape
                 inference and potentially for z-scoring. It needs to return a PyTorch
                 `nn.Module` implementing the classifier.
-            device: torch device on which to compute, e.g. gpu, cpu.
+            device: Training device, e.g., "cpu", "gpu" or "cuda:0". Defaults to "cuda"
+                when "gpu" is passed.
             logging_level: Minimum severity of messages to log. One of the strings
                 INFO, WARNING, DEBUG, ERROR and CRITICAL.
             summary_writer: A tensorboard `SummaryWriter` to control, among others, log

--- a/sbi/inference/snre/snre_b.py
+++ b/sbi/inference/snre/snre_b.py
@@ -37,7 +37,8 @@ class SNRE_B(RatioEstimator):
                 first batch of simulations (theta, x), which can thus be used for shape
                 inference and potentially for z-scoring. It needs to return a PyTorch
                 `nn.Module` implementing the classifier.
-            device: torch device on which to compute, e.g. gpu, cpu.
+            device: Training device, e.g., "cpu", "gpu" or "cuda:0". Defaults to "cuda"
+                when "gpu" is passed.
             logging_level: Minimum severity of messages to log. One of the strings
                 INFO, WARNING, DEBUG, ERROR and CRITICAL.
             summary_writer: A tensorboard `SummaryWriter` to control, among others, log

--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -16,12 +16,15 @@ from sbi.types import Array, OneOrMore, ScalarFloat
 
 
 def process_device(device: str, prior: Optional[Any] = None) -> str:
-    """Set and return the default device to cpu or gpu.
+    """Set and return the default device to cpu or cuda.
 
     Throws an AssertionError if the prior is not matching the training device not.
     """
 
     if not device == "cpu":
+        assert device == "gpu" or device.startswith(
+            "cuda"
+        ), f"Invalid device string: {device}."
         if device == "gpu":
             device = "cuda"
         try:


### PR DESCRIPTION
ensure the device string is `"cpu"` or `"cuda{:*}"` and change docstrings accordingly. 

see #533 