### PR TITLE
check effect of z-scoring only on valid data, #576.

### DIFF
--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -252,7 +252,7 @@ class NeuralInference(ABC):
         # Check for NaNs in simulations.
         is_valid_x, num_nans, num_infs = handle_invalid_x(x, exclude_invalid_x)
         # Check for problematic z-scoring
-        warn_if_zscoring_changes_data(x)
+        warn_if_zscoring_changes_data(x[is_valid_x])
         if warn_on_invalid:
             warn_on_invalid_x(num_nans, num_infs, exclude_invalid_x)
             warn_on_invalid_x_for_snpec_leakage(


### PR DESCRIPTION
closes #576 

slow tests where failing because we were checking for non-unique `x` without excluding invalid `x`. This is fixed here.