### PR TITLE
Change mp context to allow for multi-chain MCMC (pyro)

### DIFF
--- a/sbi/inference/posteriors/mcmc_posterior.py
+++ b/sbi/inference/posteriors/mcmc_posterior.py
@@ -399,7 +399,7 @@ class MCMCPosterior(NeuralPosterior):
             warmup_steps=warmup_steps,
             initial_params={"": initial_params},
             num_chains=num_chains,
-            mp_context="fork",
+            mp_context="spawn",
             disable_progbar=not show_progress_bars,
             transforms={},
         )


### PR DESCRIPTION
See #547 

I reproduced the issue on mac and linux. The fix works for both macbook pro (2013) and ubuntu.