### PR TITLE
Allow MCMC transforms for MultipleIndependentConstraints prior

### DIFF
--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -517,8 +517,23 @@ def mcmc_transform(
             )
             has_support = False
 
-        # Prior with bounded support, e.g., uniform priors.
+        # If the distribution has a `support`, check if the support is bounded.
+        # If it is not bounded, we want to z-score the space. This is not done
+        # by `biject_to()`, so we have to deal with this case separately.
         if has_support:
+            if hasattr(prior.support, "base_constraint"):
+                constraint = prior.support.base_constraint
+            else:
+                constraint = prior.support
+            if isinstance(constraint, constraints._Real):
+                support_is_bounded = False
+            else:
+                support_is_bounded = True
+        else:
+            support_is_bounded = False
+
+        # Prior with bounded support, e.g., uniform priors.
+        if has_support and support_is_bounded:
             transform = biject_to(prior.support)
         # For all other cases build affine transform with mean and std.
         else:

--- a/sbi/utils/user_input_checks.py
+++ b/sbi/utils/user_input_checks.py
@@ -387,7 +387,7 @@ def check_prior_support(prior):
     """
 
     try:
-        within_support(prior, prior.sample())
+        within_support(prior, prior.sample((1,)))
     except NotImplementedError:
         raise NotImplementedError(
             """The prior must implement the support property or allow to call

--- a/tests/sbiutils_test.py
+++ b/tests/sbiutils_test.py
@@ -4,14 +4,13 @@ import matplotlib.pyplot as plt
 import pytest
 import torch
 from torch import Tensor, eye, ones, zeros
