### PR TITLE
add sbc plotting funtions.

### DIFF
--- a/sbi/analysis/__init__.py
+++ b/sbi/analysis/__init__.py
@@ -9,6 +9,7 @@ from sbi.analysis.plot import (
     conditional_pairplot,
     marginal_plot,
     pairplot,
+    sbc_rank_plot,
 )
 from sbi.analysis.sensitivity_analysis import ActiveSubspace
 from sbi.analysis.sbc import run_sbc, check_sbc, get_nltp

--- a/sbi/analysis/plot.py
+++ b/sbi/analysis/plot.py
@@ -2,13 +2,15 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 import collections
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import matplotlib as mpl
 import numpy as np
 import six
 import torch
 from matplotlib import pyplot as plt
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
 from scipy.stats import binom, gaussian_kde
 from torch import Tensor
 
@@ -979,39 +981,96 @@ def _get_default_opts():
 
 
 def sbc_rank_plot(
-    ranks,
-    num_posterior_samples,
-    num_bins=100,
-    num_repeats=50,
-    plot_type="cdf",
-    parameter_labels=None,
-    ranks_labels=None,
-    colors=None,
-    line_alpha=0.8,
-    show_uniform_region=True,
-    uniform_region_alpha=0.2,
-    num_cols=4,
-    params_in_subplots=False,
-    fig=None,
-    ax=None,
-    figsize=None,
-):
-    """Plot simulation-based calibration ranks as empirical CDFs.
+    ranks: Union[Tensor, np.ndarray, List[Tensor], List[np.ndarray]],
+    num_posterior_samples: int,
+    num_bins: int = None,
+    plot_type: str = "cdf",
+    parameter_labels: List[str] = None,
+    ranks_labels: List[str] = None,
+    colors: List[str] = None,
+    kwargs: Dict = {},
+) -> Tuple[Figure, Axes]:
+    """Plot simulation-based calibration ranks as empirical CDFs or histograms.
+
+    Additional options can be passed via the kwargs argument, see _sbc_rank_plot.
 
     Args:
-        ranks: Tensor of ranks to be plotted, or list of Tensors when comparing several sets
-            of ranks, e.g., set of ranks obtained from different methods.
-        num_bins: number of bins used for calculating empirical cdfs via histograms.
-        num_repeats: number of repeats for each empirical CDF step (resolution).
+        ranks: Tensor of ranks to be plotted shape (num_sbc_runs, num_parameters), or
+            list of Tensors when comparing several sets of ranks, e.g., set of ranks
+            obtained from different methods.
+        num_bins: number of bins used for binning the ranks, default is
+            num_sbc_runs / 20.
+        plot_type: type of SBC plot, histograms ("hist") or empirical cdfs ("cdf").
         parameter_labels: list of labels for each parameter dimension.
         ranks_labels: list of labels for each set of ranks.
         colors: list of colors for each parameter dimension, or each set of ranks.
-        line_alpha: alpha for cdf lines
-        show_uniform_region: whether to plot the region showing the cdfs expected under uniformity
-        uniform_region_alpha: alpha for region showing the cdfs expected under uniformity.
+
+    Returns:
+        fig, ax: figure and axis objects.
+
+    """
+
+    return _sbc_rank_plot(
+        ranks,
+        num_posterior_samples,
+        num_bins,
+        plot_type,
+        parameter_labels,
+        ranks_labels,
+        colors,
+        **kwargs,
+    )
+
+
+def _sbc_rank_plot(
+    ranks: Union[Tensor, np.ndarray, List[Tensor], List[np.ndarray]],
+    num_posterior_samples: int,
+    num_bins: int = None,
+    plot_type: str = "cdf",
+    parameter_labels: List[str] = None,
+    ranks_labels: List[str] = None,
+    colors: List[str] = None,
+    num_repeats: int = 50,
+    line_alpha: float = 0.8,
+    show_uniform_region: bool = True,
+    uniform_region_alpha: float = 0.3,
+    xlim_offset_factor: float = 0.1,
+    num_cols: int = 4,
+    params_in_subplots: bool = False,
+    show_ylabel: bool = False,
+    sharey: bool = False,
+    fig: Figure = None,
+    ax: Axes = None,
+    figsize: tuple = None,
+) -> Tuple[Figure, Axes]:
+    """Plot simulation-based calibration ranks as empirical CDFs or histograms.
+
+    Args:
+        ranks: Tensor of ranks to be plotted shape (num_sbc_runs, num_parameters), or
+            list of Tensors when comparing several sets of ranks, e.g., set of ranks
+            obtained from different methods.
+        num_bins: number of bins used for binning the ranks, default is
+            num_sbc_runs / 20.
+        plot_type: type of SBC plot, histograms ("hist") or empirical cdfs ("cdf").
+        parameter_labels: list of labels for each parameter dimension.
+        ranks_labels: list of labels for each set of ranks.
+        colors: list of colors for each parameter dimension, or each set of ranks.
+        num_repeats: number of repeats for each empirical CDF step (resolution).
+        line_alpha: alpha for cdf lines or histograms.
+        show_uniform_region: whether to plot the region showing the cdfs expected under
+            uniformity.
+        uniform_region_alpha: alpha for region showing the cdfs expected under
+            uniformity.
+        xlim_offset_factor: factor for empty space left and right of the histogram.
+        num_cols: number of subplot columns, e.g., when plotting ranks of many
+            parameters.
+        params_in_subplots: whether to show each parameter in a separate subplot, or
+            all in one.
+        show_ylabel: whether to show ylabels and ticks.
+        sharey: whether to share the y-labels, ticks, and limits across subplots.
         fig: figure object to plot in.
