### PR TITLE
use independent transform to wrap event dims. formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.17.2
+
+## Minor changes
+- bug fix for transforms in KDE (#552)
+
 # v0.17.1
 
 ## Minor changes

--- a/sbi/__version__.py
+++ b/sbi/__version__.py
@@ -1,6 +1,6 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
-VERSION = (0, 17, 1)
+VERSION = (0, 17, 2)
 
 __version__ = ".".join(map(str, VERSION))

--- a/sbi/inference/abc/smcabc.py
+++ b/sbi/inference/abc/smcabc.py
@@ -149,7 +149,7 @@ class SMCABC(ABCBASE):
                 'sample_weights': weights associated with samples. See 'get_kde' for
                 more details
             kde_sample_weights: Whether perform weighted KDE with SMC weights or on raw
-                particles. 
+                particles.
             return_summary: Whether to return a dictionary with all accepted particles,
                 weights, etc. at the end.
 

--- a/sbi/utils/kde.py
+++ b/sbi/utils/kde.py
@@ -5,7 +5,7 @@ import torch
 from sklearn.model_selection import GridSearchCV
 from sklearn.neighbors import KernelDensity
 from torch import Tensor
-from torch.distributions.transforms import identity_transform
+from torch.distributions.transforms import IndependentTransform, identity_transform
 
 from sbi.types import transform_types
 
@@ -30,7 +30,6 @@ class KDEWrapper:
         log_probs = torch.from_numpy(
             self.kde.score_samples(parameters_unconstrained.numpy()).astype(np.float32)
         )
-        # Sum over event dimension of parameters returned by log abs det jacobian.
         log_probs += self.transform.log_abs_det_jacobian(
             parameters_constrained, parameters_unconstrained
         )
@@ -46,7 +45,7 @@ class KDEWrapper:
 def get_kde(
     samples: Tensor,
     bandwidth: Union[float, str] = "cv",
-    transform: transform_types = None,
+    transform: transform_types = identity_transform,
     sample_weights: Optional[np.ndarray] = None,
     num_cv_partitions: int = 20,
     num_cv_repetitions: int = 5,
@@ -68,8 +67,11 @@ def get_kde(
     [1]: https://github.com/scikit-learn/scikit-learn/blob/
          0303fca35e32add9d7346dcb2e0e697d4e68706f/sklearn/neighbors/kde.py
     """
-    if transform is None or not transform:
+    if not transform:
         transform = identity_transform
+    # Make sure transform has event dimension and returns scalar log_prob.
+    if transform.event_dim == 0:
+        transform = IndependentTransform(transform, reinterpreted_batch_ndims=1)
     if isinstance(bandwidth, str):
         assert bandwidth in ["cv", "scott", "silvermann"], "invalid kde bandwidth name."
 

--- a/tests/abc_test.py
+++ b/tests/abc_test.py
@@ -151,7 +151,7 @@ def test_smcabc_sass_lra(lra, sass_expansion_degree, set_seed):
         sass=True,
         sass_expansion_degree=sass_expansion_degree,
         prior_type="gaussian",
-        num_simulations=120000
+        num_simulations=120000,
     )
 
 


### PR DESCRIPTION
TL;DL always wrap with transforms as `IndependentTransform` to have parameter dimension as event dimension. 

transforms need an event dimensions such that when `log_prob` is called with a tensor shaped `(batch, parameter_dims)` a tensor shaped `(batch,)` is returned, instead of a tensor with a log_prob for every parameter dimension separately. 

To do this we need to wrap the transforms with `IndependentTransform` to reinterpret the batch dim as event dim (like it is done for the `BoxUniform` prior). 

This was not happening for the default case in `get_kde` where no transform is passed and an `identity_transform` is used. 