-from torch.distributions import Exponential, LogNormal, MultivariateNormal
+from torch.distributions import MultivariateNormal
 from torch.distributions.transforms import IndependentTransform, identity_transform
 
 from sbi.inference import SNPE, SNPE_A
 from sbi.inference.snpe.snpe_a import SNPE_A_MDN
 from sbi.utils import (
     BoxUniform,
-    MultipleIndependent,
     get_kde,
     mcmc_transform,
     posterior_nn,
@@ -361,40 +360,6 @@ def test_gaussian_transforms(snpe_method: str, plot_results: bool = False):
             ax[3].set_title("SNPE-A")
 
         plt.show()
-
-
-@pytest.mark.parametrize(
-    "prior, enable_transform",
-    (
-        (BoxUniform(zeros(5), ones(5)), True),
-        (BoxUniform(zeros(1), ones(1)), True),
-        (BoxUniform(zeros(5), ones(5)), False),
-        (MultivariateNormal(zeros(5), eye(5)), True),
-        (Exponential(rate=ones(1)), True),
-        (LogNormal(zeros(1), ones(1)), True),
-        (
-            MultipleIndependent(
-                [Exponential(rate=ones(1)), BoxUniform(zeros(5), ones(5))]
-            ),
-            True,
-        ),
-    ),
-)
-def test_mcmc_transform(prior, enable_transform):
-    """
-    Test whether the transform for MCMC returns the log_abs_det in the correct shape.
-    """
-
-    num_samples = 1000
-    prior, _, _ = process_prior(prior)
-    tf = mcmc_transform(prior, enable_transform=enable_transform)
-
-    samples = prior.sample((num_samples,))
-    unconstrained_samples = tf(samples)
-    samples_original = tf.inv(unconstrained_samples)
-
-    log_abs_det = tf.log_abs_det_jacobian(samples_original, unconstrained_samples)
-    assert log_abs_det.shape == torch.Size([num_samples])
 
 
 @pytest.mark.parametrize(

--- a/tests/transforms_test.py
+++ b/tests/transforms_test.py
@@ -1,26 +1,27 @@
-from turtle import pd
 import pytest
 import torch
-
-from torch.distributions import Uniform, MultivariateNormal, LogNormal
+from torch import ones, zeros, eye
+from torch.distributions import Uniform, MultivariateNormal, LogNormal, Exponential
 from torch.distributions.transforms import (
     AffineTransform,
     ComposeTransform,
+    ExpTransform,
     IndependentTransform,
+    SigmoidTransform,
 )
 
-from sbi.utils import BoxUniform, mcmc_transform, process_prior
+from sbi.utils import BoxUniform, mcmc_transform, process_prior, MultipleIndependent
 from tests.user_input_checks_test import UserNumpyUniform
 
 
 @pytest.mark.parametrize(
     "prior, target_transform",
     (
-        (Uniform(-torch.ones(1), torch.ones(1)), ComposeTransform),
-        (BoxUniform(-torch.ones(2), torch.ones(2)), ComposeTransform),
-        (UserNumpyUniform(torch.zeros(2), torch.ones(2)), ComposeTransform),
+        (Uniform(-torch.ones(1), torch.ones(1)), SigmoidTransform),
+        (BoxUniform(-torch.ones(2), torch.ones(2)), SigmoidTransform),
+        (UserNumpyUniform(torch.zeros(2), torch.ones(2)), SigmoidTransform),
         (MultivariateNormal(torch.zeros(2), torch.eye(2)), AffineTransform),
-        (LogNormal(loc=torch.zeros(1), scale=torch.ones(1)), AffineTransform),
+        (LogNormal(loc=torch.zeros(1), scale=torch.ones(1)), ExpTransform),
     ),
 )
 def test_transforms(prior, target_transform):
@@ -37,8 +38,47 @@ def test_transforms(prior, target_transform):
     if isinstance(core_transform, IndependentTransform):
         core_transform = core_transform.base_transform
 
-    assert isinstance(core_transform, target_transform)
+    if hasattr(core_transform, "parts"):
+        transform_to_inspect = core_transform.parts[0]
+    else:
+        transform_to_inspect = core_transform
+
+    assert isinstance(transform_to_inspect, target_transform)
 
     samples = prior.sample((2,))
     transformed_samples = transform(samples)
     assert torch.allclose(samples, transform.inv(transformed_samples))
+
+
+@pytest.mark.parametrize(
+    "prior, enable_transform",
+    (
+        (BoxUniform(zeros(5), ones(5)), True),
+        (BoxUniform(zeros(1), ones(1)), True),
+        (BoxUniform(zeros(5), ones(5)), False),
+        (MultivariateNormal(zeros(5), eye(5)), True),
+        (Exponential(rate=ones(1)), True),
+        (LogNormal(zeros(1), ones(1)), True),
+        (
+            MultipleIndependent(
+                [Exponential(rate=ones(1)), BoxUniform(zeros(5), ones(5))]
+            ),
+            True,
+        ),
+    ),
+)
+def test_mcmc_transform(prior, enable_transform):
+    """
+    Test whether the transform for MCMC returns the log_abs_det in the correct shape.
+    """
+
+    num_samples = 1000
+    prior, _, _ = process_prior(prior)
+    tf = mcmc_transform(prior, enable_transform=enable_transform)
+
+    samples = prior.sample((num_samples,))
+    unconstrained_samples = tf(samples)
+    samples_original = tf.inv(unconstrained_samples)
+
+    log_abs_det = tf.log_abs_det_jacobian(samples_original, unconstrained_samples)
+    assert log_abs_det.shape == torch.Size([num_samples])

--- a/tests/transforms_test.py
+++ b/tests/transforms_test.py
@@ -1,0 +1,44 @@
+from turtle import pd
+import pytest
+import torch
+
+from torch.distributions import Uniform, MultivariateNormal, LogNormal
+from torch.distributions.transforms import (
+    AffineTransform,
+    ComposeTransform,
+    IndependentTransform,
+)
+
+from sbi.utils import BoxUniform, mcmc_transform, process_prior
+from tests.user_input_checks_test import UserNumpyUniform
+
+
+@pytest.mark.parametrize(
+    "prior, target_transform",
+    (
+        (Uniform(-torch.ones(1), torch.ones(1)), ComposeTransform),
+        (BoxUniform(-torch.ones(2), torch.ones(2)), ComposeTransform),
+        (UserNumpyUniform(torch.zeros(2), torch.ones(2)), ComposeTransform),
+        (MultivariateNormal(torch.zeros(2), torch.eye(2)), AffineTransform),
+        (LogNormal(loc=torch.zeros(1), scale=torch.ones(1)), AffineTransform),
+    ),
+)
+def test_transforms(prior, target_transform):
+
+    if isinstance(prior, UserNumpyUniform):
+        prior, *_ = process_prior(
+            prior,
+            dict(lower_bound=torch.zeros(2), upper_bound=torch.ones(2)),
+        )
+
+    transform = mcmc_transform(prior)
+    core_transform = transform._inv
+
+    if isinstance(core_transform, IndependentTransform):
+        core_transform = core_transform.base_transform
+
+    assert isinstance(core_transform, target_transform)
+
+    samples = prior.sample((2,))
+    transformed_samples = transform(samples)
+    assert torch.allclose(samples, transform.inv(transformed_samples))

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -9,7 +9,7 @@ import pytest
 from sbi.inference.posteriors.mcmc_posterior import MCMCPosterior
 import torch
 from pyknos.mdn.mdn import MultivariateGaussianMDN
-from scipy.stats import beta, multivariate_normal, uniform
+from scipy.stats import beta, multivariate_normal, uniform, lognorm
 from torch import Tensor, eye, nn, ones, zeros
 from torch.distributions import Beta, Distribution, Gamma, MultivariateNormal, Uniform
 
@@ -94,6 +94,7 @@ def matrix_simulator(theta):
             dict(lower_bound=zeros(3), upper_bound=ones(3)),
         ),
         (ScipyPytorchWrapper, multivariate_normal(), dict()),
+        (ScipyPytorchWrapper, lognorm(s=1.0), dict()),
         (
             ScipyPytorchWrapper,
             uniform(),


### PR DESCRIPTION
This PR allows to infer the `transform` for priors that were provided as `MultipleIndependentDistributions`.

In addition, it allows inferring the transform for **any** bounded distribution (not just interval constraints)