### PR TITLE
Fix for rejection sampling

### DIFF
--- a/sbi/inference/posteriors/direct_posterior.py
+++ b/sbi/inference/posteriors/direct_posterior.py
@@ -668,7 +668,7 @@ class PotentialFunctionProvider:
         posterior_nn: nn.Module,
         x: Tensor,
         method: str,
-        transform: torch_tf.Transform = torch_tf.identity_transform,
+        transform: Optional[torch_tf.Transform] = None,
     ) -> Callable:
         """Return potential function.
 
@@ -678,7 +678,12 @@ class PotentialFunctionProvider:
         self.prior = prior
         self.device = next(posterior_nn.parameters()).device
         self.x = atleast_2d(x).to(self.device)
-        self.transform = transform
+        if transform is None:
+            self.transform = torch_tf.IndependentTransform(
+                torch_tf.identity_transform, reinterpreted_batch_ndims=1
+            )
+        else:
+            self.transform = transform
 
         if method == "slice":
             return partial(self.pyro_potential, track_gradients=False)

--- a/sbi/inference/posteriors/likelihood_based_posterior.py
+++ b/sbi/inference/posteriors/likelihood_based_posterior.py
@@ -445,7 +445,7 @@ class PotentialFunctionProvider:
         likelihood_nn: nn.Module,
         x: Tensor,
         method: str,
-        transform: torch_tf.Transform = torch_tf.identity_transform,
+        transform: Optional[torch_tf.Transform] = None,
     ) -> Callable:
         r"""Return potential function for posterior $p(\theta|x)$.
 
@@ -465,7 +465,12 @@ class PotentialFunctionProvider:
         self.prior = prior
         self.device = next(likelihood_nn.parameters()).device
         self.x = atleast_2d(x).to(self.device)
-        self.transform = transform
+        if transform is None:
+            self.transform = torch_tf.IndependentTransform(
+                torch_tf.identity_transform, reinterpreted_batch_ndims=1
+            )
+        else:
+            self.transform = transform
 
         if method == "slice":
             return partial(self.pyro_potential, track_gradients=False)

--- a/sbi/inference/posteriors/ratio_based_posterior.py
+++ b/sbi/inference/posteriors/ratio_based_posterior.py
@@ -473,7 +473,7 @@ class PotentialFunctionProvider:
         classifier: nn.Module,
         x: Tensor,
         method: str,
-        transform: torch_tf.Transform = torch_tf.identity_transform,
+        transform: Optional[torch_tf.Transform] = None,
     ) -> Callable:
         r"""Return potential function for posterior $p(\theta|x)$.
 
@@ -494,7 +494,12 @@ class PotentialFunctionProvider:
         self.prior = prior
         self.device = next(classifier.parameters()).device
         self.x = atleast_2d(x).to(self.device)
-        self.transform = transform
+        if transform is None:
+            self.transform = torch_tf.IndependentTransform(
+                torch_tf.identity_transform, reinterpreted_batch_ndims=1
+            )
+        else:
+            self.transform = transform
 
         if method == "slice":
             return partial(self.pyro_potential, track_gradients=False)

--- a/tests/linearGaussian_snle_test.py
+++ b/tests/linearGaussian_snle_test.py
@@ -256,6 +256,8 @@ def test_c2st_multi_round_snl_on_linearGaussian(num_trials: int, set_seed):
         ("nuts", "gaussian"),
         ("nuts", "uniform"),
         ("hmc", "gaussian"),
+        ("rejection", "uniform"),
+        ("rejection", "gaussian"),
     ),
 )
 @pytest.mark.parametrize("init_strategy", ("prior", "sir"))

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -329,13 +329,7 @@ def test_api_snpe_c_posterior_correction(sample_with, mcmc_method, prior_str, se
     simulator, prior = prepare_for_sbi(
         lambda theta: linear_gaussian(theta, likelihood_shift, likelihood_cov), prior
     )
-    inference = SNPE_C(
-        prior,
-        simulation_batch_size=50,
-        sample_with=sample_with,
-        mcmc_method=mcmc_method,
-        show_progress_bars=False,
-    )
+    inference = SNPE_C(prior, show_progress_bars=False)
 
     theta, x = simulate_for_sbi(simulator, prior, 1000)
     _ = inference.append_simulations(theta, x).train(max_num_epochs=5)

--- a/tests/linearGaussian_snre_test.py
+++ b/tests/linearGaussian_snre_test.py
@@ -240,6 +240,8 @@ def test_c2st_sre_variants_on_linearGaussian(
         ("nuts", "gaussian"),
         ("nuts", "uniform"),
         ("hmc", "gaussian"),
+        ("rejection", "uniform"),
+        ("rejection", "gaussian"),
     ),
 )
 def test_api_sre_sampling_methods(sampling_method: str, prior_str: str, set_seed):


### PR DESCRIPTION
The `transforms` to unconstrained space used in MCMC broke the rejection sampler. We did not realize because there were no rejection sampling tests due to a bug. This PR
- fixes the bug
- adds rejection sampling API tests