### PR TITLE
Set SIR as default init_strategy for MCMC

### DIFF
--- a/sbi/inference/posteriors/mcmc_posterior.py
+++ b/sbi/inference/posteriors/mcmc_posterior.py
@@ -48,7 +48,7 @@ class MCMCPosterior(NeuralPosterior):
         thin: int = 10,
         warmup_steps: int = 10,
         num_chains: int = 1,
-        init_strategy: str = "prior",
+        init_strategy: str = "sir",
         init_strategy_num_candidates: int = 1_000,
         device: Optional[str] = None,
         x_shape: Optional[torch.Size] = None,


### PR DESCRIPTION
See #567 

@jan-matthis liked the issue, so I guess he agrees with using SIR as default?