### PR TITLE
Make inference object serializable

### DIFF
--- a/docs/docs/faq/question_05.md
+++ b/docs/docs/faq/question_05.md
@@ -12,7 +12,9 @@ with open("/path/to/my_posterior.pkl", "wb") as handle:
     pickle.dump(posterior, handle)
 ```
 
-Note: if you try to load a posterior that was saved under `sbi v0.14.x` or earlier under `sbi v0.15.0` or later, you have to add:
+Note: posterior objects that were saved under `sbi v0.17.2` or older can not be loaded under `sbi v0.18.0` or newer.
+
+Note: if you try to load a posterior that was saved under `sbi v0.14.x` or earlier under `sbi v0.15.x` until `sbi v0.17.x`, you have to add:
 ```python
 import sys
 from sbi.utils import user_input_checks_utils
@@ -22,35 +24,16 @@ sys.modules["sbi.user_input.user_input_checks_utils"] = user_input_checks_utils
 to your script before loading the posterior.
 
 
-`NeuralInference` objects are not picklable. There are two workarounds:
-
-- Pickle with [`dill`](https://pypi.org/project/dill/) (has to be installed with `pip install dill` first)
-```python
-import dill
-
-inference = SNPE(prior)
-# ... run inference
-
-with open("path/to/my_inference.pkl", "wb") as handle:
-    dill.dump(inference)
-```
-
-- Delete un-picklable attributes and serialize with pickle. Using this option, you will not be able to use the `retrain_from_scratch` feature and you can only use the default `SummaryWriter`.
+As of `sbi v0.18.0`, `NeuralInference` objects are also picklable.
 ```python
 import pickle
 
-inference = SNPE(prior)
 # ... run inference
-
 posterior = inference.build_posterior()
-inference._summary_writer = None
-inference._build_neural_net = None
+
 with open("/path/to/my_inference.pkl", "wb") as handle:
     pickle.dump(inference, handle)
 ```
-Then, to load:
-```python
-with open("/path/to/my_inference.pkl", "rb") as handle:
-    inference_from_disk = pickle.load(handle)
-inference_from_disk._summary_writer = inference_from_disk._default_summary_writer()
-```
+However, saving and loading the `inference` object will slightly modify the object (in order to make it serializable). These modifications lead to the following two changes in behaviour:
+1) Retraining from scratch is not supported, i.e. `.train(..., retrain_from_scratch=True)` does not work.
+2) When the loaded object calls the `.train()` method, it generates a new tensorboard summary writer (instead of appending to the current one).

--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -514,6 +514,42 @@ class NeuralInference(ABC):
     def summary(self):
         return self._summary
 
+    def __getstate__(self) -> Dict:
+        """Returns the state of the object that is supposed to be pickled.
+
+        Attributes that can not be serialized are set to `None`.
+
+        Returns:
+            Dictionary containing the state.
+        """
+        warn(
+            "When the inference object is pickled, the behaviour of the loaded object "
+            "changes in the following two ways: "
+            "1) `.train(..., retrain_from_scratch=True)` is not supported. "
+            "2) When the loaded object calls the `.train()` method, it generates a new "
+            "tensorboard summary writer (instead of appending to the current one)."
+        )
+        dict_to_save = {}
+        unpicklable_attributes = ["_summary_writer", "_build_neural_net"]
+        for key in self.__dict__.keys():
+            if key in unpicklable_attributes:
+                dict_to_save[key] = None
+            else:
+                dict_to_save[key] = self.__dict__[key]
+        return dict_to_save
+
+    def __setstate__(self, state_dict: Dict):
+        """Sets the state when being loaded from pickle.
+
+        Also creates a new summary writer (because the previous one was set to `None`
+        during serializing, see `__get_state__()`).
+
+        Args:
+            state_dict: State to be restored.
+        """
+        state_dict["_summary_writer"] = self._default_summary_writer()
+        self.__dict__ = state_dict
+
 
 def simulate_for_sbi(
     simulator: Callable,


### PR DESCRIPTION
Resolves #476 

Saving the inference object was always a bit messy. But `dill` used to work.

I just tried and could no longer save the inference object with dill. The workaround in this PR is to set the non-serializable objects to `None` before saving. This allows to save the inference object with `pickle`. These modifications lead to the following two changes in behaviour:
1) Retraining from scratch is not supported, i.e. `.train(..., retrain_from_scratch=True)` does not work after loading.
2) When the loaded object calls the `.train()` method, it generates a new tensorboard summary writer (instead of appending to the current one).