### PR TITLE
Add `log_prob()` to RestrictedPrior

### DIFF
--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -584,7 +584,7 @@ def mcmc_transform(
         try:
             _ = prior.support
             has_support = True
-        except NotImplementedError or AttributeError:
+        except (NotImplementedError, AttributeError):
             # NotImplementedError -> Distribution that inherits from torch dist but
             # does not implement support.
             # AttributeError -> Custom distribution that has no support attribute.


### PR DESCRIPTION
The `RestrictedPrior` was not originally meant to be passed as a `prior` to SNPE. But this has been requested in #640. Thus, we are allowing this with this PR. In order to do this, we add a `.log_prob()` method to the `RestrictedPrior`.