### PR TITLE
Refactor nsf

### DIFF
--- a/sbi/neural_nets/flow.py
+++ b/sbi/neural_nets/flow.py
@@ -2,6 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 
+from functools import partial
 from warnings import warn
 
 from pyknos.nflows import distributions as distributions_
@@ -107,34 +108,32 @@ def build_maf(
     if x_numel == 1:
         warn(f"In one-dimensional output space, this flow is limited to Gaussians")
 
-    transform = transforms.CompositeTransform(
-        [
-            transforms.CompositeTransform(
-                [
-                    transforms.MaskedAffineAutoregressiveTransform(
-                        features=x_numel,
-                        hidden_features=hidden_features,
-                        context_features=y_numel,
-                        num_blocks=2,
-                        use_residual_blocks=False,
-                        random_mask=False,
-                        activation=tanh,
-                        dropout_probability=0.0,
-                        use_batch_norm=True,
-                    ),
-                    transforms.RandomPermutation(features=x_numel),
-                ]
-            )
-            for _ in range(num_transforms)
+    transform_list = []
+    for _ in range(num_transforms):
+        block = [
+            transforms.MaskedAffineAutoregressiveTransform(
+                features=x_numel,
+                hidden_features=hidden_features,
+                context_features=y_numel,
+                num_blocks=2,
+                use_residual_blocks=False,
+                random_mask=False,
+                activation=tanh,
+                dropout_probability=0.0,
+                use_batch_norm=True,
+            ),
+            transforms.RandomPermutation(features=x_numel),
         ]
-    )
+        transform_list += block
 
     if z_score_x:
-        transform_zx = standardizing_transform(batch_x)
-        transform = transforms.CompositeTransform([transform_zx, transform])
+        transform_list = [standardizing_transform(batch_x)] + transform_list
 
     if z_score_y:
         embedding_net = nn.Sequential(standardizing_net(batch_y), embedding_net)
+
+    # Combine transforms.
+    transform = transforms.CompositeTransform(transform_list)
 
     distribution = distributions_.StandardNormal((x_numel,))
     neural_net = flows.Flow(transform, distribution, embedding_net)
@@ -151,6 +150,8 @@ def build_nsf(
     num_transforms: int = 5,
     num_bins: int = 10,
     embedding_net: nn.Module = nn.Identity(),
+    tail_bound: float = 3.0,
+    hidden_layers_spline_context: int = 1,
     **kwargs,
 ) -> nn.Module:
     """Builds NSF p(x|y).
@@ -174,87 +175,30 @@ def build_nsf(
     # Infer the output dimensionality of the embedding_net by making a forward pass.
     y_numel = embedding_net(batch_y[:1]).numel()
 
+    # If x is just a scalar then use a dummy mask and learn spline parameters using the
+    # conditioning variables only.
     if x_numel == 1:
 
-        class ContextSplineMap(nn.Module):
-            """
-            Neural network from `context` to the spline parameters.
+        # Define dummy mask because there is only one dimension.
+        def mask_in_layer(_):
+            return tensor([1], dtype=uint8)
 
-            We cannot use the resnet as conditioner to learn each dimension conditioned
-            on the other dimensions (because there is only one). Instead, we learn the
-            spline parameters directly. In the case of conditinal density estimation,
-            we make the spline parameters conditional on the context. This is
-            implemented in this class.
-            """
-
-            def __init__(
-                self,
-                in_features: int,
-                out_features: int,
-                hidden_features: int,
-                context_features: int,
-            ):
-                """
-                Initialize neural network that learns to predict spline parameters.
-
-                Args:
-                    in_features: Unused since there is no `conditioner` in 1D.
-                    out_features: Number of spline parameters.
-                    hidden_features: Number of hidden units.
-                    context_features: Number of context features.
-                """
-                super().__init__()
-                # `self.hidden_features` is only defined such that nflows can infer
-                # a scaling factor for initializations.
-                self.hidden_features = hidden_features
-
-                # Use a non-linearity because otherwise, there will be a linear
-                # mapping from context features onto distribution parameters.
-                self.spline_predictor = nn.Sequential(
-                    nn.Linear(context_features, self.hidden_features),
-                    nn.ReLU(),
-                    nn.Linear(self.hidden_features, self.hidden_features),
-                    nn.ReLU(),
-                    nn.Linear(self.hidden_features, out_features),
-                )
-
-            def __call__(
-                self, inputs: Tensor, context: Tensor, *args, **kwargs
-            ) -> Tensor:
-                """
-                Return parameters of the spline given the context.
-
-                Args:
-                    inputs: Unused. It would usually be the other dimensions, but in
-                        1D, there are no other dimensions.
-                    context: Context features.
-
-                Returns:
-                    Spline parameters.
-                """
-                return self.spline_predictor(context)
-
-        mask_in_layer = lambda i: tensor([1], dtype=uint8)
-        conditioner = lambda in_features, out_features: ContextSplineMap(
-            in_features, out_features, hidden_features, context_features=y_numel
+        # Conditioner ignores the data and uses the conditioning variables only.
+        conditioner = partial(
+            ContextSplineMap,
+            hidden_features=hidden_features,
+            context_features=y_numel,
+            hidden_layers=hidden_layers_spline_context,
         )
-        if num_transforms > 1:
-            warn(
-                f"You are using `num_transforms={num_transforms}`. When estimating a "
-                f"1D density, you will not get any performance increase by using "
-                f"multiple transforms with NSF. We recommend setting "
-                f"`num_transforms=1` for faster training (see also 'Change "
-                f"hyperparameters of density esitmators' here: "
-                f"https://www.mackelab.org/sbi/tutorial/04_density_estimators/)."
-            )
 
     else:
-        mask_in_layer = lambda i: create_alternating_binary_mask(
-            features=x_numel, even=(i % 2 == 0)
-        )
-        conditioner = lambda in_features, out_features: nets.ResidualNet(
-            in_features=in_features,
-            out_features=out_features,
+        # Define mask function to alternate between predicted x-dimensions.
+        def mask_in_layer(i):
+            return create_alternating_binary_mask(features=x_numel, even=(i % 2 == 0))
+
+        # Use conditional resnet as spline conditioner.
+        conditioner = partial(
+            nets.ResidualNet,
             hidden_features=hidden_features,
             context_features=y_numel,
             num_blocks=2,
@@ -263,33 +207,100 @@ def build_nsf(
             use_batch_norm=False,
         )
 
-    transform = transforms.CompositeTransform(
-        [
-            transforms.CompositeTransform(
-                [
-                    transforms.PiecewiseRationalQuadraticCouplingTransform(
-                        mask=mask_in_layer(i),
-                        transform_net_create_fn=conditioner,
-                        num_bins=num_bins,
-                        tails="linear",
-                        tail_bound=3.0,
-                        apply_unconditional_transform=False,
-                    ),
-                    transforms.LULinear(x_numel, identity_init=True),
-                ]
+    # Stack spline transforms.
+    transform_list = []
+    for i in range(num_transforms):
+        block = [
+            transforms.PiecewiseRationalQuadraticCouplingTransform(
+                mask=mask_in_layer(i),
+                transform_net_create_fn=conditioner,
+                num_bins=num_bins,
+                tails="linear",
+                tail_bound=tail_bound,
+                apply_unconditional_transform=False,
             )
-            for i in range(num_transforms)
         ]
-    )
+        # Add LU transform only for high D x. Permutation makes sense only for more than
+        # one feature.
+        if x_numel > 1:
+            block.append(
+                transforms.LULinear(x_numel, identity_init=True),
+            )
+        transform_list += block
 
     if z_score_x:
-        transform_zx = standardizing_transform(batch_x)
-        transform = transforms.CompositeTransform([transform_zx, transform])
-
+        # Prepend standardizing transform to nsf transforms.
+        transform_list = [standardizing_transform(batch_x)] + transform_list
     if z_score_y:
+        # Prepend standardizing transform to y-embedding.
         embedding_net = nn.Sequential(standardizing_net(batch_y), embedding_net)
 
     distribution = distributions_.StandardNormal((x_numel,))
+
+    # Combine transforms.
+    transform = transforms.CompositeTransform(transform_list)
     neural_net = flows.Flow(transform, distribution, embedding_net)
 
     return neural_net
+
+
+class ContextSplineMap(nn.Module):
+    """
+    Neural network from `context` to the spline parameters.
+
+    We cannot use the resnet as conditioner to learn each dimension conditioned
+    on the other dimensions (because there is only one). Instead, we learn the
+    spline parameters directly. In the case of conditinal density estimation,
+    we make the spline parameters conditional on the context. This is
+    implemented in this class.
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        hidden_features: int,
+        context_features: int,
+        hidden_layers: int,
+    ):
+        """
+        Initialize neural network that learns to predict spline parameters.
+
+        Args:
+            in_features: Unused since there is no `conditioner` in 1D.
+            out_features: Number of spline parameters.
+            hidden_features: Number of hidden units.
+            context_features: Number of context features.
+        """
+        super().__init__()
+        # `self.hidden_features` is only defined such that nflows can infer
+        # a scaling factor for initializations.
+        self.hidden_features = hidden_features
+
+        # Use a non-linearity because otherwise, there will be a linear
+        # mapping from context features onto distribution parameters.
+
+        # Initialize with input layer.
+        layer_list = [nn.Linear(context_features, hidden_features), nn.ReLU()]
+        # Add hidden layers.
+        layer_list += [
+            nn.Linear(hidden_features, hidden_features),
+            nn.ReLU(),
+        ] * hidden_layers
+        # Add output layer.
+        layer_list += [nn.Linear(hidden_features, out_features)]
+        self.spline_predictor = nn.Sequential(*layer_list)
+
+    def __call__(self, inputs: Tensor, context: Tensor, *args, **kwargs) -> Tensor:
+        """
+        Return parameters of the spline given the context.
+
+        Args:
+            inputs: Unused. It would usually be the other dimensions, but in
+                1D, there are no other dimensions.
+            context: Context features.
+
+        Returns:
+            Spline parameters.
+        """
+        return self.spline_predictor(context)

--- a/tutorials/11_sampler_interface.ipynb
+++ b/tutorials/11_sampler_interface.ipynb
@@ -125,7 +125,7 @@
    "source": [
     "from sbi.inference import MCMCPosterior, RejectionPosterior\n",
     "\n",
-    "posterior = MCMCPosterior(potential_fn, proposal=prior, parameter_transform=parameter_transform)\n",
+    "posterior = MCMCPosterior(potential_fn, proposal=prior, theta_transform=parameter_transform)\n",
     "posterior = RejectionPosterior(potential_fn, proposal=prior)"
    ]
   },


### PR DESCRIPTION
refactoring the usage of `nsf`. Importantly, in case of a one-dimensional `x` we are currently warning that in this case it wouldn't help to have more than one transform. 
However, I think it still makes sense to have multiple transforms. In this case the spline parameters are learned from the conditioning variables only, because there is no "other" dimension in `x` to learn from. But we can still use multiple transforms to stack conditioners and get more flexibility. 

Maybe I am missing something here? But in my current view this makes sense and we should remove the warning. 
