### PR TITLE
FIX neg num_workers + adaptive rejction batch + reduce memory leak

### DIFF
--- a/sbi/analysis/sbc.py
+++ b/sbi/analysis/sbc.py
@@ -64,7 +64,7 @@ def run_sbc(
     thetas_batches = torch.split(thetas, sbc_batch_size, dim=0)
     xs_batches = torch.split(xs, sbc_batch_size, dim=0)
 
-    if num_workers > 1:
+    if num_workers != 1:
         # Parallelize the sequence of batches across workers.
         # We use the solution proposed here: https://stackoverflow.com/a/61689175
         # to update the pbar only after the workers finished a task.

--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -177,13 +177,13 @@ class NeuralInference(ABC):
         f"https://github.com/mackelab/sbi/pull/378.",
         """
         raise NameError(
-            f"The inference object is no longer callable as of `sbi` v0.14.0. "
-            f"Please consult the release notes for a tutorial on how to adapt your "
-            f"code: https://github.com/mackelab/sbi/releases/tag/v0.14.0"
-            f"For more information, visit our website: "
-            f"https://www.mackelab.org/sbi/tutorial/02_flexible_interface/ or "
-            f"see the corresponding pull request on github: "
-            f"https://github.com/mackelab/sbi/pull/378.",
+            "The inference object is no longer callable as of `sbi` v0.14.0. "
+            "Please consult the release notes for a tutorial on how to adapt your "
+            "code: https://github.com/mackelab/sbi/releases/tag/v0.14.0"
+            "For more information, visit our website: "
+            "https://www.mackelab.org/sbi/tutorial/02_flexible_interface/ or "
+            "see the corresponding pull request on github: "
+            "https://github.com/mackelab/sbi/pull/378.",
         )
 
     def provide_presimulated(
@@ -208,15 +208,15 @@ class NeuralInference(ABC):
                 that the data came from the first round, i.e. the prior.
         """
         raise NameError(
-            f"Deprecated since sbi 0.14.0. "
-            f"Instead of using this, please use `.append_simulations()`. Please "
-            f"consult release notes to see how you can update your code: "
-            f"https://github.com/mackelab/sbi/releases/tag/v0.14.0"
-            f"More information can be found under the corresponding pull request on "
-            f"github: "
-            f"https://github.com/mackelab/sbi/pull/378"
-            f"and tutorials: "
-            f"https://www.mackelab.org/sbi/tutorial/02_flexible_interface/",
+            "Deprecated since sbi 0.14.0. "
+            "Instead of using this, please use `.append_simulations()`. Please "
+            "consult release notes to see how you can update your code: "
+            "https://github.com/mackelab/sbi/releases/tag/v0.14.0"
+            "More information can be found under the corresponding pull request on "
+            "github: "
+            "https://github.com/mackelab/sbi/pull/378"
+            "and tutorials: "
+            "https://www.mackelab.org/sbi/tutorial/02_flexible_interface/",
         )
 
     def get_simulations(
@@ -295,7 +295,7 @@ class NeuralInference(ABC):
             resume_training: Whether the current call is resuming training so that no
                 new training and validation indices into the dataset have to be created.
             dataloader_kwargs: Additional or updated kwargs to be passed to the training
-                and validation dataloaders (like, e.g., a collate_fn)
+                and validation dataloaders (like, e.g., a collate_fn).
 
         Returns:
             Tuple of dataloaders for training and validation.
@@ -325,22 +325,16 @@ class NeuralInference(ABC):
             "drop_last": True,
             "sampler": data.sampler.SubsetRandomSampler(self.train_indices),
         }
-        train_loader_kwargs = (
-            dict(train_loader_kwargs, **dataloader_kwargs)
-            if dataloader_kwargs is not None
-            else train_loader_kwargs
-        )
         val_loader_kwargs = {
             "batch_size": min(training_batch_size, num_validation_examples),
             "shuffle": False,
             "drop_last": True,
             "sampler": data.sampler.SubsetRandomSampler(self.val_indices),
         }
-        val_loader_kwargs = (
-            dict(val_loader_kwargs, **dataloader_kwargs)
-            if dataloader_kwargs is not None
-            else val_loader_kwargs
-        )
+        if dataloader_kwargs is not None:
+            train_loader_kwargs = dict(train_loader_kwargs, **dataloader_kwargs)
+            val_loader_kwargs = dict(val_loader_kwargs, **dataloader_kwargs)
+
         train_loader = data.DataLoader(dataset, **train_loader_kwargs)
         val_loader = data.DataLoader(dataset, **val_loader_kwargs)
 

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -269,7 +269,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
 
         # Avoid keeping the gradients in the resulting network, which can
         # cause memory leakage when benchmarking.
-        self._neural_net.zero_grad()
+        self._neural_net.zero_grad(set_to_none=True)
 
         return deepcopy(self._neural_net)
 

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -267,6 +267,10 @@ class LikelihoodEstimator(NeuralInference, ABC):
         if show_train_summary:
             print(self._describe_round(self._round, self._summary))
 
+        # Avoid keeping the gradients in the resulting network, which can
+        # cause memory leakage when benchmarking.
+        self._neural_net.zero_grad()
+
         return deepcopy(self._neural_net)
 
     def build_posterior(

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -351,7 +351,8 @@ class PosteriorEstimator(NeuralInference, ABC):
 
         # Avoid keeping the gradients in the resulting network, which can
         # cause memory leakage when benchmarking.
-        self._neural_net.zero_grad()
+        self._neural_net.zero_grad(set_to_none=True)
+
         return deepcopy(self._neural_net)
 
     def build_posterior(

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -272,6 +272,10 @@ class RatioEstimator(NeuralInference, ABC):
         if show_train_summary:
             print(self._describe_round(self._round, self._summary))
 
+        # Avoid keeping the gradients in the resulting network, which can
+        # cause memory leakage when benchmarking.
+        self._neural_net.zero_grad()
+
         return deepcopy(self._neural_net)
 
     def _classifier_logits(self, theta: Tensor, x: Tensor, num_atoms: int) -> Tensor:

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -274,7 +274,7 @@ class RatioEstimator(NeuralInference, ABC):
 
         # Avoid keeping the gradients in the resulting network, which can
         # cause memory leakage when benchmarking.
-        self._neural_net.zero_grad()
+        self._neural_net.zero_grad(set_to_none=True)
 
         return deepcopy(self._neural_net)
 

--- a/sbi/samplers/rejection/rejection.py
+++ b/sbi/samplers/rejection/rejection.py
@@ -7,7 +7,6 @@ import torch.distributions.transforms as torch_tf
 from torch import Tensor, as_tensor
 from tqdm.auto import tqdm
 
-from sbi import utils as utils
 from sbi.utils import gradient_ascent, within_support
 
 
@@ -150,9 +149,13 @@ def rejection_sample(
             # acceptance rate is too low after the first 1_000 samples.
             acceptance_rate = (num_samples - num_remaining) / num_sampled_total
 
-            # For remaining iterations (leakage or many samples) continue sampling with
-            # fixed batch size.
-            sampling_batch_size = max_sampling_batch_size
+            # For remaining iterations (leakage or many samples) continue
+            # sampling with fixed batch size, reduced in cased the number
+            # of remaining samples is low.
+            sampling_batch_size = min(
+                max_sampling_batch_size,
+                max(int(1.5 * num_remaining / acceptance_rate), 100)
+            )
             if (
                 num_sampled_total > 1000
                 and acceptance_rate < warn_acceptance

--- a/sbi/simulators/simutils.py
+++ b/sbi/simulators/simutils.py
@@ -47,7 +47,7 @@ def simulate_in_batches(
         # as of PyTorch 1.4.0, see https://github.com/microsoft/pyright/issues/291
         batches = torch.split(theta, sim_batch_size, dim=0)
 
-        if num_workers > 1:
+        if num_workers != 1:
             # Parallelize the sequence of batches across workers.
             # We use the solution proposed here: https://stackoverflow.com/a/61689175
             # to update the pbar only after the workers finished a task.

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -9,16 +9,15 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 import torch
 import pyknos.nflows.transforms as transforms
 from pyro.distributions import Empirical
-from torch import Tensor, as_tensor, float32
+from torch import Tensor
 from torch import nn as nn
 from torch import ones, optim, zeros
 from torch.distributions import Distribution, Independent, biject_to, constraints
 import torch.distributions.transforms as torch_tf
-from tqdm.auto import tqdm
 
 from sbi import utils as utils
 from sbi.types import TorchTransform
-from sbi.utils.torchutils import BoxUniform, atleast_2d
+from sbi.utils.torchutils import atleast_2d
 
 
 def warn_if_zscoring_changes_data(x: Tensor, duplicate_tolerance: float = 0.1) -> None:
@@ -96,8 +95,9 @@ def z_score_parser(z_score_flag: Optional["str"]) -> Tuple[bool, bool]:
     if type(z_score_flag) is bool:
         # Raise warning if boolean was passed.
         warnings.warn(
-            """Boolean flag for z-scoring is deprecated as of sbi v0.18.0. It will be removed in a future release. Use 'none', 'independent', or 'structured' to indicate z-scoring option.
-        """
+            "Boolean flag for z-scoring is deprecated as of sbi v0.18.0. It will be "
+            "removed in a future release. Use 'none', 'independent', or 'structured' "
+            "to indicate z-scoring option."
         )
         z_score_bool, structured_data = z_score_flag, False
 

--- a/tests/multiprocessing_test.py
+++ b/tests/multiprocessing_test.py
@@ -25,8 +25,9 @@ def slow_linear_gaussian(theta):
 
 
 @pytest.mark.slow
+@pytest.mark.parametrize("num_workers", [10, -2])
 @pytest.mark.parametrize("sim_batch_size", ((1, 10, 100)))
-def test_benchmarking_sp(sim_batch_size):
+def test_benchmarking_sp(sim_batch_size, num_workers):
 
     num_simulations = 100
     theta = torch.zeros(num_simulations, 2)
@@ -47,7 +48,7 @@ def test_benchmarking_sp(sim_batch_size):
         slow_linear_gaussian,
         theta,
         sim_batch_size,
-        num_workers=10,
+        num_workers=num_workers,
         show_progress_bars=show_pbar,
     )
     toc_joblib = time.time() - tic


### PR DESCRIPTION
First of all, thanks for this great library!

I used it recently and I had to change a few things on my use case:

- Use an adaptive batch size for rejection sampling. When trying to get `1000` samples with rejection rate to `3%`, it can be quite frustrating to need to do a second full `1000` batch instead of sampling `100`. I propose a strategy that should not change to much the current behavior but simply reduce these edge cases.
- Setting grad to zero before returning/copying the model to avoid large memory consumption.
- Using negative number to set the `num_workers` parameter to compute simulations. When running experiments on heterogeneouse cluster, it is nice to be able to set the number of workers relative the number of CPUs available.
- A few clean up for some unused imports.

I did this PR to integrate them in the library if you think it is useful.
If some part should be trimmed or better tested, let me know.