### PR TITLE
vi failing with independent prior

### DIFF
--- a/sbi/samplers/vi/vi_pyro_flows.py
+++ b/sbi/samplers/vi/vi_pyro_flows.py
@@ -385,8 +385,10 @@ def build_flow(
     """
     # Some transforms increase dimension by decreasing the degrees of freedom e.g.
     # SoftMax.
+    # `unsqueeze(0)` because the `link_flow` requires a batch dimension if the prior is
+    # a `MultipleIndependent`.
     additional_dim = (
-        len(link_flow(torch.zeros(event_shape, device=device)))
+        len(link_flow(torch.zeros(event_shape, device=device).unsqueeze(0))[0])
         - torch.tensor(event_shape, device=device).item()
     )
     event_shape = torch.Size(


### PR DESCRIPTION
this adds a test showing a failure mode of VI: 

When sampling from a `VIPosterior` based on a `MultipleIndependent` prior there is a problem with the `theta_transform` and the `vi_pyro_flows`. I think it has to do with change in dimensionality from transformed to untransformed space, .e.g., it happens when calling `link_flow(torch.zeros(event_shape, device=device))` (see trace below). Potential problem: Why is this called with just the `event_shape` and not the entire `theta.shape`? 

track: 
```
sbi/inference/posteriors/vi_posterior.py:132: in __init__
    self.set_q(q, parameters=parameters, modules=modules)
sbi/inference/posteriors/vi_posterior.py:230: in set_q
    device=self._device,
sbi/samplers/vi/vi_pyro_flows.py:156: in build_fn
    return _FLOW_BUILDERS[name](event_shape, link_flow, device=device, **kwargs)
sbi/samplers/vi/vi_pyro_flows.py:535: in masked_autoregressive_flow_builder
    **kwargs,
sbi/samplers/vi/vi_pyro_flows.py:389: in build_flow
    link_flow(torch.zeros(event_shape, device=device))
../../anaconda3/envs/mnle/lib/python3.7/site-packages/torch/distributions/transforms.py:150: in __call__
    return self._call(x)
../../anaconda3/envs/mnle/lib/python3.7/site-packages/torch/distributions/transforms.py:443: in _call
    return self.base_transform(x)
../../anaconda3/envs/mnle/lib/python3.7/site-packages/torch/distributions/transforms.py:150: in __call__
    return self._call(x)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = CatTransform(), x = tensor([0., 0.])

    def _call(self, x):
>       assert -x.dim() <= self.dim < x.dim()
E       AssertionError

../../anaconda3/envs/mnle/lib/python3.7/site-packages/torch/distributions/transforms.py:1017: AssertionError
```