### PR TITLE
Fix device string handling if density estimator is provided

### DIFF
--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -311,7 +311,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
             device = self._device
         else:
             # Otherwise, infer it from the device of the net parameters.
-            device = next(density_estimator.parameters()).device
+            device = str(next(density_estimator.parameters()).device)
 
         self._posterior = LikelihoodBasedPosterior(
             method_family="snle",

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -311,7 +311,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
             device = self._device
         else:
             # Otherwise, infer it from the device of the net parameters.
-            device = str(next(density_estimator.parameters()).device)
+            device = next(density_estimator.parameters()).device.type
 
         self._posterior = LikelihoodBasedPosterior(
             method_family="snle",

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -414,7 +414,7 @@ class PosteriorEstimator(NeuralInference, ABC):
             device = self._device
         else:
             # Otherwise, infer it from the device of the net parameters.
-            device = next(density_estimator.parameters()).device
+            device = str(next(density_estimator.parameters()).device)
 
         self._posterior = DirectPosterior(
             method_family="snpe",

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -414,7 +414,7 @@ class PosteriorEstimator(NeuralInference, ABC):
             device = self._device
         else:
             # Otherwise, infer it from the device of the net parameters.
-            device = str(next(density_estimator.parameters()).device)
+            device = next(density_estimator.parameters()).device.type
 
         self._posterior = DirectPosterior(
             method_family="snpe",

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -322,7 +322,7 @@ class RatioEstimator(NeuralInference, ABC):
             device = self._device
         else:
             # Otherwise, infer it from the device of the net parameters.
-            device = next(density_estimator.parameters()).device
+            device = str(next(density_estimator.parameters()).device)
 
         self._posterior = RatioBasedPosterior(
             method_family=self.__class__.__name__.lower(),

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -322,7 +322,7 @@ class RatioEstimator(NeuralInference, ABC):
             device = self._device
         else:
             # Otherwise, infer it from the device of the net parameters.
-            device = str(next(density_estimator.parameters()).device)
+            device = next(density_estimator.parameters()).device.type
 
         self._posterior = RatioBasedPosterior(
             method_family=self.__class__.__name__.lower(),


### PR DESCRIPTION
When passing a custom density estimator to the build_posterior function of SNPE, I ran into **AttributeError: 'torch.device' object has no attribute 'startswith'** (see traceback below).

This seems to be caused by the else case of `build_posterior( )` in snpe_base.py, snle_base.py and snre_base.py, where the device is determined from the density estimator's parameters and becomes a torch.device object instead of a string. Finally, `process_device(device, prior)` in torchutils.py causes an assertion error, as `startswith()` is a string-specific function.

The error can be reproduced by running https://github.com/mackelab/sbi/blob/main/tutorials/02_flexible_interface.ipynb with either SNPE, SNLE or SNRE. 

I fixed it by converting the torch.device object into a string.

```
AttributeError: 'torch.device' object has no attribute 'startswith'
AttributeError                            Traceback (most recent call last)
/var/folders/g9/ps2dx93s41sdk_s71jljg5gr0000gn/T/ipykernel_3374/3387236704.py in <module>
----> 1 posterior = inference.build_posterior(density_estimator)

~/sbi/sbi/inference/snre/snre_base.py in build_posterior(self, density_estimator, sample_with, mcmc_method, mcmc_parameters, rejection_sampling_parameters)
    334             mcmc_parameters=mcmc_parameters,
    335             rejection_sampling_parameters=rejection_sampling_parameters,
--> 336             device=device,
    337         )
    338 

~/sbi/sbi/inference/posteriors/ratio_based_posterior.py in __init__(self, method_family, neural_net, prior, x_shape, sample_with, mcmc_method, mcmc_parameters, rejection_sampling_parameters, device)
     80         """
     81         kwargs = del_entries(locals(), entries=("self", "__class__"))
---> 82         super().__init__(**kwargs)
     83 
     84     def log_prob(

~/sbi/sbi/inference/posteriors/base_posterior.py in __init__(self, method_family, neural_net, prior, x_shape, sample_with, 
mcmc_method, mcmc_parameters, rejection_sampling_parameters, device)
    101 
    102         # Ensure device string.
--> 103         device = process_device(device)
    104 
    105         self.net = neural_net

~/sbi/sbi/utils/torchutils.py in process_device(device, prior)
     23 
     24     if not device == "cpu":
---> 25         assert device.startswith("cuda"), f"Invalid device string: {device}."
     26         try:
     27             torch.zeros(1).to(device)

AttributeError: 'torch.device' object has no attribute 'startswith'
```
