### PR TITLE
added z-scoring method for structured data (e.g., time series)

### DIFF
--- a/sbi/analysis/plot.py
+++ b/sbi/analysis/plot.py
@@ -903,7 +903,6 @@ def _arrange_plots(
             y0, y1 = ax.get_ylim()
             text_kwargs = {"fontsize": plt.rcParams["font.size"] * 2.0}
             ax.text(x1 + (x1 - x0) / 8.0, (y0 + y1) / 2.0, "...", **text_kwargs)
-<<<<<<< HEAD:sbi/analysis/plot.py
         else:
             for row in range(len(subset)):
                 ax = axes[row, len(subset) - 1]
@@ -919,16 +918,6 @@ def _arrange_plots(
                         rotation=-45,
                         **text_kwargs,
                     )
-=======
-            if row == len(subset) - 1:
-                ax.text(
-                    x1 + (x1 - x0) / 12.0,
-                    y0 - (y1 - y0) / 1.5,
-                    "...",
-                    rotation=-45,
-                    **text_kwargs,
-                )
->>>>>>> sbiutils.standardizing_net now takes flag whether to z-score data with structured or independent dimensions:sbi/utils/plot.py
 
     return fig, axes
 

--- a/sbi/analysis/plot.py
+++ b/sbi/analysis/plot.py
@@ -903,6 +903,7 @@ def _arrange_plots(
             y0, y1 = ax.get_ylim()
             text_kwargs = {"fontsize": plt.rcParams["font.size"] * 2.0}
             ax.text(x1 + (x1 - x0) / 8.0, (y0 + y1) / 2.0, "...", **text_kwargs)
+<<<<<<< HEAD:sbi/analysis/plot.py
         else:
             for row in range(len(subset)):
                 ax = axes[row, len(subset) - 1]
@@ -918,6 +919,16 @@ def _arrange_plots(
                         rotation=-45,
                         **text_kwargs,
                     )
+=======
+            if row == len(subset) - 1:
+                ax.text(
+                    x1 + (x1 - x0) / 12.0,
+                    y0 - (y1 - y0) / 1.5,
+                    "...",
+                    rotation=-45,
+                    **text_kwargs,
+                )
+>>>>>>> sbiutils.standardizing_net now takes flag whether to z-score data with structured or independent dimensions:sbi/utils/plot.py
 
     return fig, axes
 

--- a/sbi/neural_nets/classifier.py
+++ b/sbi/neural_nets/classifier.py
@@ -47,12 +47,14 @@ def build_input_layer(
     Args:
         batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring.
         batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring.
-        z_score_x: Whether to z-score xs passing into the network, can take one of the following:
-            - `none`, None: do not z-score
-            - `independent`: z-score each dimension independently
+        z_score_x: Whether to z-score xs passing into the network, can be one of:
+            - `none`, or None: do not z-score.
+            - `independent`: z-score each dimension independently.
             - `structured`: treat dimensions as related, therefore compute mean and std
-            over the entire batch, instead of per-dimension.
-        z_score_y: Whether to z-score ys passing into the network, same as z_score_x.
+            over the entire batch, instead of per-dimension. Should be used when each
+            sample is, for example, a time series or an image.
+        z_score_y: Whether to z-score ys passing into the network, same options as
+            z_score_x.
         hidden_features: Number of hidden features.
         embedding_net_x: Optional embedding network for x.
         embedding_net_y: Optional embedding network for y.
@@ -95,12 +97,14 @@ def build_linear_classifier(
     Args:
         batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring.
         batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring.
-        z_score_x: Whether to z-score xs passing into the network, can take one of the following:
-            - `none`, None: do not z-score
-            - `independent`: z-score each dimension independently
+        z_score_x: Whether to z-score xs passing into the network, can be one of:
+            - `none`, or None: do not z-score.
+            - `independent`: z-score each dimension independently.
             - `structured`: treat dimensions as related, therefore compute mean and std
-            over the entire batch, instead of per-dimension.
-        z_score_y: Whether to z-score ys passing into the network, same as z_score_x.
+            over the entire batch, instead of per-dimension. Should be used when each
+            sample is, for example, a time series or an image.
+        z_score_y: Whether to z-score ys passing into the network, same options as
+            z_score_x.
         embedding_net_x: Optional embedding network for x.
         embedding_net_y: Optional embedding network for y.
         kwargs: Additional arguments that are passed by the build function but are not
@@ -141,12 +145,14 @@ def build_mlp_classifier(
     Args:
         batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring.
         batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring.
-        z_score_x: Whether to z-score xs passing into the network, can take one of the following:
-            - `none`, None: do not z-score
-            - `independent`: z-score each dimension independently
+        z_score_x: Whether to z-score xs passing into the network, can be one of:
+            - `none`, or None: do not z-score.
+            - `independent`: z-score each dimension independently.
             - `structured`: treat dimensions as related, therefore compute mean and std
-            over the entire batch, instead of per-dimension.
-        z_score_y: Whether to z-score ys passing into the network, same as z_score_x.
+            over the entire batch, instead of per-dimension. Should be used when each
+            sample is, for example, a time series or an image.
+        z_score_y: Whether to z-score ys passing into the network, same options as
+            z_score_x.
         hidden_features: Number of hidden features.
         embedding_net_x: Optional embedding network for x.
         embedding_net_y: Optional embedding network for y.
@@ -194,12 +200,14 @@ def build_resnet_classifier(
     Args:
         batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring.
         batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring.
-        z_score_x: Whether to z-score xs passing into the network, can take one of the following:
-            - `none`, None: do not z-score
-            - `independent`: z-score each dimension independently
+        z_score_x: Whether to z-score xs passing into the network, can be one of:
+            - `none`, or None: do not z-score.
+            - `independent`: z-score each dimension independently.
             - `structured`: treat dimensions as related, therefore compute mean and std
-            over the entire batch, instead of per-dimension.
-        z_score_y: Whether to z-score ys passing into the network, same as z_score_x.
+            over the entire batch, instead of per-dimension. Should be used when each
+            sample is, for example, a time series or an image.
+        z_score_y: Whether to z-score ys passing into the network, same options as
+            z_score_x.
         hidden_features: Number of hidden features.
         embedding_net_x: Optional embedding network for x.
         embedding_net_y: Optional embedding network for y.

--- a/sbi/neural_nets/classifier.py
+++ b/sbi/neural_nets/classifier.py
@@ -1,12 +1,13 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
+from typing import Optional
 
 import torch
 from pyknos.nflows.nn import nets
 from torch import Tensor, nn, relu
 
-from sbi.utils.sbiutils import standardizing_net
+from sbi.utils.sbiutils import standardizing_net, z_score_parser
 
 
 class StandardizeInputs(nn.Module):
@@ -34,8 +35,8 @@ class StandardizeInputs(nn.Module):
 def build_input_layer(
     batch_x: Tensor = None,
     batch_y: Tensor = None,
-    z_score_x: bool = True,
-    z_score_y: bool = True,
+    z_score_x: Optional[str] = "independent",
+    z_score_y: Optional[str] = "independent",
     embedding_net_x: nn.Module = nn.Identity(),
     embedding_net_y: nn.Module = nn.Identity(),
 ) -> nn.Module:
@@ -46,8 +47,12 @@ def build_input_layer(
     Args:
         batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring.
         batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring.
-        z_score_x: Whether to z-score xs passing into the network.
-        z_score_y: Whether to z-score ys passing into the network.
+        z_score_x: Whether to z-score xs passing into the network, can take one of the following:
+            - `none`, None, or False (for backwards compatibility): do not z-score
+            - `independent` or True (for backwards compatibility): z-score each dimension independently
+            - `structured`: treat dimensions as related, therefore compute mean and std
+            over the entire batch, instead of per-dimension.
+        z_score_y: Whether to z-score ys passing into the network, same as z_score_x.
         hidden_features: Number of hidden features.
         embedding_net_x: Optional embedding network for x.
         embedding_net_y: Optional embedding network for y.
@@ -55,11 +60,17 @@ def build_input_layer(
     Returns:
         Input layer that optionally z-scores.
     """
+    z_score_x, structured_x = z_score_parser(z_score_x)
     if z_score_x:
-        embedding_net_x = nn.Sequential(standardizing_net(batch_x), embedding_net_x)
+        embedding_net_x = nn.Sequential(
+            standardizing_net(batch_x, structured_x), embedding_net_x
+        )
 
+    z_score_y, structured_y = z_score_parser(z_score_y)
     if z_score_y:
-        embedding_net_y = nn.Sequential(standardizing_net(batch_y), embedding_net_y)
+        embedding_net_y = nn.Sequential(
+            standardizing_net(batch_y, structured_y), embedding_net_y
+        )
 
     input_layer = StandardizeInputs(
         embedding_net_x, embedding_net_y, dim_x=batch_x.shape[1], dim_y=batch_y.shape[1]
@@ -71,8 +82,8 @@ def build_input_layer(
 def build_linear_classifier(
     batch_x: Tensor = None,
     batch_y: Tensor = None,
-    z_score_x: bool = True,
-    z_score_y: bool = True,
+    z_score_x: Optional[str] = "independent",
+    z_score_y: Optional[str] = "independent",
     embedding_net_x: nn.Module = nn.Identity(),
     embedding_net_y: nn.Module = nn.Identity(),
     **kwargs
@@ -84,8 +95,12 @@ def build_linear_classifier(
     Args:
         batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring.
         batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring.
-        z_score_x: Whether to z-score xs passing into the network.
-        z_score_y: Whether to z-score ys passing into the network.
+        z_score_x: Whether to z-score xs passing into the network, can take one of the following:
+            - `none`, None, or False (for backwards compatibility): do not z-score
+            - `independent` or True (for backwards compatibility): z-score each dimension independently
+            - `structured`: treat dimensions as related, therefore compute mean and std
+            over the entire batch, instead of per-dimension.
+        z_score_y: Whether to z-score ys passing into the network, same as z_score_x.
         embedding_net_x: Optional embedding network for x.
         embedding_net_y: Optional embedding network for y.
         kwargs: Additional arguments that are passed by the build function but are not
@@ -113,8 +128,8 @@ def build_linear_classifier(
 def build_mlp_classifier(
     batch_x: Tensor = None,
     batch_y: Tensor = None,
-    z_score_x: bool = True,
-    z_score_y: bool = True,
+    z_score_x: Optional[str] = "independent",
+    z_score_y: Optional[str] = "independent",
     hidden_features: int = 50,
     embedding_net_x: nn.Module = nn.Identity(),
     embedding_net_y: nn.Module = nn.Identity(),
@@ -126,8 +141,12 @@ def build_mlp_classifier(
     Args:
         batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring.
         batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring.
-        z_score_x: Whether to z-score xs passing into the network.
-        z_score_y: Whether to z-score ys passing into the network.
+        z_score_x: Whether to z-score xs passing into the network, can take one of the following:
+            - `none`, None, or False (for backwards compatibility): do not z-score
+            - `independent` or True (for backwards compatibility): z-score each dimension independently
+            - `structured`: treat dimensions as related, therefore compute mean and std
+            over the entire batch, instead of per-dimension.
+        z_score_y: Whether to z-score ys passing into the network, same as z_score_x.
         hidden_features: Number of hidden features.
         embedding_net_x: Optional embedding network for x.
         embedding_net_y: Optional embedding network for y.
@@ -162,8 +181,8 @@ def build_mlp_classifier(
 def build_resnet_classifier(
     batch_x: Tensor = None,
     batch_y: Tensor = None,
-    z_score_x: bool = True,
-    z_score_y: bool = True,
+    z_score_x: Optional[str] = "independent",
+    z_score_y: Optional[str] = "independent",
     hidden_features: int = 50,
     embedding_net_x: nn.Module = nn.Identity(),
     embedding_net_y: nn.Module = nn.Identity(),
@@ -175,8 +194,12 @@ def build_resnet_classifier(
     Args:
         batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring.
         batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring.
-        z_score_x: Whether to z-score xs passing into the network.
-        z_score_y: Whether to z-score ys passing into the network.
+        z_score_x: Whether to z-score xs passing into the network, can take one of the following:
+            - `none`, None, or False (for backwards compatibility): do not z-score
+            - `independent` or True (for backwards compatibility): z-score each dimension independently
+            - `structured`: treat dimensions as related, therefore compute mean and std
+            over the entire batch, instead of per-dimension.
+        z_score_y: Whether to z-score ys passing into the network, same as z_score_x.
         hidden_features: Number of hidden features.
         embedding_net_x: Optional embedding network for x.
         embedding_net_y: Optional embedding network for y.

--- a/sbi/neural_nets/classifier.py
+++ b/sbi/neural_nets/classifier.py
@@ -48,8 +48,8 @@ def build_input_layer(
         batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring.
         batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring.
         z_score_x: Whether to z-score xs passing into the network, can take one of the following:
-            - `none`, None, or False (for backwards compatibility): do not z-score
-            - `independent` or True (for backwards compatibility): z-score each dimension independently
+            - `none`, None: do not z-score
+            - `independent`: z-score each dimension independently
             - `structured`: treat dimensions as related, therefore compute mean and std
             over the entire batch, instead of per-dimension.
         z_score_y: Whether to z-score ys passing into the network, same as z_score_x.
@@ -96,8 +96,8 @@ def build_linear_classifier(
         batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring.
         batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring.
         z_score_x: Whether to z-score xs passing into the network, can take one of the following:
-            - `none`, None, or False (for backwards compatibility): do not z-score
-            - `independent` or True (for backwards compatibility): z-score each dimension independently
+            - `none`, None: do not z-score
+            - `independent`: z-score each dimension independently
             - `structured`: treat dimensions as related, therefore compute mean and std
             over the entire batch, instead of per-dimension.
         z_score_y: Whether to z-score ys passing into the network, same as z_score_x.
@@ -142,8 +142,8 @@ def build_mlp_classifier(
         batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring.
         batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring.
         z_score_x: Whether to z-score xs passing into the network, can take one of the following:
-            - `none`, None, or False (for backwards compatibility): do not z-score
-            - `independent` or True (for backwards compatibility): z-score each dimension independently
+            - `none`, None: do not z-score
+            - `independent`: z-score each dimension independently
             - `structured`: treat dimensions as related, therefore compute mean and std
             over the entire batch, instead of per-dimension.
         z_score_y: Whether to z-score ys passing into the network, same as z_score_x.
@@ -195,8 +195,8 @@ def build_resnet_classifier(
         batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring.
         batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring.
         z_score_x: Whether to z-score xs passing into the network, can take one of the following:
-            - `none`, None, or False (for backwards compatibility): do not z-score
-            - `independent` or True (for backwards compatibility): z-score each dimension independently
+            - `none`, None: do not z-score
+            - `independent`: z-score each dimension independently
             - `structured`: treat dimensions as related, therefore compute mean and std
             over the entire batch, instead of per-dimension.
         z_score_y: Whether to z-score ys passing into the network, same as z_score_x.

--- a/sbi/neural_nets/flow.py
+++ b/sbi/neural_nets/flow.py
@@ -10,7 +10,11 @@ from pyknos.nflows import flows, transforms
 from pyknos.nflows.nn import nets
 from torch import Tensor, nn, relu, tanh, tensor, uint8
 
-from sbi.utils.sbiutils import standardizing_net, standardizing_transform
+from sbi.utils.sbiutils import (
+    standardizing_net,
+    standardizing_transform,
+    z_score_parser,
+)
 from sbi.utils.torchutils import create_alternating_binary_mask
 
 
@@ -29,8 +33,12 @@ def build_made(
     Args:
         batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring.
         batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring.
-        z_score_x: Whether to z-score xs passing into the network.
-        z_score_y: Whether to z-score ys passing into the network.
+        z_score_x: Whether to z-score xs passing into the network, can take one of the following:
+            - `none`, None: do not z-score
+            - `independent`: z-score each dimension independently
+            - `structured`: treat dimensions as related, therefore compute mean and std
+            over the entire batch, instead of per-dimension.
+        z_score_y: Whether to z-score ys passing into the network, same as z_score_x.
         hidden_features: Number of hidden features.
         num_mixture_components: Number of mixture components.
         embedding_net: Optional embedding network for y.
@@ -49,12 +57,16 @@ def build_made(
 
     transform = transforms.IdentityTransform()
 
+    z_score_x, structured_x = z_score_parser(z_score_x)
     if z_score_x:
-        transform_zx = standardizing_transform(batch_x)
+        transform_zx = standardizing_transform(batch_x, structured_x)
         transform = transforms.CompositeTransform([transform_zx, transform])
 
+    z_score_y, structured_y = z_score_parser(z_score_y)
     if z_score_y:
-        embedding_net = nn.Sequential(standardizing_net(batch_y), embedding_net)
+        embedding_net = nn.Sequential(
+            standardizing_net(batch_y, structured_y), embedding_net
+        )
 
     distribution = distributions_.MADEMoG(
         features=x_numel,
@@ -90,8 +102,12 @@ def build_maf(
     Args:
         batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring.
         batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring.
-        z_score_x: Whether to z-score xs passing into the network.
-        z_score_y: Whether to z-score ys passing into the network.
+        z_score_x: Whether to z-score xs passing into the network, can take one of the following:
+            - `none`, None: do not z-score
+            - `independent`: z-score each dimension independently
+            - `structured`: treat dimensions as related, therefore compute mean and std
+            over the entire batch, instead of per-dimension.
+        z_score_y: Whether to z-score ys passing into the network, same as z_score_x.
         hidden_features: Number of hidden features.
         num_transforms: Number of transforms.
         embedding_net: Optional embedding network for y.
@@ -126,11 +142,17 @@ def build_maf(
         ]
         transform_list += block
 
+    z_score_x, structured_x = z_score_parser(z_score_x)
     if z_score_x:
-        transform_list = [standardizing_transform(batch_x)] + transform_list
+        transform_list = [
+            standardizing_transform(batch_x, structured_x)
+        ] + transform_list
 
+    z_score_y, structured_y = z_score_parser(z_score_y)
     if z_score_y:
-        embedding_net = nn.Sequential(standardizing_net(batch_y), embedding_net)
+        embedding_net = nn.Sequential(
+            standardizing_net(batch_y, structured_y), embedding_net
+        )
 
     # Combine transforms.
     transform = transforms.CompositeTransform(transform_list)
@@ -159,8 +181,12 @@ def build_nsf(
     Args:
         batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring.
         batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring.
-        z_score_x: Whether to z-score xs passing into the network.
-        z_score_y: Whether to z-score ys passing into the network.
+        z_score_x: Whether to z-score xs passing into the network, can take one of the following:
+            - `none`, None: do not z-score
+            - `independent`: z-score each dimension independently
+            - `structured`: treat dimensions as related, therefore compute mean and std
+            over the entire batch, instead of per-dimension.
+        z_score_y: Whether to z-score ys passing into the network, same as z_score_x.
         hidden_features: Number of hidden features.
         num_transforms: Number of transforms.
         num_bins: Number of bins used for the splines.
@@ -228,12 +254,19 @@ def build_nsf(
             )
         transform_list += block
 
+    z_score_x, structured_x = z_score_parser(z_score_x)
     if z_score_x:
         # Prepend standardizing transform to nsf transforms.
-        transform_list = [standardizing_transform(batch_x)] + transform_list
+        transform_list = [
+            standardizing_transform(batch_x, structured_x)
+        ] + transform_list
+
+    z_score_y, structured_y = z_score_parser(z_score_y)
     if z_score_y:
         # Prepend standardizing transform to y-embedding.
-        embedding_net = nn.Sequential(standardizing_net(batch_y), embedding_net)
+        embedding_net = nn.Sequential(
+            standardizing_net(batch_y, structured_y), embedding_net
+        )
 
     distribution = distributions_.StandardNormal((x_numel,))
 

--- a/sbi/neural_nets/flow.py
+++ b/sbi/neural_nets/flow.py
@@ -33,12 +33,14 @@ def build_made(
     Args:
         batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring.
         batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring.
-        z_score_x: Whether to z-score xs passing into the network, can take one of the following:
-            - `none`, None: do not z-score
-            - `independent`: z-score each dimension independently
+        z_score_x: Whether to z-score xs passing into the network, can be one of:
+            - `none`, or None: do not z-score.
+            - `independent`: z-score each dimension independently.
             - `structured`: treat dimensions as related, therefore compute mean and std
-            over the entire batch, instead of per-dimension.
-        z_score_y: Whether to z-score ys passing into the network, same as z_score_x.
+            over the entire batch, instead of per-dimension. Should be used when each
+            sample is, for example, a time series or an image.
+        z_score_y: Whether to z-score ys passing into the network, same options as
+            z_score_x.
         hidden_features: Number of hidden features.
         num_mixture_components: Number of mixture components.
         embedding_net: Optional embedding network for y.
@@ -102,12 +104,14 @@ def build_maf(
     Args:
         batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring.
         batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring.
-        z_score_x: Whether to z-score xs passing into the network, can take one of the following:
-            - `none`, None: do not z-score
-            - `independent`: z-score each dimension independently
+        z_score_x: Whether to z-score xs passing into the network, can be one of:
+            - `none`, or None: do not z-score.
+            - `independent`: z-score each dimension independently.
             - `structured`: treat dimensions as related, therefore compute mean and std
-            over the entire batch, instead of per-dimension.
-        z_score_y: Whether to z-score ys passing into the network, same as z_score_x.
+            over the entire batch, instead of per-dimension. Should be used when each
+            sample is, for example, a time series or an image.
+        z_score_y: Whether to z-score ys passing into the network, same options as
+            z_score_x.
         hidden_features: Number of hidden features.
         num_transforms: Number of transforms.
         embedding_net: Optional embedding network for y.
@@ -181,12 +185,14 @@ def build_nsf(
     Args:
         batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring.
         batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring.
-        z_score_x: Whether to z-score xs passing into the network, can take one of the following:
-            - `none`, None: do not z-score
-            - `independent`: z-score each dimension independently
+        z_score_x: Whether to z-score xs passing into the network, can be one of:
+            - `none`, or None: do not z-score.
+            - `independent`: z-score each dimension independently.
             - `structured`: treat dimensions as related, therefore compute mean and std
-            over the entire batch, instead of per-dimension.
-        z_score_y: Whether to z-score ys passing into the network, same as z_score_x.
+            over the entire batch, instead of per-dimension. Should be used when each
+            sample is, for example, a time series or an image.
+        z_score_y: Whether to z-score ys passing into the network, same options as
+            z_score_x.
         hidden_features: Number of hidden features.
         num_transforms: Number of transforms.
         num_bins: Number of bins used for the splines.

--- a/sbi/neural_nets/mdn.py
+++ b/sbi/neural_nets/mdn.py
@@ -24,12 +24,14 @@ def build_mdn(
     Args:
         batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring.
         batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring.
-        z_score_x: Whether to z-score xs passing into the network, can take one of the following:
-            - `none`, None: do not z-score
-            - `independent`: z-score each dimension independently
+        z_score_x: Whether to z-score xs passing into the network, can be one of:
+            - `none`, or None: do not z-score.
+            - `independent`: z-score each dimension independently.
             - `structured`: treat dimensions as related, therefore compute mean and std
-            over the entire batch, instead of per-dimension.
-        z_score_y: Whether to z-score ys passing into the network, same as z_score_x.
+            over the entire batch, instead of per-dimension. Should be used when each
+            sample is, for example, a time series or an image.
+        z_score_y: Whether to z-score ys passing into the network, same options as
+            z_score_x.
         hidden_features: Number of hidden features.
         num_components: Number of components.
         embedding_net: Optional embedding network for y.

--- a/sbi/neural_nets/mdn.py
+++ b/sbi/neural_nets/mdn.py
@@ -24,8 +24,12 @@ def build_mdn(
     Args:
         batch_x: Batch of xs, used to infer dimensionality and (optional) z-scoring.
         batch_y: Batch of ys, used to infer dimensionality and (optional) z-scoring.
-        z_score_x: Whether to z-score xs passing into the network.
-        z_score_y: Whether to z-score ys passing into the network.
+        z_score_x: Whether to z-score xs passing into the network, can take one of the following:
+            - `none`, None: do not z-score
+            - `independent`: z-score each dimension independently
+            - `structured`: treat dimensions as related, therefore compute mean and std
+            over the entire batch, instead of per-dimension.
+        z_score_y: Whether to z-score ys passing into the network, same as z_score_x.
         hidden_features: Number of hidden features.
         num_components: Number of components.
         embedding_net: Optional embedding network for y.
@@ -41,12 +45,16 @@ def build_mdn(
 
     transform = transforms.IdentityTransform()
 
+    z_score_x, structured_x = utils.z_score_parser(z_score_x)
     if z_score_x:
-        transform_zx = utils.standardizing_transform(batch_x)
+        transform_zx = utils.standardizing_transform(batch_x, structured_x)
         transform = transforms.CompositeTransform([transform_zx, transform])
 
+    z_score_y, structured_y = utils.z_score_parser(z_score_y)
     if z_score_y:
-        embedding_net = nn.Sequential(utils.standardizing_net(batch_y), embedding_net)
+        embedding_net = nn.Sequential(
+            utils.standardizing_net(batch_y, structured_y), embedding_net
+        )
 
     distribution = MultivariateGaussianMDN(
         features=x_numel,

--- a/sbi/utils/__init__.py
+++ b/sbi/utils/__init__.py
@@ -32,6 +32,8 @@ from sbi.utils.sbiutils import (
     warn_on_invalid_x_for_snpec_leakage,
     within_support,
     x_shape_from_simulation,
+    match_theta_and_x_batch_shapes,
+    z_score_parser,
 )
 from sbi.utils.torchutils import (
     BoxUniform,

--- a/sbi/utils/get_nn_models.py
+++ b/sbi/utils/get_nn_models.py
@@ -36,8 +36,8 @@ def classifier_nn(
             `resnet`].
         z_score_theta: Whether to z-score parameters $\theta$ before passing them into
             the network, can take one of the following:
-            - `none`, None, or False (for backwards compatibility): do not z-score
-            - `independent` or True (for backwards compatibility): z-score each dimension independently
+            - `none`, None: do not z-score
+            - `independent`: z-score each dimension independently
             - `structured`: treat dimensions as related, therefore compute mean and std
             over the entire batch, instead of per-dimension.
         z_score_x: Whether to z-score simulation outputs $x$ before passing them into
@@ -105,9 +105,13 @@ def likelihood_nn(
         model: The type of density estimator that will be created. One of [`mdn`,
             `made`, `maf`, `nsf`].
         z_score_theta: Whether to z-score parameters $\theta$ before passing them into
-            the network.
+            the network, can take one of the following:
+            - `none`, None: do not z-score
+            - `independent`: z-score each dimension independently
+            - `structured`: treat dimensions as related, therefore compute mean and std
+            over the entire batch, instead of per-dimension.
         z_score_x: Whether to z-score simulation outputs $x$ before passing them into
-            the network.
+            the network, same as z_score_theta.
         hidden_features: Number of hidden features.
         num_transforms: Number of transforms when a flow is used. Only relevant if
             density estimator is a normalizing flow (i.e. currently either a `maf` or a
@@ -177,9 +181,13 @@ def posterior_nn(
         model: The type of density estimator that will be created. One of [`mdn`,
             `made`, `maf`, `nsf`].
         z_score_theta: Whether to z-score parameters $\theta$ before passing them into
-            the network.
+            the network, can take one of the following:
+            - `none`, None: do not z-score
+            - `independent`: z-score each dimension independently
+            - `structured`: treat dimensions as related, therefore compute mean and std
+            over the entire batch, instead of per-dimension.
         z_score_x: Whether to z-score simulation outputs $x$ before passing them into
-            the network.
+            the network, same as z_score_theta.
         hidden_features: Number of hidden features.
         num_transforms: Number of transforms when a flow is used. Only relevant if
             density estimator is a normalizing flow (i.e. currently either a `maf` or a

--- a/sbi/utils/get_nn_models.py
+++ b/sbi/utils/get_nn_models.py
@@ -36,12 +36,13 @@ def classifier_nn(
             `resnet`].
         z_score_theta: Whether to z-score parameters $\theta$ before passing them into
             the network, can take one of the following:
-            - `none`, None: do not z-score
-            - `independent`: z-score each dimension independently
+            - `none`, or None: do not z-score.
+            - `independent`: z-score each dimension independently.
             - `structured`: treat dimensions as related, therefore compute mean and std
-            over the entire batch, instead of per-dimension.
+            over the entire batch, instead of per-dimension. Should be used when each
+            sample is, for example, a time series or an image.
         z_score_x: Whether to z-score simulation outputs $x$ before passing them into
-            the network, same as z_score_theta.
+            the network, same options as z_score_theta.
         hidden_features: Number of hidden features.
         embedding_net_theta:  Optional embedding network for parameters $\theta$.
         embedding_net_x:  Optional embedding network for simulation outputs $x$. This
@@ -106,12 +107,13 @@ def likelihood_nn(
             `made`, `maf`, `nsf`].
         z_score_theta: Whether to z-score parameters $\theta$ before passing them into
             the network, can take one of the following:
-            - `none`, None: do not z-score
-            - `independent`: z-score each dimension independently
+            - `none`, or None: do not z-score.
+            - `independent`: z-score each dimension independently.
             - `structured`: treat dimensions as related, therefore compute mean and std
-            over the entire batch, instead of per-dimension.
+            over the entire batch, instead of per-dimension. Should be used when each
+            sample is, for example, a time series or an image.
         z_score_x: Whether to z-score simulation outputs $x$ before passing them into
-            the network, same as z_score_theta.
+            the network, same options as z_score_theta.
         hidden_features: Number of hidden features.
         num_transforms: Number of transforms when a flow is used. Only relevant if
             density estimator is a normalizing flow (i.e. currently either a `maf` or a
@@ -182,12 +184,13 @@ def posterior_nn(
             `made`, `maf`, `nsf`].
         z_score_theta: Whether to z-score parameters $\theta$ before passing them into
             the network, can take one of the following:
-            - `none`, None: do not z-score
-            - `independent`: z-score each dimension independently
+            - `none`, or None: do not z-score.
+            - `independent`: z-score each dimension independently.
             - `structured`: treat dimensions as related, therefore compute mean and std
-            over the entire batch, instead of per-dimension.
+            over the entire batch, instead of per-dimension. Should be used when each
+            sample is, for example, a time series or an image.
         z_score_x: Whether to z-score simulation outputs $x$ before passing them into
-            the network, same as z_score_theta.
+            the network, same options as z_score_theta.
         hidden_features: Number of hidden features.
         num_transforms: Number of transforms when a flow is used. Only relevant if
             density estimator is a normalizing flow (i.e. currently either a `maf` or a

--- a/sbi/utils/get_nn_models.py
+++ b/sbi/utils/get_nn_models.py
@@ -2,7 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 
-from typing import Callable
+from typing import Callable, Optional
 
 from torch import nn
 
@@ -17,8 +17,8 @@ from sbi.neural_nets.mdn import build_mdn
 
 def classifier_nn(
     model: str,
-    z_score_theta: bool = True,
-    z_score_x: bool = True,
+    z_score_theta: Optional[str] = "independent",
+    z_score_x: Optional[str] = "independent",
     hidden_features: int = 50,
     embedding_net_theta: nn.Module = nn.Identity(),
     embedding_net_x: nn.Module = nn.Identity(),
@@ -35,9 +35,13 @@ def classifier_nn(
         model: The type of classifier that will be created. One of [`linear`, `mlp`,
             `resnet`].
         z_score_theta: Whether to z-score parameters $\theta$ before passing them into
-            the network.
+            the network, can take one of the following:
+            - `none`, None, or False (for backwards compatibility): do not z-score
+            - `independent` or True (for backwards compatibility): z-score each dimension independently
+            - `structured`: treat dimensions as related, therefore compute mean and std
+            over the entire batch, instead of per-dimension.
         z_score_x: Whether to z-score simulation outputs $x$ before passing them into
-            the network.
+            the network, same as z_score_theta.
         hidden_features: Number of hidden features.
         embedding_net_theta:  Optional embedding network for parameters $\theta$.
         embedding_net_x:  Optional embedding network for simulation outputs $x$. This
@@ -83,8 +87,8 @@ def classifier_nn(
 
 def likelihood_nn(
     model: str,
-    z_score_theta: bool = True,
-    z_score_x: bool = True,
+    z_score_theta: Optional[str] = "independent",
+    z_score_x: Optional[str] = "independent",
     hidden_features: int = 50,
     num_transforms: int = 5,
     num_bins: int = 10,
@@ -155,8 +159,8 @@ def likelihood_nn(
 
 def posterior_nn(
     model: str,
-    z_score_theta: bool = True,
-    z_score_x: bool = True,
+    z_score_theta: Optional[str] = "independent",
+    z_score_x: Optional[str] = "independent",
     hidden_features: int = 50,
     num_transforms: int = 5,
     num_bins: int = 10,

--- a/sbi/utils/restriction_estimator.py
+++ b/sbi/utils/restriction_estimator.py
@@ -16,6 +16,7 @@ from sbi.utils.sbiutils import (
     get_simulations_since_round,
     handle_invalid_x,
     standardizing_net,
+    z_score_parser,
 )
 from sbi.utils.user_input_checks import validate_theta_and_x
 
@@ -32,14 +33,21 @@ def build_input_layer(
     Args:
         batch_theta: Batch of $\theta$s, used to infer dimensionality and (optional)
             z-scoring.
-        z_score_theta: Whether to z-score $\theta$s passing into the network.
+        z_score_theta: Whether to z-score $\theta$s passing into the network, can take one of the following:
+            - `none`, None: do not z-score
+            - `independent`: z-score each dimension independently
+            - `structured`: treat dimensions as related, therefore compute mean and std
+            over the entire batch, instead of per-dimension.
         embedding_net_theta: Optional embedding network for $\theta$s.
 
     Returns:
         Input layer with optional embedding net and z-scoring.
     """
+    z_score_theta, structured_theta = z_score_parser(z_score_theta)
     if z_score_theta:
-        input_layer = nn.Sequential(standardizing_net(batch_theta), embedding_net_theta)
+        input_layer = nn.Sequential(
+            standardizing_net(batch_theta, structured_theta), embedding_net_theta
+        )
     else:
         input_layer = embedding_net_theta
 

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -87,8 +87,8 @@ def z_score_parser(z_score_flag: Optional["str"]) -> Tuple[bool, bool]:
 
     Args:
         z_score_flag: str flag for z-scoring method stating whether the data
-        dimensions are "structured" or "independent", or does not require z-scoring
-        ("none" or None).
+            dimensions are "structured" or "independent", or does not require z-scoring
+            ("none" or None).
 
     Returns:
         Flag for whether or not to z-score, and whether data is structured
@@ -96,8 +96,7 @@ def z_score_parser(z_score_flag: Optional["str"]) -> Tuple[bool, bool]:
     if type(z_score_flag) is bool:
         # Raise warning if boolean was passed.
         warnings.warn(
-            """Boolean flag for z-scoring is accepted for backwards compatibility only.
-            Please use 'none', 'independent', or 'structured' to indicate z-scoring option.
+            """Boolean flag for z-scoring is deprecated as of sbi v0.18.0. It will be removed in a future release. Use 'none', 'independent', or 'structured' to indicate z-scoring option.
         """
         )
         z_score_bool, structured_data = z_score_flag, False
@@ -113,8 +112,9 @@ def z_score_parser(z_score_flag: Optional["str"]) -> Tuple[bool, bool]:
 
     else:
         # Return warning due to invalid option, defaults to not z-scoring.
-        warnings.warn("Invalid z-scoring option, defaulting to no z-scoring.")
-        z_score_bool, structured_data = False, False
+        raise ValueError(
+            "Invalid z-scoring option. Use 'none', 'independent', or 'structured'."
+        )
 
     return z_score_bool, structured_data
 

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -144,7 +144,7 @@ def standardizing_transform(
     if structured_dims:
         # Structured data so compute a single mean over all dimensions
         # equivalent to taking mean over per-sample mean, i.e.,
-        # `torch.mean(torch.mean(.., dim=1)).`
+        # `torch.mean(torch.mean(.., dim=1))`.
         t_mean = torch.mean(batch_t[is_valid_t])
         # Compute std per-sample first.
         sample_std = torch.std(batch_t[is_valid_t], dim=1)
@@ -198,7 +198,7 @@ def standardizing_net(
     if structured_dims:
         # Structured data so compute a single mean over all dimensions
         # equivalent to taking mean over per-sample mean, i.e.,
-        # `torch.mean(torch.mean(.., dim=1)).`
+        # `torch.mean(torch.mean(.., dim=1))`.
         t_mean = torch.mean(batch_t[is_valid_t])
     else:
         # Compute per-dimension (independent) mean.

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -79,6 +79,41 @@ def clamp_and_warn(name: str, value: float, min_val: float, max_val: float) -> f
     return clamped_val
 
 
+def z_score_parser(z_score_flag: Optional["str"]) -> Tuple[bool, bool]:
+    """Parses z-score flag into 2 booleans: to z-score or not, and whether the data
+    requires structured z-scoring (e.g., time series).
+
+    Args:
+        z_score_flag: string flag for z-scoring method stating whether the data
+        dimensions are structured or independent.
+
+    Returns:
+        Flag for whether or not to z-score, and whether data is structured
+    """
+    if type(z_score_flag) is bool:
+        # if boolean was passed
+        warnings.warn(
+            """Boolean flag for z-scoring is accepted for backwards
+                      compatibility only. Please use 'none', 'independent', or
+                      'structured' to indicate z-scoring option.
+        """
+        )
+        z_score_bool, structured_data = z_score_flag, False
+    elif (z_score_flag is None) or (z_score_flag == "none"):
+        # if "none" or None was passed
+        z_score_bool, structured_data = False, False
+    elif (z_score_flag == "independent") or (z_score_flag == "structured"):
+        # one of two valid z-scoring methods
+        z_score_bool = True
+        structured_data = True if z_score_flag == "structured" else False
+    else:
+        # invalid option
+        warnings.warn("Invalid z-scoring option, defaulting to no z-scoring")
+        z_score_bool, structured_data = False, False
+
+    return z_score_bool, structured_data
+
+
 def standardizing_transform(
     batch_t: Tensor, min_std: float = 1e-14
 ) -> transforms.AffineTransform:
@@ -118,7 +153,7 @@ class Standardize(nn.Module):
 
 def standardizing_net(
     batch_t: Tensor,
-    structured_dims: bool,
+    structured_dims: bool = False,
     min_std: float = 1e-7,
 ) -> nn.Module:
     """Builds standardizing network
@@ -129,7 +164,7 @@ def standardizing_net(
         structured_dim: Whether data dimensions are structured (e.g., time-series,
             images), which requires computing mean and std per sample first before
             aggregating over samples for a single standardization mean and std for the
-            batch, or independent, which z-scores each dimension independently.
+            batch, or independent (default), which z-scores dimensions independently.
         min_std:  Minimum value of the standard deviation to use when z-scoring to
             avoid division by zero.
 

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -96,9 +96,8 @@ def z_score_parser(z_score_flag: Optional["str"]) -> Tuple[bool, bool]:
     if type(z_score_flag) is bool:
         # Raise warning if boolean was passed.
         warnings.warn(
-            """Boolean flag for z-scoring is accepted for backwards
-                      compatibility only. Please use 'none', 'independent', or
-                      'structured' to indicate z-scoring option.
+            """Boolean flag for z-scoring is accepted for backwards compatibility only.
+            Please use 'none', 'independent', or 'structured' to indicate z-scoring option.
         """
         )
         z_score_bool, structured_data = z_score_flag, False

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -255,7 +255,10 @@ def test_c2st_multi_round_snpe_on_linearGaussian(method_str: str, set_seed):
     target_samples = gt_posterior.sample((num_samples,))
 
     if method_str == "snpe_c_non_atomic":
-        density_estimator = utils.posterior_nn("mdn", num_components=5)
+        # Test whether SNPE works properly with structured z-scoring.
+        density_estimator = utils.posterior_nn(
+            "mdn", z_score_x="structured", num_components=5
+        )
         method_str = "snpe_c"
     elif method_str == "snpe_a":
         density_estimator = "mdn_snpe_a"
@@ -416,7 +419,7 @@ def test_sample_conditional(set_seed):
         else:
             return linear_gaussian(theta, -likelihood_shift, likelihood_cov)
 
-    # Test whether SNPE works properly with structured z-scoring
+    # Test whether SNPE works properly with structured z-scoring.
     net = utils.posterior_nn("maf", z_score_x="structured", hidden_features=20)
 
     simulator, prior = prepare_for_sbi(simulator, prior)

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -416,7 +416,7 @@ def test_sample_conditional(set_seed):
         else:
             return linear_gaussian(theta, -likelihood_shift, likelihood_cov)
 
-    net = utils.posterior_nn("maf", hidden_features=20)
+    net = utils.posterior_nn("maf", z_score_x="structured", hidden_features=20)
 
     simulator, prior = prepare_for_sbi(simulator, prior)
 

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -416,6 +416,7 @@ def test_sample_conditional(set_seed):
         else:
             return linear_gaussian(theta, -likelihood_shift, likelihood_cov)
 
+    # Test whether SNPE works properly with structured z-scoring
     net = utils.posterior_nn("maf", z_score_x="structured", hidden_features=20)
 
     simulator, prior = prepare_for_sbi(simulator, prior)

--- a/tests/multidimensional_x_test.py
+++ b/tests/multidimensional_x_test.py
@@ -91,7 +91,7 @@ def test_inference_with_2d_x(embedding, method):
     else:
         net_provider = utils.classifier_nn(
             model="mlp",
-            z_score_theta="structured",
+            z_score_theta="structured",  # Test that structured z-scoring works.
             embedding_net_x=embedding(),
         )
         num_trials = 2

--- a/tests/multidimensional_x_test.py
+++ b/tests/multidimensional_x_test.py
@@ -91,6 +91,7 @@ def test_inference_with_2d_x(embedding, method):
     else:
         net_provider = utils.classifier_nn(
             model="mlp",
+            z_score_theta="structured",
             embedding_net_x=embedding(),
         )
         num_trials = 2

--- a/tests/sbiutils_test.py
+++ b/tests/sbiutils_test.py
@@ -277,7 +277,8 @@ def test_gaussian_transforms(snpe_method: str, plot_results: bool = False):
         # Set up a SNPE object in order to use the
         # `_automatic_posterior_transformation()`.
         prior = BoxUniform(-5 * ones(2), 5 * ones(2))
-        density_estimator = posterior_nn("mdn", z_score_theta=False, z_score_x=False)
+        # Testing new z-score arg options.
+        density_estimator = posterior_nn("mdn", z_score_theta=None, z_score_x=None)
         inference = SNPE(prior=prior, density_estimator=density_estimator)
         theta_ = torch.rand(100, 2)
         x_ = torch.rand(100, 2)


### PR DESCRIPTION
`standardizing_net()` and `standardizing_transform()` now both have options to perform z-scoring for structured data, i.e., to compute `mean` and `std` for each sample first, then taking the global mean to be used for z-scoring the batch (instead of z-scoring each dimension independently): 

`x_mean = torch.mean(x)`
`x_std = torch.mean(torch.std(x, dim=1))`

Re: #570  