### PR TITLE
autouse seed fixture in pytest to seed all tests. 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,9 @@ head over to [issues on GitHub](https://github.com/mackelab/sbi/issues).
 
 ## Code contributions
 
-In general, we use pull requests to make changes to `sbi`.
+In general, we use pull requests to make changes to `sbi`. So, if you are planning to
+make a contribution, please fork, create a feature branch and then make a PR from
+your feature branch to the upstream `sbi` ([more details](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork)).
 
 
 ### Development environment
@@ -51,6 +53,12 @@ repository, which will format all files.
 **[isort](https://github.com/timothycrosley/isort)**: Used to consistently order
 imports. You can run isort manually from the console using `isort` in the top
 directory.
+
+**[pyright](https://github.com/Microsoft/pyright)**: Used for static type checking. 
+
+`black` and `isort` and `pyright` are checked as part of our CI actions. If these
+checks fail please make sure you have installed the latest versions for each of them
+and run them locally.
 
 
 ## Online documentation

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ REQUIRED = [
 EXTRAS = {
     "dev": [
         "autoflake",
-        "black>=20.8bo",
+        "black",
         "deepdiff",
         "flake8",
         "isort",

--- a/tests/abc_test.py
+++ b/tests/abc_test.py
@@ -64,7 +64,7 @@ def test_mcabc_inference_on_linear_gaussian(
 @pytest.mark.slow
 @pytest.mark.parametrize("lra", (True, False))
 @pytest.mark.parametrize("sass_expansion_degree", (1, 2))
-def test_mcabc_sass_lra(lra, sass_expansion_degree, set_seed):
+def test_mcabc_sass_lra(lra, sass_expansion_degree):
 
     test_mcabc_inference_on_linear_gaussian(
         num_dim=2, lra=lra, sass=True, sass_expansion_degree=sass_expansion_degree
@@ -143,7 +143,7 @@ def test_smcabc_inference_on_linear_gaussian(
 @pytest.mark.slow
 @pytest.mark.parametrize("lra", (True, False))
 @pytest.mark.parametrize("sass_expansion_degree", (1, 2))
-def test_smcabc_sass_lra(lra, sass_expansion_degree, set_seed):
+def test_smcabc_sass_lra(lra, sass_expansion_degree):
 
     test_smcabc_inference_on_linear_gaussian(
         num_dim=2,
@@ -156,7 +156,7 @@ def test_smcabc_sass_lra(lra, sass_expansion_degree, set_seed):
 
 
 @pytest.mark.parametrize("kde_bandwidth", ("cv", "silvermann", "scott", 0.1))
-def test_mcabc_kde(kde_bandwidth, set_seed):
+def test_mcabc_kde(kde_bandwidth):
     test_mcabc_inference_on_linear_gaussian(
         num_dim=2, kde=True, kde_bandwidth=kde_bandwidth
     )
@@ -164,7 +164,7 @@ def test_mcabc_kde(kde_bandwidth, set_seed):
 
 @pytest.mark.slow
 @pytest.mark.parametrize("kde_bandwidth", ("cv",))
-def test_smcabc_kde(kde_bandwidth, set_seed):
+def test_smcabc_kde(kde_bandwidth):
     test_smcabc_inference_on_linear_gaussian(
         num_dim=2,
         lra=False,

--- a/tests/analysis_test.py
+++ b/tests/analysis_test.py
@@ -9,14 +9,13 @@ from sbi.utils import BoxUniform
 @pytest.mark.slow
 @pytest.mark.gpu
 @pytest.mark.parametrize("device", ["cpu", "cuda:0"])
-def test_analysis_modules(device: str, set_seed) -> None:
+def test_analysis_modules(device: str) -> None:
     """Tests sensitivity analysis and conditional posterior utils on GPU and CPU.
 
     This test performs only API tests. It does not test the accuracy of the modules.
 
     Args:
         device: Which device to run the inference on.
-        set_seed: Fixture for seeding.
     """
     num_dim = 3
     prior = BoxUniform(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,8 @@ import torch
 seed = 1
 
 
-@pytest.fixture(scope="function")
+# Use seed automatically for every test function.
+@pytest.fixture(autouse=True)
 def set_seed():
     torch.manual_seed(seed)
     numpy.random.seed(seed)

--- a/tests/ensemble_test.py
+++ b/tests/ensemble_test.py
@@ -25,12 +25,10 @@ from tests.test_utils import check_c2st, get_dkl_gaussian_prior
         "SNPE_C",
     ],
 )
-def test_c2st_posterior_ensemble_on_linearGaussian(inference_method, set_seed):
+def test_c2st_posterior_ensemble_on_linearGaussian(inference_method):
     """Test whether NeuralPosteriorEnsemble infers well a simple example with available
     ground truth.
 
-    Args:
-        set_seed: fixture for manual seeding
     """
 
     num_trials = 1

--- a/tests/inference_on_device_test.py
+++ b/tests/inference_on_device_test.py
@@ -458,16 +458,14 @@ def test_nograd_after_inference_train(inference_method) -> None:
 @pytest.mark.parametrize("q", ("maf", "nsf", "gaussian_diag", "gaussian", "mcf", "scf"))
 @pytest.mark.parametrize("vi_method", ("rKL", "fKL", "IW", "alpha"))
 @pytest.mark.parametrize("sampling_method", ("naive", "sir"))
-def test_vi_on_gpu(
-    num_dim: int, q: Distribution, vi_method: str, sampling_method: str, set_seed
-):
+def test_vi_on_gpu(num_dim: int, q: Distribution, vi_method: str, sampling_method: str):
     """Test VI on Gaussian, comparing to ground truth target via c2st.
 
     Args:
         num_dim: parameter dimension of the gaussian model
         vi_method: different vi methods
         sampling_method: Different sampling methods
-        set_seed: fixture for manual seeding
+
     """
 
     device = "cuda:0"

--- a/tests/inference_with_NaN_simulator_test.py
+++ b/tests/inference_with_NaN_simulator_test.py
@@ -35,7 +35,7 @@ from tests.test_utils import check_c2st
         torch.Size((10, 10)),
     ),
 )
-def test_handle_invalid_x(x_shape, set_seed):
+def test_handle_invalid_x(x_shape):
 
     x = torch.rand(x_shape)
     x[x < 0.1] = float("nan")
@@ -69,7 +69,7 @@ def test_z_scoring_warning(snpe_method: type):
     ((SNPE_C, True, 0.05), (SNL, True, 0.05), (SRE, True, 0.05)),
 )
 def test_inference_with_nan_simulator(
-    method: type, exclude_invalid_x: bool, percent_nans: float, set_seed
+    method: type, exclude_invalid_x: bool, percent_nans: float
 ):
 
     # likelihood_mean will be likelihood_shift+theta
@@ -114,7 +114,7 @@ def test_inference_with_nan_simulator(
 
 
 @pytest.mark.slow
-def test_inference_with_restriction_estimator(set_seed):
+def test_inference_with_restriction_estimator():
 
     # likelihood_mean will be likelihood_shift+theta
     num_dim = 3
@@ -171,7 +171,7 @@ def test_inference_with_restriction_estimator(set_seed):
 
 
 @pytest.mark.parametrize("prior", ("uniform", "gaussian"))
-def test_restricted_prior_log_prob(prior, set_seed):
+def test_restricted_prior_log_prob(prior):
     """Test whether the log-prob method of the restricted prior works appropriately."""
 
     def simulator(theta):

--- a/tests/linearGaussian_mdn_test.py
+++ b/tests/linearGaussian_mdn_test.py
@@ -24,16 +24,16 @@ from sbi.simulators.linear_gaussian import (
 from tests.test_utils import check_c2st
 
 
-def test_mdn_with_snpe(set_seed):
-    mdn_inference_with_different_methods(SNPE, set_seed)
+def test_mdn_with_snpe():
+    mdn_inference_with_different_methods(SNPE)
 
 
 @pytest.mark.slow
-def test_mdn_with_snle(set_seed):
-    mdn_inference_with_different_methods(SNLE, set_seed)
+def test_mdn_with_snle():
+    mdn_inference_with_different_methods(SNLE)
 
 
-def mdn_inference_with_different_methods(method, set_seed):
+def mdn_inference_with_different_methods(method):
 
     num_dim = 2
     x_o = torch.tensor([[1.0, 0.0]])

--- a/tests/linearGaussian_snle_test.py
+++ b/tests/linearGaussian_snle_test.py
@@ -30,7 +30,7 @@ from tests.test_utils import check_c2st, get_prob_outside_uniform_prior
 
 
 @pytest.mark.parametrize("num_dim", (1, 3))
-def test_api_snl_on_linearGaussian(num_dim: int, set_seed):
+def test_api_snl_on_linearGaussian(num_dim: int):
     """Test API for inference on linear Gaussian model using SNL.
 
     Avoids expensive computations by training on few simulations and generating few
@@ -68,14 +68,12 @@ def test_api_snl_on_linearGaussian(num_dim: int, set_seed):
         posterior.sample(sample_shape=(num_samples,))
 
 
-def test_c2st_snl_on_linearGaussian(set_seed):
+def test_c2st_snl_on_linearGaussian():
     """Test whether SNL infers well a simple example with available ground truth.
 
     This example has different number of parameters theta than number of x. This test
     also acts as the only functional test for SNL not marked as slow.
 
-    Args:
-        set_seed: fixture for manual seeding
     """
 
     theta_dim = 3
@@ -135,15 +133,13 @@ def test_c2st_snl_on_linearGaussian(set_seed):
 @pytest.mark.slow
 @pytest.mark.parametrize("num_dim", (1, 2))
 @pytest.mark.parametrize("prior_str", ("uniform", "gaussian"))
-def test_c2st_and_map_snl_on_linearGaussian_different(
-    num_dim: int, prior_str: str, set_seed
-):
+def test_c2st_and_map_snl_on_linearGaussian_different(num_dim: int, prior_str: str):
     """Test SNL on linear Gaussian, comparing to ground truth posterior via c2st.
 
     Args:
         num_dim: parameter dimension of the gaussian model
         prior_str: one of "gaussian" or "uniform"
-        set_seed: fixture for manual seeding
+
     """
     num_samples = 500
     num_simulations = 3000
@@ -230,12 +226,8 @@ def test_c2st_and_map_snl_on_linearGaussian_different(
 
 @pytest.mark.slow
 @pytest.mark.parametrize("num_trials", (1, 3))
-def test_c2st_multi_round_snl_on_linearGaussian(num_trials: int, set_seed):
-    """Test SNL on linear Gaussian, comparing to ground truth posterior via c2st.
-
-    Args:
-        set_seed: fixture for manual seeding
-    """
+def test_c2st_multi_round_snl_on_linearGaussian(num_trials: int):
+    """Test SNL on linear Gaussian, comparing to ground truth posterior via c2st."""
 
     num_dim = 2
     x_o = zeros((num_trials, num_dim))
@@ -297,12 +289,8 @@ def test_c2st_multi_round_snl_on_linearGaussian(num_trials: int, set_seed):
 
 @pytest.mark.slow
 @pytest.mark.parametrize("num_trials", (1, 3))
-def test_c2st_multi_round_snl_on_linearGaussian_vi(num_trials: int, set_seed):
-    """Test SNL on linear Gaussian, comparing to ground truth posterior via c2st.
-
-    Args:
-        set_seed: fixture for manual seeding
-    """
+def test_c2st_multi_round_snl_on_linearGaussian_vi(num_trials: int):
+    """Test SNL on linear Gaussian, comparing to ground truth posterior via c2st."""
 
     num_dim = 2
     x_o = zeros((num_trials, num_dim))
@@ -384,14 +372,14 @@ def test_c2st_multi_round_snl_on_linearGaussian_vi(num_trials: int, set_seed):
 )
 @pytest.mark.parametrize("init_strategy", ("proposal", "sir"))
 def test_api_snl_sampling_methods(
-    sampling_method: str, prior_str: str, init_strategy: str, set_seed
+    sampling_method: str, prior_str: str, init_strategy: str
 ):
     """Runs SNL on linear Gaussian and tests sampling from posterior via mcmc.
 
     Args:
         mcmc_method: which mcmc method to use for sampling
         prior_str: use gaussian or uniform prior
-        set_seed: fixture for manual seeding
+
     """
 
     num_dim = 2

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -52,13 +52,9 @@ from tests.test_utils import (
     ),
 )
 def test_c2st_snpe_on_linearGaussian(
-    snpe_method, num_dim: int, prior_str: str, num_trials: int, set_seed
+    snpe_method, num_dim: int, prior_str: str, num_trials: int
 ):
-    """Test whether SNPE infers well a simple example with available ground truth.
-
-    Args:
-        set_seed: fixture for manual seeding
-    """
+    """Test whether SNPE infers well a simple example with available ground truth."""
 
     x_o = zeros(num_trials, num_dim)
     num_samples = 1000
@@ -147,15 +143,13 @@ def test_c2st_snpe_on_linearGaussian(
         assert ((map_ - ones(num_dim)) ** 2).sum() < 0.5
 
 
-def test_c2st_snpe_on_linearGaussian_different_dims(set_seed):
+def test_c2st_snpe_on_linearGaussian_different_dims():
     """Test whether SNPE B/C infer well a simple example with available ground truth.
 
     This example has different number of parameters theta than number of x. Also
     this implicitly tests simulation_batch_size=1. It also impleictly tests whether the
     prior can be `None` and whether we can stop and resume training.
 
-    Args:
-        set_seed: fixture for manual seeding
     """
 
     theta_dim = 3
@@ -224,11 +218,9 @@ def test_c2st_snpe_on_linearGaussian_different_dims(set_seed):
         "snpe_c_non_atomic",
     ),
 )
-def test_c2st_multi_round_snpe_on_linearGaussian(method_str: str, set_seed):
+def test_c2st_multi_round_snpe_on_linearGaussian(method_str: str):
     """Test whether SNPE B/C infer well a simple example with available ground truth.
-
-    Args:
-        set_seed: fixture for manual seeding.
+    .
     """
 
     num_dim = 2
@@ -329,12 +321,10 @@ def test_c2st_multi_round_snpe_on_linearGaussian(method_str: str, set_seed):
         ("rejection", "rejection", "uniform"),
     ),
 )
-def test_api_snpe_c_posterior_correction(sample_with, mcmc_method, prior_str, set_seed):
+def test_api_snpe_c_posterior_correction(sample_with, mcmc_method, prior_str):
     """Test that leakage correction applied to sampling works, with both MCMC and
     rejection.
 
-    Args:
-        set_seed: fixture for manual seeding
     """
 
     num_dim = 2
@@ -383,7 +373,7 @@ def test_api_snpe_c_posterior_correction(sample_with, mcmc_method, prior_str, se
 
 
 @pytest.mark.slow
-def test_sample_conditional(set_seed):
+def test_sample_conditional():
     """
     Test whether sampling from the conditional gives the same results as evaluating.
 
@@ -486,7 +476,6 @@ def test_sample_conditional(set_seed):
     assert max_err < 0.0027
 
 
-@pytest.mark.slow
 def test_mdn_conditional_density(num_dim: int = 3, cond_dim: int = 1):
     """Test whether the conditional density infered from MDN parameters of a
     `DirectPosterior` matches analytical results for MVN. This uses a n-D joint and
@@ -505,7 +494,7 @@ def test_mdn_conditional_density(num_dim: int = 3, cond_dim: int = 1):
 
     x_o = zeros(1, num_dim)
     num_samples = 1000
-    num_simulations = 2600
+    num_simulations = 2700
     condition = 0.1 * ones(1, num_dim)
 
     dims = list(range(num_dim))

--- a/tests/linearGaussian_snre_test.py
+++ b/tests/linearGaussian_snre_test.py
@@ -67,14 +67,12 @@ def test_api_sre_on_linearGaussian(num_dim: int):
         posterior.sample(sample_shape=(10,))
 
 
-def test_c2st_sre_on_linearGaussian(set_seed):
+def test_c2st_sre_on_linearGaussian():
     """Test whether SRE infers well a simple example with available ground truth.
 
     This example has different number of parameters theta than number of x. This test
     also acts as the only functional test for SRE not marked as slow.
 
-    Args:
-        set_seed: fixture for manual seeding
     """
 
     theta_dim = 3
@@ -150,14 +148,13 @@ def test_c2st_sre_variants_on_linearGaussian(
     num_trials: int,
     prior_str: str,
     method_str: str,
-    set_seed,
 ):
     """Test c2st accuracy of inference with SRE on linear Gaussian model.
 
     Args:
         num_dim: parameter dimension of the gaussian model
         prior_str: one of "gaussian" or "uniform"
-        set_seed: fixture for manual seeding
+
     """
 
     x_o = zeros(num_trials, num_dim)
@@ -253,12 +250,8 @@ def test_c2st_sre_variants_on_linearGaussian(
 
 @pytest.mark.slow
 @pytest.mark.parametrize("num_trials", (1, 3))
-def test_c2st_multi_round_snr_on_linearGaussian_vi(num_trials: int, set_seed):
-    """Test SNL on linear Gaussian, comparing to ground truth posterior via c2st.
-
-    Args:
-        set_seed: fixture for manual seeding
-    """
+def test_c2st_multi_round_snr_on_linearGaussian_vi(num_trials: int):
+    """Test SNL on linear Gaussian, comparing to ground truth posterior via c2st."""
 
     num_dim = 2
     x_o = zeros((num_trials, num_dim))
@@ -340,13 +333,13 @@ def test_c2st_multi_round_snr_on_linearGaussian_vi(num_trials: int, set_seed):
         ("alpha", "gaussian"),
     ),
 )
-def test_api_sre_sampling_methods(sampling_method: str, prior_str: str, set_seed):
+def test_api_sre_sampling_methods(sampling_method: str, prior_str: str):
     """Test leakage correction both for MCMC and rejection sampling.
 
     Args:
         mcmc_method: which mcmc method to use for sampling
         prior_str: one of "gaussian" or "uniform"
-        set_seed: fixture for manual seeding
+
     """
     num_dim = 2
     num_samples = 10

--- a/tests/mcmc_slice_pyro/test_slice.py
+++ b/tests/mcmc_slice_pyro/test_slice.py
@@ -218,7 +218,7 @@ def test_beta_bernoulli():
         return p_latent
 
     true_probs = torch.tensor([0.9, 0.1])
-    data = dist.Bernoulli(true_probs).sample(sample_shape=(torch.Size((1000,))))
+    data = dist.Bernoulli(true_probs).sample(sample_shape=(torch.Size((1200,))))
     slice_kernel = Slice(model)
     mcmc = MCMC(slice_kernel, num_samples=400, warmup_steps=200)
     mcmc.run(data)

--- a/tests/mcmc_test.py
+++ b/tests/mcmc_test.py
@@ -17,12 +17,12 @@ from tests.test_utils import check_c2st
 
 
 @pytest.mark.parametrize("num_dim", (1, 2))
-def test_c2st_slice_np_on_Gaussian(num_dim: int, set_seed):
+def test_c2st_slice_np_on_Gaussian(num_dim: int):
     """Test MCMC on Gaussian, comparing to ground truth target via c2st.
 
     Args:
         num_dim: parameter dimension of the gaussian model
-        set_seed: fixture for manual seeding
+
     """
     warmup = 100
     num_samples = 500
@@ -50,12 +50,12 @@ def test_c2st_slice_np_on_Gaussian(num_dim: int, set_seed):
 
 
 @pytest.mark.parametrize("num_dim", (1, 2))
-def test_c2st_slice_np_vectorized_on_Gaussian(num_dim: int, set_seed):
+def test_c2st_slice_np_vectorized_on_Gaussian(num_dim: int):
     """Test MCMC on Gaussian, comparing to ground truth target via c2st.
 
     Args:
         num_dim: parameter dimension of the gaussian model
-        set_seed: fixture for manual seeding
+
     """
     num_samples = 500
     warmup = 500

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -41,7 +41,7 @@ TESTCASECONFIG = [
     TESTCASECONFIG,
 )
 def test_c2st_with_different_distributions(
-    dist_sigma, c2st_lowerbound, c2st_upperbound, set_seed
+    dist_sigma, c2st_lowerbound, c2st_upperbound
 ):
 
     ndim = 10
@@ -68,7 +68,7 @@ def test_c2st_with_different_distributions(
     TESTCASECONFIG,
 )
 def test_c2st_with_different_distributions_mlp(
-    dist_sigma, c2st_lowerbound, c2st_upperbound, set_seed
+    dist_sigma, c2st_lowerbound, c2st_upperbound
 ):
 
     ndim = 10
@@ -94,7 +94,7 @@ def test_c2st_with_different_distributions_mlp(
     "dist_sigma, c2st_lowerbound, c2st_upperbound,",
     TESTCASECONFIG,
 )
-def test_c2st_scores(dist_sigma, c2st_lowerbound, c2st_upperbound, set_seed):
+def test_c2st_scores(dist_sigma, c2st_lowerbound, c2st_upperbound):
 
     ndim = 10
     nsamples = 1024

--- a/tests/sbc_test.py
+++ b/tests/sbc_test.py
@@ -51,7 +51,7 @@ def test_running_sbc(method=SNPE_C, model="mdn"):
 
 
 @pytest.mark.slow
-def test_sbc_checks(set_seed):
+def test_sbc_checks():
     """Test the uniformity checks for SBC."""
 
     num_dim = 2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -62,6 +62,7 @@ def get_dkl_gaussian_prior(
     likelihood_cov: Tensor,
     prior_mean: Tensor,
     prior_cov: Tensor,
+    num_samples: int = 200,
 ) -> Tensor:
     """
     Return the Kullback-Leibler divergence between estimated posterior (with Gaussian
@@ -74,13 +75,14 @@ def get_dkl_gaussian_prior(
         likelihood_cov: Covariance matrix of likelihood.
         prior_mean: Mean of prior.
         prior_cov: Covariance matrix of prior.
+        num_samples: number of samples that the Monte-Carlo estimate is based on
     """
 
     target_dist = true_posterior_linear_gaussian_mvn_prior(
         x_o, likelihood_shift, likelihood_cov, prior_mean, prior_cov
     )
 
-    return kl_d_via_monte_carlo(target_dist, posterior, num_samples=200)
+    return kl_d_via_monte_carlo(target_dist, posterior, num_samples=num_samples)
 
 
 def get_prob_outside_uniform_prior(

--- a/tests/vi_test.py
+++ b/tests/vi_test.py
@@ -27,16 +27,14 @@ from tests.test_utils import check_c2st
 @pytest.mark.parametrize("num_dim", (1, 2))
 @pytest.mark.parametrize("vi_method", ("rKL", "fKL", "IW", "alpha"))
 @pytest.mark.parametrize("sampling_method", ("naive", "sir"))
-def test_c2st_vi_on_Gaussian(
-    num_dim: int, vi_method: str, sampling_method: str, set_seed
-):
+def test_c2st_vi_on_Gaussian(num_dim: int, vi_method: str, sampling_method: str):
     """Test VI on Gaussian, comparing to ground truth target via c2st.
 
     Args:
         num_dim: parameter dimension of the gaussian model
         vi_method: different vi methods
         sampling_method: Different sampling methods
-        set_seed: fixture for manual seeding
+
     """
 
     if sampling_method == "naive" and vi_method == "IW":
@@ -81,14 +79,14 @@ def test_c2st_vi_on_Gaussian(
 @pytest.mark.slow
 @pytest.mark.parametrize("num_dim", (1, 2))
 @pytest.mark.parametrize("q", ("maf", "nsf", "gaussian_diag", "gaussian", "mcf", "scf"))
-def test_c2st_vi_flows_on_Gaussian(num_dim: int, q: str, set_seed):
+def test_c2st_vi_flows_on_Gaussian(num_dim: int, q: str):
     """Test VI on Gaussian, comparing to ground truth target via c2st.
 
     Args:
         num_dim: parameter dimension of the gaussian model
         vi_method: different vi methods
         sampling_method: Different sampling methods
-        set_seed: fixture for manual seeding
+
     """
     # Coupling flows undefined at 1d
     if num_dim == 1 and q in ["mcf", "scf"]:
@@ -131,14 +129,14 @@ def test_c2st_vi_flows_on_Gaussian(num_dim: int, q: str, set_seed):
 
 @pytest.mark.slow
 @pytest.mark.parametrize("num_dim", (1, 2))
-def test_c2st_vi_external_distributions_on_Gaussian(num_dim: int, set_seed):
+def test_c2st_vi_external_distributions_on_Gaussian(num_dim: int):
     """Test VI on Gaussian, comparing to ground truth target via c2st.
 
     Args:
         num_dim: parameter dimension of the gaussian model
         vi_method: different vi methods
         sampling_method: Different sampling methods
-        set_seed: fixture for manual seeding
+
     """
     num_samples = 2000
 
@@ -186,7 +184,7 @@ def test_c2st_vi_external_distributions_on_Gaussian(num_dim: int, set_seed):
 
 
 @pytest.mark.parametrize("q", ("maf", "nsf", "gaussian_diag", "gaussian", "mcf", "scf"))
-def test_deepcopy_support(q: str, set_seed):
+def test_deepcopy_support(q: str):
     """Tests if the variational does support deepcopy.
 
     Args:


### PR DESCRIPTION
- remove `set_seed` args
- adapt two tests that were not seeded before to make them pass with seed