-        ax: axis object, must have shape (number of set of ranks,) or be a raw Axes object.
-        figsize: dimensions of figure object, defaults to (8, 5) or (number of set of ranks * 4, 5).
+        ax: axis object, must contain as many sublpots as parameters or len(ranks).
+        figsize: dimensions of figure object, default (8, 5) or (len(ranks) * 4, 5).
 
     Returns:
         fig, ax: figure and axis objects.
@@ -1019,21 +1078,30 @@ def sbc_rank_plot(
     """
 
     if isinstance(ranks, (Tensor, np.ndarray)):
-        ranks = [ranks]
+        ranks_list = [ranks]
     else:
         assert isinstance(ranks, List)
-        assert isinstance(ranks[0], (Tensor, np.ndarray))
+        ranks_list = ranks
+    for idx, rank in enumerate(ranks_list):
+        assert isinstance(rank, (Tensor, np.ndarray))
+        if isinstance(rank, Tensor):
+            ranks_list[idx] = rank.numpy()
 
-    num_sbc_runs, num_parameters = ranks[0].shape
-    num_ranks = len(ranks)
+    plot_types = ["hist", "cdf"]
+    assert (
+        plot_type in plot_types
+    ), "plot type {plot_type} not implemented, use one in {plot_types}."
+
+    num_sbc_runs, num_parameters = ranks_list[0].shape
+    num_ranks = len(ranks_list)
 
     # For multiple methods, and for the hist plots plot each param in a separate subplot
     if num_ranks > 1 or plot_type == "hist":
         params_in_subplots = True
 
-    for ranki in ranks:
+    for ranki in ranks_list:
         assert (
-            ranki.shape == ranks[0].shape
+            ranki.shape == ranks_list[0].shape
         ), "all ranks in list must have the same shape."
 
     num_rows = int(np.ceil(num_parameters / num_cols))
@@ -1044,27 +1112,38 @@ def sbc_rank_plot(
         parameter_labels = [f"dim {i+1}" for i in range(num_parameters)]
     if ranks_labels is None:
         ranks_labels = [f"rank set {i+1}" for i in range(num_ranks)]
+    if num_bins is None:
+        # Recommendation from Talts et al.
+        num_bins = num_sbc_runs // 20
 
     # Plot one row subplot for each parameter, different "methods" on top of each other.
     if params_in_subplots:
         if fig is None or ax is None:
-            fig, ax = plt.subplots(num_rows, num_parameters, figsize=figsize)
+            fig, ax = plt.subplots(
+                num_rows, min(num_parameters, num_cols), figsize=figsize, sharey=sharey
+            )
         else:
-            assert ax.shape == (
-                num_parameters,
-            ), "Expecting subplots of shape 1, num_parameters."
+            assert (
+                ax.size >= num_parameters
+            ), "There must be at least as many subplots as parameters."
+            if ax.ndim > 1:
+                num_rows = ax.shape[0]
+            else:
+                num_rows = 1
 
-        for ii, ranki in enumerate(ranks):
+        col_idx, row_idx = 0, 0
+        for ii, ranki in enumerate(ranks_list):
             for jj in range(num_parameters):
-                col_idx = jj if num_rows == 1 else jj % num_rows
-                plt.sca(ax[col_idx] if num_rows == 1 else ax[num_rows, col_idx])
+                col_idx = jj if num_rows == 1 else jj % num_cols
+                row_idx = jj // num_cols
+                plt.sca(ax[col_idx] if num_rows == 1 else ax[row_idx, col_idx])
 
                 if plot_type == "cdf":
-                    plot_ranks_as_cdf(
+                    _plot_ranks_as_cdf(
                         ranki[:, jj],
                         num_bins,
                         num_repeats,
-                        label=ranks_labels[ii],
+                        ranks_label=ranks_labels[ii],
                         color=f"C{ii}" if colors is None else colors[ii],
                         xlabel=f"posterior rank {parameter_labels[jj]}",
                         # Show legend and ylabel only in first subplot.
@@ -1073,30 +1152,39 @@ def sbc_rank_plot(
                         alpha=line_alpha,
                     )
                     if ii == 0 and show_uniform_region:
-                        plot_cdf_region_expected_under_uniformity(
+                        _plot_cdf_region_expected_under_uniformity(
                             num_sbc_runs, num_bins, num_repeats, alpha=0.1
                         )
                 elif plot_type == "hist":
-                    plot_ranks_as_hist(
+                    _plot_ranks_as_hist(
                         ranki[:, jj],
                         num_bins,
                         num_posterior_samples,
-                        label=ranks_labels[ii],
-                        color=f"C{ii}" if colors is None else colors[ii],
+                        ranks_label=ranks_labels[ii],
+                        color="firebrick" if colors is None else colors[ii],
                         xlabel=f"posterior rank {parameter_labels[jj]}",
                         # Show legend and ylabel only in first subplot.
-                        show_ylabel=False,
+                        show_ylabel=show_ylabel,
                         show_legend=jj == 0,
                         alpha=line_alpha,
+                        xlim_offset_factor=xlim_offset_factor,
                     )
-                    # TODO: fix uniform region plotting.
-                #                     plot_hist_region_expected_under_uniformity(num_sbc_runs,
-                #                                                                num_bins,
-                #                                                                num_posterior_samples,
-                #                                                                alpha=0.1)
+                    # Plot expected uniform band.
+                    _plot_hist_region_expected_under_uniformity(
+                        num_sbc_runs,
+                        num_bins,
+                        num_posterior_samples,
+                        alpha=uniform_region_alpha,
+                    )
                 else:
-                    pass
-                    # TODO: raise ValueError(f"plot_type {plot_type} not defined, use one in {plot_types}")
+                    raise ValueError(
+                        f"plot_type {plot_type} not defined, use one in {plot_types}"
+                    )
+                # Remove empty subplots.
+        col_idx += 1
+        while num_rows > 1 and col_idx < num_cols:
+            ax[row_idx, col_idx].axis("off")
+            col_idx += 1
 
     # When there is only one set of ranks show all params in a single subplot.
     else:
@@ -1104,13 +1192,13 @@ def sbc_rank_plot(
             fig, ax = plt.subplots(1, 1, figsize=figsize)
 
         plt.sca(ax)
-        ranki = ranks[0]
+        ranki = ranks_list[0]
         for jj in range(num_parameters):
             plot_ranks_as_cdf(
                 ranki[:, jj],
                 num_bins,
                 num_repeats,
-                label=parameter_labels[jj],
+                ranks_label=parameter_labels[jj],
                 color=f"C{jj}" if colors is None else colors[jj],
                 xlabel=f"posterior rank",
                 # Plot ylabel and legend at last.
@@ -1126,85 +1214,84 @@ def sbc_rank_plot(
     return fig, ax
 
 
-def plot_ranks_as_hist(
-    ranks: Tensor,
+def _plot_ranks_as_hist(
+    ranks: np.ndarray,
     num_bins: int,
     num_posterior_samples: int,
-    label: str = None,
-    color: str = None,
-    alpha: float = 0.8,
+    ranks_label: str = None,
     xlabel: str = None,
+    color: str = "firebrick",
+    alpha: float = 0.8,
     show_ylabel: bool = False,
     show_legend: bool = False,
-    num_ticks: int = 5,
+    num_ticks: int = 3,
     xlim_offset_factor: float = 0.1,
     legend_kwargs: dict = {},
 ) -> None:
-    """Plot ranks as empirical CDFs.
+    """Plot ranks as histograms on the current axis.
 
     Args:
-        ranks:
-        num_bins:
-        num_repeats:
-        label:
-        color:
-        alpha:
-        xlabel:
-        show_ylabel:
-        show_legend:
-        num_ticks:
-        legend_kwargs:
-
+        ranks: SBC ranks in shape (num_sbc_runs, )
+        num_bins: number of bins for the histogram, recommendation is num_sbc_runs / 20.
+        num_posteriors_samples: number of posterior samples used for ranking.
+        ranks_label: label for the ranks, e.g., when comparing ranks of different methods.
+        xlabel: label for the current parameter.
+        color: histogram color, default from Talts et al.
+        alpha: histogram transparency.
+        show_ylabel: whether to show y-label "counts".
+        show_legend: whether to show the legend, e.g., when comparing multiple ranks.
+        num_ticks: number of ticks on the x-axis.
+        xlim_offset_factor: factor for empty space left and right of the histogram.
+        legend_kwargs: kwargs for the legend.
     """
     xlim_offset = int(num_posterior_samples * xlim_offset_factor)
     plt.hist(
         ranks,
         bins=num_bins,
-        label=label,
+        label=ranks_label,
         color=color,
         alpha=alpha,
-        density=True,
     )
 
     if show_ylabel:
         plt.ylabel("counts")
     else:
         plt.yticks([])
-    if show_legend and label:
-        plt.legend(loc=2, handlelength=0.8, **legend_kwargs)
+    if show_legend and ranks_label:
+        plt.legend(loc=1, handlelength=0.8, **legend_kwargs)
 
     plt.xlim(-xlim_offset, num_posterior_samples + xlim_offset)
     plt.xticks(np.linspace(0, num_posterior_samples, num_ticks))
     plt.xlabel("posterior rank" if xlabel is None else xlabel)
 
 
-def plot_ranks_as_cdfs(
-    ranks: Tensor,
+def _plot_ranks_as_cdf(
+    ranks: np.ndarray,
     num_bins: int,
     num_repeats: int,
-    label: str = None,
+    ranks_label: str = None,
+    xlabel: str = None,
     color: str = None,
     alpha: float = 0.8,
-    xlabel: str = None,
-    show_ylabel: bool = False,
+    show_ylabel: bool = True,
     show_legend: bool = False,
     num_ticks: int = 3,
     legend_kwargs: dict = {},
 ) -> None:
-    """Plot ranks as empirical CDFs.
+    """Plot ranks as empirical CDFs on the current axis.
 
     Args:
-        ranks:
-        num_bins:
-        num_repeats:
-        label:
-        color:
-        alpha:
-        xlabel:
-        show_ylabel:
-        show_legend:
-        num_ticks:
-        legend_kwargs:
+        ranks: SBC ranks in shape (num_sbc_runs, )
+        num_bins: number of bins for the histogram, recommendation is num_sbc_runs / 20.
+        num_repeats: number of repeats of each CDF step, i.e., resolution of the eCDF.
+        ranks_label: label for the ranks, e.g., when comparing ranks of different methods.
+        xlabel: label for the current parameter
+        color: line color for the cdf.
+        alpha: line transparency.
+        show_ylabel: whether to show y-label "counts".
+        show_legend: whether to show the legend, e.g., when comparing multiple ranks.
+        num_ticks: number of ticks on the x-axis.
+        legend_kwargs: kwargs for the legend.
 
     """
     # Generate histogram of ranks.
@@ -1215,7 +1302,7 @@ def plot_ranks_as_cdfs(
     plt.plot(
         np.linspace(0, num_bins, num_repeats * num_bins),
         np.repeat(histcs / histcs.max(), num_repeats),
-        label=label,
+        label=ranks_label,
         color=color,
         alpha=alpha,
     )
@@ -1226,7 +1313,7 @@ def plot_ranks_as_cdfs(
     else:
         # Plot ticks only
         plt.yticks(np.linspace(0, 1, 3), [])
-    if show_legend and label:
+    if show_legend and ranks_label:
         plt.legend(loc=2, handlelength=0.8, **legend_kwargs)
 
     plt.ylim(0, 1)
@@ -1235,14 +1322,14 @@ def plot_ranks_as_cdfs(
     plt.xlabel("posterior rank" if xlabel is None else xlabel)
 
 
-def plot_cdf_region_expected_under_uniformity(
+def _plot_cdf_region_expected_under_uniformity(
     num_sbc_runs: int,
     num_bins: int,
     num_repeats: int,
-    alpha: float = 0.1,
-    color="grey",
-):
-    """Plot region of empirical cdfs expected under uniformity."""
+    alpha: float = 0.2,
+    color: str = "grey",
+) -> None:
+    """Plot region of empirical cdfs expected under uniformity on the current axis."""
 
     # Construct uniform histogram.
     uni_bins = binom(num_sbc_runs, p=1 / num_bins).ppf(0.5) * np.ones(num_bins)
@@ -1264,24 +1351,23 @@ def plot_cdf_region_expected_under_uniformity(
     )
 
 
-def plot_hist_region_expected_under_uniformity(
+def _plot_hist_region_expected_under_uniformity(
     num_sbc_runs: int,
     num_bins: int,
     num_posterior_samples: int,
-    alpha: float = 0.1,
-    color="grey",
-):
+    alpha: float = 0.2,
+    color: str = "grey",
+) -> None:
     """Plot region of empirical cdfs expected under uniformity."""
 
     lower = binom(num_sbc_runs, p=1 / (num_bins + 1)).ppf(0.005)
     upper = binom(num_sbc_runs, p=1 / (num_bins + 1)).ppf(0.995)
-        
+
     # Plot grey area with expected ECDF.
     plt.fill_between(
-        x=np.linspace(0, num_bins, num_posterior_samples),
-        y1=np.repeat(lower, num_posterior_samples),
-        y2=np.repeat(upper, num_posterior_samples),
+        x=np.linspace(0, num_posterior_samples, num_bins),
+        y1=np.repeat(lower, num_bins),
+        y2=np.repeat(upper, num_bins),
         color=color,
         alpha=alpha,
     )
-

--- a/sbi/analysis/plot.py
+++ b/sbi/analysis/plot.py
@@ -3,14 +3,14 @@
 
 import collections
 from typing import Any, List, Optional, Tuple, Union
-from warnings import warn
 
 import matplotlib as mpl
 import numpy as np
 import six
 import torch
 from matplotlib import pyplot as plt
-from scipy.stats import gaussian_kde
+from scipy.stats import binom, gaussian_kde
+from torch import Tensor
 
 from sbi.utils import eval_conditional_density
 
@@ -976,3 +976,200 @@ def _get_default_opts():
         },
         "title_format": {"fontsize": 16},
     }
+
+
+def sbc_rank_plot(
+    ranks,
+    num_bins=100,
+    num_repeats=50,
+    parameter_labels=None,
+    ranks_labels=None,
+    colors=None,
+    line_alpha=0.8,
+    show_uniform_region=True,
+    uniform_region_alpha=0.2,
+    fig=None,
+    ax=None,
+    figsize=None,
+):
+    """Plot simulation-based calibration ranks as empirical CDFs.
+
+    Args:
+        ranks: Tensor of ranks to be plotted, or list of Tensors when comparing several sets
+            of ranks, e.g., set of ranks obtained from different methods.
+        num_bins: number of bins used for calculating empirical cdfs via histograms.
+        num_repeats: number of repeats for each empirical CDF step (resolution).
+        parameter_labels: list of labels for each parameter dimension.
+        ranks_labels: list of labels for each set of ranks.
+        colors: list of colors for each parameter dimension, or each set of ranks.
+        line_alpha: alpha for cdf lines
+        show_uniform_region: whether to plot the region showing the cdfs expected under uniformity
+        uniform_region_alpha: alpha for region showing the cdfs expected under uniformity.
+        fig: figure object to plot in.
+        ax: axis object, must have shape (number of set of ranks,) or be a raw Axes object.
+        figsize: dimensions of figure object, defaults to (8, 5) or (number of set of ranks * 4, 5).
+
+    Returns:
+        fig, ax: figure and axis objects.
+
+    """
+
+    if isinstance(ranks, (Tensor, np.ndarray)):
+        ranks = [ranks]
+    else:
+        assert isinstance(ranks, List)
+
+    num_sbc_runs, num_parameters = ranks[0].shape
+    num_ranks = len(ranks)
+
+    for ranki in ranks:
+        assert (
+            ranki.shape == ranks[0].shape
+        ), "all ranks in list must have the same shape."
+
+    if figsize is None:
+        figsize = (num_parameters * 4, 5) if num_ranks > 1 else (8, 5)
+
+    if parameter_labels is None:
+        parameter_labels = [f"dim {i+1}" for i in range(num_parameters)]
+    if ranks_labels is None:
+        ranks_labels = [f"rank set {i+1}" for i in range(num_ranks)]
+
+    # Plot one row subplot for each parameter, different "methods" in each subplot.
+    if num_ranks > 1:
+        if fig is None or ax is None:
+            fig, ax = plt.subplots(1, num_parameters, figsize=figsize)
+        else:
+            assert ax.shape == (
+                num_parameters,
+            ), "Expecting subplots of shape 1, num_parameters."
+
+        for ii, ranki in enumerate(ranks):
+            for jj in range(num_parameters):
+                plt.sca(ax[jj])
+
+                plot_ranks_as_cdfs(
+                    ranki[:, jj],
+                    num_bins,
+                    num_repeats,
+                    label=ranks_labels[ii],
+                    color=f"C{ii}" if colors is None else colors[ii],
+                    xlabel=f"posterior rank {parameter_labels[jj]}",
+                    # Show legend and ylabel only in first subplot.
+                    show_ylabel=jj == 0,
+                    show_legend=jj == 0,
+                    alpha=line_alpha,
+                )
+                if ii == 0 and show_uniform_region:
+                    plot_cdf_region_expected_under_uniformity(
+                        num_sbc_runs, num_bins, num_repeats, alpha=0.1
+                    )
+
+    # When there is only one set of ranks show all params in a single subplot.
+    else:
+        if fig is None or ax is None:
+            fig, ax = plt.subplots(1, 1, figsize=figsize)
+
+        plt.sca(ax)
+        ranki = ranks[0]
+        for jj in range(num_parameters):
+            plot_ranks_as_cdfs(
+                ranki[:, jj],
+                num_bins,
+                num_repeats,
+                label=parameter_labels[jj],
+                color=f"C{jj}" if colors is None else colors[jj],
+                xlabel=f"posterior rank",
+                # Plot ylabel and legend at last.
+                show_ylabel=jj == (num_parameters - 1),
+                show_legend=jj == (num_parameters - 1),
+                alpha=line_alpha,
+            )
+        if show_uniform_region:
+            plot_cdf_region_expected_under_uniformity(
+                num_sbc_runs, num_bins, num_repeats, alpha=uniform_region_alpha
+            )
+
+    return fig, ax
+
+
+def plot_ranks_as_cdfs(
+    ranks,
+    num_bins,
+    num_repeats,
+    label=None,
+    color=None,
+    alpha: float = 0.8,
+    xlabel=None,
+    show_ylabel=False,
+    show_legend=False,
+    num_ticks: int = 3,
+    legend_kwargs=dict(),
+) -> None:
+    """Plot ranks as empirical CDFs.
+
+    Args:
+        ranks:
+        num_bins:
+        num_repeats:
+        label:
+        color:
+        alpha:
+        xlabel:
+        show_ylabel:
+        show_legend:
+        num_ticks:
+        legend_kwargs:
+
+    """
+    # Generate histogram of ranks.
+    hist, *_ = np.histogram(ranks, bins=num_bins, density=False)
+    # Construct empirical CDF.
+    histcs = hist.cumsum()
+    # Plot cdf and repeat each stair step
+    plt.plot(
+        np.linspace(0, num_bins, num_repeats * num_bins),
+        np.repeat(histcs / histcs.max(), num_repeats),
+        label=label,
+        color=color,
+        alpha=alpha,
+    )
+
+    if show_ylabel:
+        plt.yticks(np.linspace(0, 1, 3))
+        plt.ylabel("empirical CDF")
+    else:
+        # Plot ticks only
+        plt.yticks(np.linspace(0, 1, 3), [])
+    if show_legend and label:
+        plt.legend(loc=2, handlelength=0.8, **legend_kwargs)
+
+    plt.ylim(0, 1)
+    plt.xlim(0, num_bins)
+    plt.xticks(np.linspace(0, num_bins, num_ticks))
+    plt.xlabel("posterior rank" if xlabel is None else xlabel)
+
+
+def plot_cdf_region_expected_under_uniformity(
+    num_sbc_runs, num_bins, num_repeats, alpha: float = 0.1, color="grey"
+):
+    """Plot region of empirical cdfs expected under uniformity."""
+
+    # Construct uniform histogram.
+    uni_bins = binom(num_sbc_runs, p=1 / num_bins).ppf(0.5) * np.ones(num_bins)
+    uni_bins_cdf = uni_bins.cumsum() / uni_bins.sum()
+    # Decrease value one in last entry by epsilon to find valid
+    # confidence intervals.
+    uni_bins_cdf[-1] -= 1e-9
+
+    lower = [binom(num_sbc_runs, p=p).ppf(0.005) for p in uni_bins_cdf]
+    upper = [binom(num_sbc_runs, p=p).ppf(0.995) for p in uni_bins_cdf]
+
+    # Plot grey area with expected ECDF.
+    plt.fill_between(
+        x=np.linspace(0, num_bins, num_repeats * num_bins),
+        y1=np.repeat(lower / np.max(lower), num_repeats),
+        y2=np.repeat(upper / np.max(upper), num_repeats),
+        color=color,
+        alpha=alpha,
+    )

--- a/tests/plot_test.py
+++ b/tests/plot_test.py
@@ -1,14 +1,16 @@
 # This file is part of sbi, a toolkit for simulation-based inference. sbi is licensed
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
+import numpy as np
 import pytest
 import torch
 
-from matplotlib.figure import Figure
 from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+from matplotlib.pyplot import subplots
 from torch.utils.tensorboard import SummaryWriter
 
-from sbi.analysis import plot_summary
+from sbi.analysis import plot_summary, sbc_rank_plot
 from sbi.inference import (
     SNLE,
     SNPE,
@@ -41,3 +43,36 @@ def test_plot_summary(method, tmp_path):
     _ = inference.append_simulations(theta, x).train(**train_kwargs)
     fig, axes = plot_summary(inference)
     assert isinstance(fig, Figure) and isinstance(axes[0], Axes)
+
+
+@pytest.mark.parametrize("num_parameters", (2, 4, 10))
+@pytest.mark.parametrize("num_cols", (2, 3, 4))
+@pytest.mark.parametrize("custom_figure", (False, True))
+@pytest.mark.parametrize("plot_type", ("hist", "cdf"))
+def test_sbc_rank_plot(num_parameters, num_cols, custom_figure, plot_type):
+    """Test sbc plots with different num_parameters, subplot shapes and plot types."""
+
+    num_sbc_runs = 100
+    num_posterior_samples = 100
+    # Create uniform bins.
+    ranks = np.random.randint(
+        1, num_posterior_samples + 1, size=(num_sbc_runs, num_parameters)
+    )
+
+    # Test passing custom figure.
+    if custom_figure:
+        fig, ax = subplots(1, num_parameters, figsize=(5, 18))
+    else:
+        fig, ax = None, None
+
+    fig, ax = sbc_rank_plot(
+        ranks,
+        num_posterior_samples,
+        plot_type=plot_type,
+        kwargs=dict(fig=fig, ax=ax, num_cols=num_cols, params_in_subplots=True),
+    )
+    if not custom_figure:
+        if num_parameters > num_cols:
+            assert ax.shape == (int(np.ceil(num_parameters / num_cols)), num_cols)
+        else:
+            assert ax.shape == (num_parameters,)


### PR DESCRIPTION
I added a first set of plotting functions for SBC like I was using them so far. 

They are plotting the SBC results as empirical CDFs like suggested in the later figures in the Talts et al. paper, not as histograms. 

@psteinb feel free to comment, and to add purely histogram-based plots if you find them more appropriate. This is all open for discussion. 

fixing #588 

to do: 
- [x] improve docstrings
- [x] fix expected uniform histogram distribution (see TODO in code)
- [x] add API tests

If this is needed in `main` for completing the SBC tutorial, we can merge after a review from @michaeldeistler . Then we should move these todos to a separate issue. 