### PR TITLE
set self._neural_net to passed density estimator

### DIFF
--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -314,7 +314,8 @@ class LikelihoodEstimator(NeuralInference, ABC):
             device = self._device
         else:
             # Otherwise, infer it from the device of the net parameters.
-            device = next(density_estimator.parameters()).device.type
+            self._neural_net = density_estimator
+            device = next(self._neural_net.parameters()).device.type
 
         potential_fn, theta_transform = likelihood_estimator_based_potential(
             likelihood_estimator=self._neural_net, prior=prior, x_o=None

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -403,7 +403,8 @@ class PosteriorEstimator(NeuralInference, ABC):
             device = self._device
         else:
             # Otherwise, infer it from the device of the net parameters.
-            device = next(density_estimator.parameters()).device.type
+            self._neural_net = density_estimator
+            device = next(self._neural_net.parameters()).device.type
 
         potential_fn, theta_transform = posterior_estimator_based_potential(
             posterior_estimator=self._neural_net, prior=prior, x_o=None

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -347,7 +347,8 @@ class RatioEstimator(NeuralInference, ABC):
             device = self._device
         else:
             # Otherwise, infer it from the device of the net parameters.
-            device = next(density_estimator.parameters()).device.type
+            self._neural_net = density_estimator
+            device = next(self._neural_net.parameters()).device.type
 
         potential_fn, theta_transform = ratio_estimator_based_potential(
             ratio_estimator=self._neural_net, prior=prior, x_o=None


### PR DESCRIPTION
error when loading an inference object and density estimator and passing the latter to the build_posterior function due to self._neural_net = None 
