### PR TITLE
check prior on input, restrict type to Distribution.

### DIFF
--- a/sbi/analysis/conditional_density.py
+++ b/sbi/analysis/conditional_density.py
@@ -8,6 +8,7 @@ import torch
 import torch.distributions.transforms as torch_tf
 from pyknos.mdn.mdn import MultivariateGaussianMDN as mdn
 from torch import Tensor, nn
+from torch.distributions import Distribution
 
 from sbi.types import Shape, TorchTransform
 from sbi.utils.conditional_density_utils import (
@@ -233,7 +234,7 @@ class ConditionedMDN:
 def conditonal_potential(
     potential_fn: Callable,
     theta_transform: TorchTransform,
-    prior: Any,
+    prior: Distribution,
     condition: Tensor,
     dims_to_sample: List[int],
 ) -> Tuple[Callable, torch_tf.Transform, Any]:

--- a/sbi/inference/posteriors/direct_posterior.py
+++ b/sbi/inference/posteriors/direct_posterior.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Optional, Union
 import torch
 from pyknos.nflows import flows
 from torch import Tensor, log, nn
+from torch.distributions import Distribution
 
 from sbi import utils as utils
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
@@ -13,7 +14,7 @@ from sbi.inference.potentials.posterior_based_potential import (
 )
 from sbi.samplers.rejection.rejection import rejection_sample_posterior_within_prior
 from sbi.types import Shape
-from sbi.utils.sbiutils import match_theta_and_x_batch_shapes, within_support
+from sbi.utils import check_prior, match_theta_and_x_batch_shapes, within_support
 from sbi.utils.torchutils import ensure_theta_batched
 
 
@@ -34,7 +35,7 @@ class DirectPosterior(NeuralPosterior):
     def __init__(
         self,
         posterior_estimator: flows.Flow,
-        prior: Any,
+        prior: Distribution,
         max_sampling_batch_size: int = 10_000,
         device: Optional[str] = None,
         x_shape: Optional[torch.Size] = None,
@@ -53,6 +54,7 @@ class DirectPosterior(NeuralPosterior):
         # Because `DirectPosterior` does not take the `potential_fn` as input, it
         # builds it itself. The `potential_fn` and `theta_transform` are used only for
         # obtaining the MAP.
+        check_prior(prior)
         potential_fn, theta_transform = posterior_estimator_based_potential(
             posterior_estimator, prior, None
         )

--- a/sbi/inference/potentials/base_potential.py
+++ b/sbi/inference/potentials/base_potential.py
@@ -2,12 +2,15 @@ from abc import ABCMeta, abstractmethod
 from typing import Any, Optional
 
 from torch import Tensor
+from torch.distributions import Distribution
 
 from sbi.utils.user_input_checks import process_x
 
 
 class BasePotential(metaclass=ABCMeta):
-    def __init__(self, prior: Any, x_o: Optional[Tensor] = None, device: str = "cpu"):
+    def __init__(
+        self, prior: Distribution, x_o: Optional[Tensor] = None, device: str = "cpu"
+    ):
         """Initialize potential function.
 
         This parent class takes care of setting `x_o`.

--- a/sbi/inference/potentials/likelihood_based_potential.py
+++ b/sbi/inference/potentials/likelihood_based_potential.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Optional, Tuple
 
 import torch
 from torch import Tensor, nn
+from torch.distributions import Distribution
 
 from sbi.inference.potentials.base_potential import BasePotential
 from sbi.neural_nets.mnle import MixedDensityEstimator
@@ -16,7 +17,7 @@ from sbi.utils.torchutils import atleast_2d
 
 def likelihood_estimator_based_potential(
     likelihood_estimator: nn.Module,
-    prior: Any,
+    prior: Distribution,
     x_o: Optional[Tensor],
 ) -> Tuple[Callable, TorchTransform]:
     r"""Returns potential $\log(p(x_o|\theta)p(\theta))$ for likelihood-based methods.
@@ -50,7 +51,7 @@ class LikelihoodBasedPotential(BasePotential):
     def __init__(
         self,
         likelihood_estimator: nn.Module,
-        prior: Any,
+        prior: Distribution,
         x_o: Optional[Tensor],
         device: str = "cpu",
     ):
@@ -141,7 +142,7 @@ def _log_likelihoods_over_trials(
 
 def mixed_likelihood_estimator_based_potential(
     likelihood_estimator: MixedDensityEstimator,
-    prior: Any,
+    prior: Distribution,
     x_o: Optional[Tensor],
 ) -> Tuple[Callable, TorchTransform]:
     r"""Returns $\log(p(x_o|\theta)p(\theta))$ for mixed likelihood-based methods.
@@ -173,7 +174,7 @@ class MixedLikelihoodBasedPotential(LikelihoodBasedPotential):
     def __init__(
         self,
         likelihood_estimator: MixedDensityEstimator,
-        prior: Any,
+        prior: Distribution,
         x_o: Optional[Tensor],
         device: str = "cpu",
     ):

--- a/sbi/inference/potentials/posterior_based_potential.py
+++ b/sbi/inference/potentials/posterior_based_potential.py
@@ -7,6 +7,7 @@ import torch
 import torch.distributions.transforms as torch_tf
 from pyknos.nflows import flows
 from torch import Tensor, nn
+from torch.distributions import Distribution
 
 from sbi.inference.potentials.base_potential import BasePotential
 from sbi.types import TorchTransform
@@ -17,7 +18,7 @@ from sbi.utils.torchutils import ensure_theta_batched
 
 def posterior_estimator_based_potential(
     posterior_estimator: nn.Module,
-    prior: Any,
+    prior: Distribution,
     x_o: Optional[Tensor],
 ) -> Tuple[Callable, TorchTransform]:
     r"""Returns the potential for posterior-based methods.
@@ -54,7 +55,7 @@ class PosteriorBasedPotential(BasePotential):
     def __init__(
         self,
         posterior_estimator: flows.Flow,
-        prior: Any,
+        prior: Distribution,
         x_o: Optional[Tensor],
         device: str = "cpu",
     ):

--- a/sbi/inference/potentials/ratio_based_potential.py
+++ b/sbi/inference/potentials/ratio_based_potential.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import torch
 import torch.distributions.transforms as torch_tf
 from torch import Tensor, nn
+from torch.distributions import Distribution
 
 from sbi.inference.potentials.base_potential import BasePotential
 from sbi.types import TorchTransform
@@ -16,7 +17,7 @@ from sbi.utils.torchutils import atleast_2d
 
 def ratio_estimator_based_potential(
     ratio_estimator: nn.Module,
-    prior: Any,
+    prior: Distribution,
     x_o: Optional[Tensor],
 ) -> Tuple[Callable, TorchTransform]:
     r"""Returns the potential for ratio-based methods.
@@ -48,7 +49,7 @@ class RatioBasedPotential(BasePotential):
     def __init__(
         self,
         ratio_estimator: nn.Module,
-        prior: Any,
+        prior: Distribution,
         x_o: Optional[Tensor],
         device: str = "cpu",
     ):

--- a/sbi/inference/snle/mnle.py
+++ b/sbi/inference/snle/mnle.py
@@ -5,19 +5,21 @@
 from copy import deepcopy
 from typing import Any, Callable, Dict, Optional, Union
 
+from torch.distributions import Distribution
+
 from sbi.inference.posteriors import MCMCPosterior, RejectionPosterior, VIPosterior
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.inference.potentials import mixed_likelihood_estimator_based_potential
 from sbi.inference.snle.snle_base import LikelihoodEstimator
 from sbi.neural_nets.mnle import MixedDensityEstimator
 from sbi.types import TensorboardSummaryWriter, TorchModule
-from sbi.utils import del_entries
+from sbi.utils import check_prior, del_entries
 
 
 class MNLE(LikelihoodEstimator):
     def __init__(
         self,
-        prior: Optional[Any] = None,
+        prior: Optional[Distribution] = None,
         density_estimator: Union[str, Callable] = "mnle",
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
@@ -66,7 +68,7 @@ class MNLE(LikelihoodEstimator):
     def build_posterior(
         self,
         density_estimator: Optional[TorchModule] = None,
-        prior: Optional[Any] = None,
+        prior: Optional[Distribution] = None,
         sample_with: str = "mcmc",
         mcmc_method: str = "slice_np",
         vi_method: str = "rKL",
@@ -108,6 +110,8 @@ class MNLE(LikelihoodEstimator):
                 self._prior is not None
             ), "You did not pass a prior. You have to pass the prior either at initialization `inference = SNLE(prior)` or to `.build_posterior(prior=prior)`."
             prior = self._prior
+        else:
+            check_prior(prior)
 
         if density_estimator is None:
             likelihood_estimator = self._neural_net

--- a/sbi/inference/snle/snle_a.py
+++ b/sbi/inference/snle/snle_a.py
@@ -5,6 +5,7 @@
 from typing import Any, Callable, Dict, Optional, Union
 
 from pyknos.nflows import flows
+from torch.distributions import Distribution
 
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.inference.snle.snle_base import LikelihoodEstimator
@@ -15,7 +16,7 @@ from sbi.utils import del_entries
 class SNLE_A(LikelihoodEstimator):
     def __init__(
         self,
-        prior: Optional[Any] = None,
+        prior: Optional[Distribution] = None,
         density_estimator: Union[str, Callable] = "maf",
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",

--- a/sbi/inference/snpe/snpe_a.py
+++ b/sbi/inference/snpe/snpe_a.py
@@ -12,7 +12,7 @@ from pyknos.mdn.mdn import MultivariateGaussianMDN
 from pyknos.nflows import flows
 from pyknos.nflows.transforms import CompositeTransform
 from torch import Tensor
-from torch.distributions import MultivariateNormal
+from torch.distributions import Distribution, MultivariateNormal
 
 import sbi.utils as utils
 from sbi.inference.posteriors.direct_posterior import DirectPosterior
@@ -24,7 +24,7 @@ from sbi.utils import torchutils
 class SNPE_A(PosteriorEstimator):
     def __init__(
         self,
-        prior: Optional[Any] = None,
+        prior: Optional[Distribution] = None,
         density_estimator: Union[str, Callable] = "mdn_snpe_a",
         num_components: int = 10,
         device: str = "cpu",
@@ -262,7 +262,7 @@ class SNPE_A(PosteriorEstimator):
     def build_posterior(
         self,
         density_estimator: Optional[TorchModule] = None,
-        prior: Optional[Any] = None,
+        prior: Optional[Distribution] = None,
     ) -> "DirectPosterior":
         r"""Build posterior from the neural density estimator.
 
@@ -367,7 +367,7 @@ class SNPE_A_MDN(nn.Module):
         self,
         flow: flows.Flow,
         proposal: Union["utils.BoxUniform", "MultivariateNormal", "DirectPosterior"],
-        prior: Any,
+        prior: Distribution,
         device: str,
     ):
         """Constructor.

--- a/sbi/inference/snpe/snpe_b.py
+++ b/sbi/inference/snpe/snpe_b.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Optional, Union
 
 import torch
 from torch import Tensor
+from torch.distributions import Distribution
 
 import sbi.utils as utils
 from sbi.inference.snpe.snpe_base import PosteriorEstimator
@@ -16,7 +17,7 @@ from sbi.utils import del_entries
 class SNPE_B(PosteriorEstimator):
     def __init__(
         self,
-        prior: Optional[Any] = None,
+        prior: Optional[Distribution] = None,
         density_estimator: Union[str, Callable] = "maf",
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -8,6 +8,7 @@ from warnings import warn
 
 import torch
 from torch import Tensor, nn, ones, optim
+from torch.distributions import Distribution
 from torch.nn.utils.clip_grad import clip_grad_norm_
 from torch.utils import data
 from torch.utils.tensorboard.writer import SummaryWriter
@@ -35,7 +36,7 @@ from sbi.utils.sbiutils import ImproperEmpirical, mask_sims_from_prior
 class PosteriorEstimator(NeuralInference, ABC):
     def __init__(
         self,
-        prior: Optional[Any] = None,
+        prior: Optional[Distribution] = None,
         density_estimator: Union[str, Callable] = "maf",
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",
@@ -355,7 +356,7 @@ class PosteriorEstimator(NeuralInference, ABC):
     def build_posterior(
         self,
         density_estimator: Optional[nn.Module] = None,
-        prior: Optional[Any] = None,
+        prior: Optional[Distribution] = None,
         sample_with: str = "rejection",
         mcmc_method: str = "slice_np",
         vi_method: str = "rKL",
@@ -404,6 +405,8 @@ class PosteriorEstimator(NeuralInference, ABC):
                 "`.build_posterior(prior=prior)`."
             )
             prior = self._prior
+        else:
+            utils.check_prior(prior)
 
         if density_estimator is None:
             posterior_estimator = self._neural_net

--- a/sbi/inference/snpe/snpe_c.py
+++ b/sbi/inference/snpe/snpe_c.py
@@ -8,7 +8,7 @@ import torch
 from pyknos.mdn.mdn import MultivariateGaussianMDN as mdn
 from pyknos.nflows.transforms import CompositeTransform
 from torch import Tensor, eye, nn, ones
-from torch.distributions import MultivariateNormal, Uniform
+from torch.distributions import Distribution, MultivariateNormal, Uniform
 
 from sbi import utils as utils
 from sbi.inference.posteriors.direct_posterior import DirectPosterior
@@ -27,7 +27,7 @@ from sbi.utils import (
 class SNPE_C(PosteriorEstimator):
     def __init__(
         self,
-        prior: Optional[Any] = None,
+        prior: Optional[Distribution] = None,
         density_estimator: Union[str, Callable] = "maf",
         device: str = "cpu",
         logging_level: Union[int, str] = "WARNING",

--- a/sbi/inference/snre/snre_a.py
+++ b/sbi/inference/snre/snre_a.py
@@ -2,6 +2,7 @@ from typing import Any, Callable, Dict, Optional, Union
 
 import torch
 from torch import Tensor, nn, ones
+from torch.distributions import Distribution
 
 from sbi.inference.snre.snre_base import RatioEstimator
 from sbi.types import TensorboardSummaryWriter
@@ -11,7 +12,7 @@ from sbi.utils import del_entries
 class SNRE_A(RatioEstimator):
     def __init__(
         self,
-        prior: Optional[Any] = None,
+        prior: Optional[Distribution] = None,
         classifier: Union[str, Callable] = "resnet",
         device: str = "cpu",
         logging_level: Union[int, str] = "warning",

--- a/sbi/inference/snre/snre_b.py
+++ b/sbi/inference/snre/snre_b.py
@@ -2,6 +2,7 @@ from typing import Any, Callable, Dict, Optional, Union
 
 import torch
 from torch import Tensor, nn
+from torch.distributions import Distribution
 
 from sbi.inference.snre.snre_base import RatioEstimator
 from sbi.types import TensorboardSummaryWriter
@@ -11,7 +12,7 @@ from sbi.utils import del_entries
 class SNRE_B(RatioEstimator):
     def __init__(
         self,
-        prior: Optional[Any] = None,
+        prior: Optional[Distribution] = None,
         classifier: Union[str, Callable] = "resnet",
         device: str = "cpu",
         logging_level: Union[int, str] = "warning",

--- a/sbi/samplers/vi/vi_divergence_optimizers.py
+++ b/sbi/samplers/vi/vi_divergence_optimizers.py
@@ -26,6 +26,7 @@ from sbi.samplers.vi.vi_utils import (
     move_all_tensor_to_device,
 )
 from sbi.types import Array
+from sbi.utils import check_prior
 
 _VI_method = {}
 
@@ -89,6 +90,7 @@ class DivergenceOptimizer(ABC):
 
         self.potential_fn = potential_fn
         self.q = q
+        check_prior(prior)
         self.prior = prior
         self.device = potential_fn.device
         self.to(self.device)

--- a/sbi/utils/__init__.py
+++ b/sbi/utils/__init__.py
@@ -59,6 +59,7 @@ from sbi.utils.typechecks import (
 )
 from sbi.utils.user_input_checks import (
     check_estimator_arg,
+    check_prior,
     process_prior,
     process_x,
     test_posterior_net_for_multi_d_x,

--- a/sbi/utils/conditional_density_utils.py
+++ b/sbi/utils/conditional_density_utils.py
@@ -12,6 +12,7 @@ import torch.distributions.transforms as torch_tf
 from pyknos.mdn.mdn import MultivariateGaussianMDN as mdn
 from pyknos.nflows.flows import Flow
 from torch import Tensor
+from torch.distributions import Distribution
 
 from sbi.types import TorchTransform
 from sbi.utils.torchutils import (
@@ -363,7 +364,7 @@ class RestrictedPriorForConditional:
     this class.
     """
 
-    def __init__(self, full_prior: Any, dims_to_sample: List[int]):
+    def __init__(self, full_prior: Distribution, dims_to_sample: List[int]):
         self.full_prior = full_prior
         self.dims_to_sample = dims_to_sample
 

--- a/sbi/utils/restriction_estimator.py
+++ b/sbi/utils/restriction_estimator.py
@@ -6,6 +6,7 @@ import torch
 import torch.nn.functional as F
 from pyknos.nflows.nn import nets
 from torch import Tensor, nn, optim, relu
+from torch.distributions import Distribution
 from torch.nn.utils.clip_grad import clip_grad_norm_
 from torch.utils import data
 from torch.utils.data.sampler import SubsetRandomSampler, WeightedRandomSampler
@@ -142,7 +143,7 @@ def build_classifier(
 class RestrictionEstimator:
     def __init__(
         self,
-        prior: Any,
+        prior: Distribution,
         model: Union[str, Callable] = "resnet",
         decision_criterion: Union[str, Callable] = "nan",
         hidden_features: int = 100,
@@ -506,7 +507,7 @@ class RestrictionEstimator:
 class RestrictedPrior:
     def __init__(
         self,
-        prior: Any,
+        prior: Distribution,
         classifier: nn.Module,
         validation_theta: Tensor,
         validation_label: Tensor,

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -549,7 +549,7 @@ def match_theta_and_x_batch_shapes(theta: Tensor, x: Tensor) -> Tuple[Tensor, Te
 
 
 def mcmc_transform(
-    prior: Any,
+    prior: Distribution,
     num_prior_samples_for_zscoring: int = 1000,
     enable_transform: bool = True,
     device: str = "cpu",

--- a/sbi/utils/user_input_checks.py
+++ b/sbi/utils/user_input_checks.py
@@ -25,6 +25,19 @@ from sbi.utils.user_input_checks_utils import (
 )
 
 
+def check_prior(prior: Any) -> None:
+    """Assert that prior is a PyTorch distribution (or pass if None)."""
+
+    if prior is None:
+        pass
+    else:
+        assert isinstance(
+            prior, Distribution
+        ), """Prior must be a PyTorch Distribution. See FAQ 7 for more details or use
+        `sbi.utils.user_input_checks.process_prior` for wrapping scipy and lists of
+        independent priors."""
+
+
 def process_prior(
     prior, custom_prior_wrapper_kwargs: Dict = {}
 ) -> Tuple[Distribution, int, bool]:


### PR DESCRIPTION
- restrict prior to be of type `Distribution`
- add checks in `base` and in `build_posterior`, i.e., where the prior could be passed by the user. 
- change type from `Any` to `Distribution` everywhere. 
