### PR TITLE
import tqdm from auto to fix pbars.

### DIFF
--- a/sbi/inference/posteriors/mcmc_posterior.py
+++ b/sbi/inference/posteriors/mcmc_posterior.py
@@ -11,7 +11,7 @@ from pyro.infer.mcmc import HMC, NUTS
 from pyro.infer.mcmc.api import MCMC
 from torch import Tensor
 from torch import multiprocessing as mp
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.samplers.mcmc import (

--- a/sbi/inference/posteriors/mcmc_posterior.py
+++ b/sbi/inference/posteriors/mcmc_posterior.py
@@ -341,7 +341,7 @@ class MCMCPosterior(NeuralPosterior):
                 torch.manual_seed(seed)
                 return init_fn()
 
-            seeds = torch.randint(high=2**31, size=(num_workers,))
+            seeds = torch.randint(high=2**31, size=(num_chains,))
 
             # Generate initial params parallelized over num_workers.
             with tqdm_joblib(

--- a/sbi/inference/posteriors/vi_posterior.py
+++ b/sbi/inference/posteriors/vi_posterior.py
@@ -8,7 +8,7 @@ import numpy as np
 import torch
 from torch import Tensor
 from torch.distributions import Distribution
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from sbi.inference.posteriors.base_posterior import NeuralPosterior
 from sbi.samplers.vi import (

--- a/sbi/samplers/mcmc/slice_numpy.py
+++ b/sbi/samplers/mcmc/slice_numpy.py
@@ -275,7 +275,10 @@ class SliceSamplerVectorized:
             self.state[c]["width"] = np.full(self.n_dims, self.init_width)
 
         if self.verbose:
-            pbar = tqdm(range(self.num_chains * num_samples))
+            pbar = tqdm(
+                range(self.num_chains * num_samples),
+                desc=f"Running vectorized MCMC with {self.num_chains} chains",
+            )
 
         num_chains_finished = 0
         while num_chains_finished != self.num_chains:
@@ -514,8 +517,9 @@ def slice_np_parallized(
     with tqdm_joblib(
         tqdm(
             range(num_batches),  # type: ignore
-            disable=not show_progress_bars,
-            desc=f"Running {num_chains} MCMC chains in {num_batches} batches.",
+            disable=not show_progress_bars or num_workers == 1,
+            desc=f"""Running {num_chains} MCMC chains with {num_workers} worker{"s" if
+                  num_workers>1 else ""} (batch_size={batch_size}).""",
             total=num_chains,
         )
     ):

--- a/sbi/samplers/mcmc/slice_numpy.py
+++ b/sbi/samplers/mcmc/slice_numpy.py
@@ -10,7 +10,7 @@ import numpy as np
 import torch
 from joblib import Parallel, delayed
 from matplotlib import pyplot as plt
-from tqdm import tqdm, trange
+from tqdm.auto import tqdm, trange
 
 from sbi.simulators.simutils import tqdm_joblib
 from sbi.utils import tensor2numpy

--- a/tutorials/02_flexible_interface.ipynb
+++ b/tutorials/02_flexible_interface.ipynb
@@ -42,11 +42,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
+    "```Python\n",
     "from sbi.inference import SNPE, prepare_for_sbi, simulate_for_sbi\n",
     "\n",
     "simulator, prior = prepare_for_sbi(simulator, prior)\n",
@@ -54,7 +53,8 @@
     "\n",
     "theta, x = simulate_for_sbi(simulator, proposal=prior, num_simulations=1000)\n",
     "density_estimator = inference.append_simulations(theta, x).train()\n",
-    "posterior = inference.build_posterior(density_estimator)"
+    "posterior = inference.build_posterior(density_estimator)\n",
+    "```"
    ]
   },
   {
@@ -73,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,7 +105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -154,13 +154,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1d5ff664ab594071beb8b06cad6c99cd",
+       "model_id": "66d28cf9f1304ca7838576033dc09099",
        "version_major": 2,
        "version_minor": 0
       },
@@ -185,7 +185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,14 +201,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " Neural network successfully converged after 129 epochs."
+      " Neural network successfully converged after 73 epochs."
      ]
     }
    ],
@@ -225,7 +225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -241,7 +241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -250,13 +250,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8e26dea8147e4e6594f266a9abecd77a",
+       "model_id": "037b102711844d3fbc63575522a65338",
        "version_major": 2,
        "version_minor": 0
       },
@@ -269,7 +269,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAS0AAAFJCAYAAADOhnuiAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAeTUlEQVR4nO3dbYxcV53n8e//PtRDu9tuJyEkccJ4Z3bELEIQHhYQBmnxDBIPYhPtMBIMYjQSb5BYCaTlhQUSm0VC5NXMvNnVCAEKL9DCjgAJbUAIFCSGZMgmZBPyNESBDSQmhNjutru7Hu+9/31xb3WX23a7H6r71nH9PlLLVdXV1393uX73nHPPOWXujohIKKK6CxAR2QmFlogERaElIkFRaIlIUBRaIhIUhZaIBCXZxc9ojsRk2F4P8O7or/RaTMgPi3/a9euh12FytvM6qKUlIkFRaIlIUBRaIhKU2kPr+Kl76y5BRAJSe2iJiOyEQktEgqLQEpGgKLREJChTEVon7r6v7hJEJBBTEVqnl7t1lyAigZiK0AJNfRCR7ak1tBRUIrJTU9HSOrbYrrsEEQlE7aF1bLHN/adO1l2GiASi9tBSYInITtQeWiIiO6HQEpGgKLREJCgKLREJikJLRIKi0BKRoCi0RCQotYXWibvvu2gm/LHFtnZ7EJGrqi20Ti93L5pYev+pk9rtQUSuSt1DEQnKVIWWuogicjVTFVrqIorI1UxVaImIXI1CS0SCotASkaAotEQkKAotEQmKQktEgqLQEpGg1BJam9cdiohsV1LHX3p6uctzd7+/jr9aRAKn7qGIBEWhJSJBUWiJSFAOPLQ0CC8ie3HgA/EahBeRvZi67qH21BKRrUxdaGlPLRHZytSFlojIVhRaIhIUhZaIBEWhJSJBUWiJSFBqWTAtU8AM3Ddubzb6nuyP0e9cv+cdU2jNKovARjfLG57nG9/zvKbCrlHjJ4n1xyKguMxzI/BCgXYFCq1ZZFYGlVWjA1VokedgERYZ7pd5k8nujLdkbf1MUf6ei0tHaCyOwQ3PsgMqMCwHGlrbXXc4mhV//6mTB1DVjBl/0zRSbG7u4u8XOQwzin4f8lxvnEkYhX8UlyeLOC6DKY6JWi3IMnwwuOj5nudlQ7g6sXg2vPhYM+xAQ2u76w7vP3WS46fuPYCKZsimM7w1UqzVxJoNSOKN7w8zPBpg7jAc4oWrqzIJo9ZtHGNJgqVJebvVBG9gzQaeF+XvejCEOIaiKE8c7lgcl6/FqDs5w6+HuoczZHR2tyQhuu4opAneTMkW5/AkwrKCuDvE1npEqzE+HBJ1e/ioJTDDb5Q9GbWwoAysubn1k4XPtfBGQt5OiVf6WH+AdfvlSaMoKFbXsDzHms3112E9vGb09VBozQKzje5Iu4W1WhRH58nnmwyONOjcmFA0IOk66VqLxvk2zZdSbK0LeXVmV1dx7yyCKMLiCBppdcJok80lDI4kRHkTyyAeFMT9nLiTES21sf4QHwywQdVFzHMoHB8Otv77rlEKrWudVQPuFmFxjLVa0G6RHW4xONqgc0PM2jEjbznJWkRjBVptIxq0ScyIev2yy5Ln5dXFGT2779qm6SRmBmZ4mlC0GgwXUgZHEnpHjSIunxtlTrqW0Dyf0kwi4rU+0fm16gpkAUMrX49hHf+g+im0rnXuWGzrg+4+P4fPt1m7tUVv0ehdb3T/eEBzvk8/i+l0EqLVhLWb5mifaXPdY4Z1+kSrHbiwgvf7anHtlBd4ERG1U2g2y5PGdYfIFlLWbkrpHzW6NzrZQo4nTtSNSLpGupLQPBeTdtoc+t0h0qUe8ZnzsLJSjnOljepEMltdRYXWtW7sTG9xhDdS8nbKYMEYHDGGR5zF61d55cIK7sb5fovl1Tb9lXmioTE82iY1w4ZZORgcx2X3ZIbeJPvBk4isHTE4YvSPwvC6nNb1XRppxupqi0EnIWvHeBSRrxiNlZi4lxDHUTlIH5etX3Mrp9Rdbh7YNUqhdS2LYqCcNGrVf+h8vsngaKNsYd1YkBzr8B+PP84b5n7DQtTl9PAoz/Ru5utLbyMepKy8qslcM6Ld6ZeD+Gb4aFLkjLxJ9sS9HIgfhX2WlVNKGhHDQxGrtznFKwYcu2mJDxx7nBuSFX689Gec6R3ibOcQZ+aPkJ5LaJ2LSFcSkiTGGo2yizmaJlFdEQZmohWs0LpWjcY/qK4aVi2uaJATDQo8Am86hw/1mIsGzFmfP03Psxh1aVjOoVd06PTny+7JWkzzcJt4eLi86rV8Hs+LsmtSaOb8tngBUQJxBElMlBUkPadxIaK7UJ5chh5zKOrz4Rt/xq/7r+TRldv4v4WxlM4z+E2DpJ8Q9w6TnImwTg/rdHHAyDempswAhda1bH1tYXnVCsCGOfGwwA08duabfSIr/7PfHLdpWY+hn+GVh1f4f0ea5K2YrGXk7ZRorlVOeFzrYAzLsRrNnN8Zi/A4wjIn7hWkqzH9bkTuRq9IiazgXa0L3BRfIMdYGrQZ5jHDQ00G3YhksUG81sCG2cWD/DM0rqXQula5r185tEaKJeVkRk/K8Jp7yclbMb+//jD/0vxjlhYO8ZrGAzw7PMyDnT/hxeXDcCElXXHiIeTNiLQ6rsURPqQ8u4/WMKrFdWVFXoZ7nmNZhmU5XuVNc8kZLES8vLTAQ40/4nRvkWd7fwCg7wlL/TkGg4S4DVkLikZ1ksjy9akPwMwEFii0ZsPoCtNoAD13kp6TdCI6K01emFskMufBQ7fwbP+V/Pz8q+itNom7EVFWXoKPh0U1Q7vqgkRja+ZmpFuyZ6MuXF5U3fSYeOAkHaN3vsGLcwtkHhHhFBjdPOWl8wsMVhrMZZSvxdCxbHZaVZdzYKGlzzusgTt4TjEAcycqHOsvEA1y0o7TXHKy36W8nC2ydP4Qv187zHKnzdq5Nsm5lGTViIZO3C1IlntYb1AGVxyDZeWCX11JvLr1bWgKfJjBYEC80sMcsvmY1jnDk4QVX6BzpEVeRCx12qwsz5G82GBuxWguOc3zBY3lYbnMJ8/L18EdZqyRe2Chpc87nBJ5XobWas6cQTSM6K6lZHMJL/22jRXQGhiNJUjXnPbZjHS1uiKVjc2Kj6KqazjbS0q2ZdRVp7q61+kSNRpEQLrSwKPyimyRJGQXYp7/w01EAyMdQOuska45rXMFzaWM+HyvnCGfbSSVF7P1u1f38Fo3Nljr7kRZDv0hyeqQaFCQrsVEWULeAsspryrGTmvJSboFjeUB0aBqTVULeNfHUSLbmCckW3PHCy+v9A0GeK+PxRFxJyM1cEso0nJOlhW2fi5oXihIuk7r3JDkQp9orVtOdciy6jWZrcAChda1bRRYRbXko3CKl89ijQZpZx5vpHizQdJtkzdj8kaE5V6ufetkRL2M+NwFGAzx4RAfjK0byXMt7dmpama8mcNwgHeN5Owq0bANkdE6V/5+s7kYyylPKisDbJARXehAr4/3+uWqhDzfmKc1Y7//qQ0t7ak1AWPdkvKS+NjGcr0+lhdYXpAkEVEjJm4nWOZE/YyoMyjDqtcv/9y0y4Pno7lBs/WG2RMfdaUNH2aYRVi3TxRHpJFhw/KCRjRIy9emnxN1+thgiHe65b5bWVaeKGb4ZDG1oaU9tSbENy6Je55jFpX/4bs9vF/Oco/6A6IkxpsNrLqU7qtrZctqtKdTtdeTF74xveFye8vLVXnh0O/jgyFRnkOnQ3wuKWe6JzHxMutXar1XbQ2UFxvd81ELd0ZNbWjJPrBoY4FtFJWhkxfluEhkZfcjz8uW1ehN4Y67b+ycOW5Gz/ST5NXYlBVe3h6tISx8I5yq18Krx2e9S34goaXpDlOkGlchz8ttUsbP2nEMwyHFYIilSfn9KLq0KzJDi3P3XVF2CR3Ww4miWA+o8TlwPoMTSS/nQEJL0x2mxKhb5zk+KFj/r1/tQz76sAtLk/KM7lcYaJ/xN82eVHPnnBiLivWZ8uX+WFkZUqMPHBmftKvf+bqp/rDW0WC87AP3sa+x8Sov1rsgs94N2Vej3/eo+ze+L1b1epTP08WOzaY6tO4/dZLTy926y5gdRTl51LNh2SrTm2X/uI/9vrP1sa1LniOX2PfuocazAqA3y3TR739L+x5aGs8SkUma6u4haFxLRC62r6E1ia7haEa8gktEYB9DaxQyk1iGowF5ERnZtzEtjWWJyH6YeGiduPs+Ti93J37FcPPYlhZSi8wmc11eFZGATP3VQxGRcQotEQmKQktEgqLQEpGg7PjqoZk9AfT2oZZJugE4U3cRV9Fy99fWXYRIaHYz5aHn7m+eeCUTZGYPh1Bj3TWIhEjdQxEJikJLRIKym9D60sSrmDzVKHKN0ox4EQmKuociEpQdhZaZfcTMfmFmj5vZA2b2+v0qbLfM7D1m9ksze9bMTtVdz2ZmdpuZ/djMnjKzJ83sk3XXJBKSHXUPzeztwNPuvmRm7wXucve37lt1O2RmMfAM8G7gBeAh4MPu/lSthY0xs5uBm939ETNbAH4O3DlNNYpMsx21tNz9AXdfqu7+DLh18iXtyVuAZ9391+4+AL4B3FFzTRdx9xfd/ZHq9grwNHCs3qpEwrGXMa2PAd+fVCETcgx4fuz+C0xxIJjZceANwIM1lyISjF1tAmhm76IMrXdMtpzZYWbzwLeAT7n7hV0eRpd+J8P28sPvjv5Kr8OE/LD4p6u+FldtaZnZJ8zs0errFjN7HfBl4A53PzuJQifoNHDb2P1bq8emipmllIH1dXf/dt31iITkqqHl7v/d3W9399spW2bfBj7q7s/sd3G78BDwp2b2b8ysAXwI+G7NNV3EzAz4CuUFjb+rux6R0Oy0e/g54Hrgf5TvPbJpWpjs7pmZ/WfgB0AMfNXdn6y5rM1OAB8FHjezR6vHPuPu36uvJJFwaEZ82Cb24k3yI98CpDGtKbGdMa19+wgxCYs+V1JCoWU8IhIUhZaIBEWhJSJBUWiJSFCCCi0zu8vMPl3d/ryZ/cUejvVVM/tD9UEdIhKIoEJrnLt/zt1/tIdD3AO8Z0LliMgBmfrQMrPPmtkzZvZT4NVjj99jZh+sbj9nZl+slho9bGZvNLMfmNmvzOzjlzuuu/8EOHcw/woRmZSpnqdlZm+iXIpzO2Wtj1DuP3U5v3X3283s7ylbUSeAFvAE8I/7XqyIHIipDi3gncB33L0DYGZbrSMcfe9xYL7aq2rFzPpmtujuy/tbarhGs+FFQjD13cMd6Fd/FmO3R/enPZxrNT4b/sTd9ynEZKpNe2j9BLjTzNrV1sQfqLuga9mxxTagJT0y3aa6BVLto/5N4DHgD5Rbz0yEmf1P4D8AN5jZC8B/dfevTOr4oXnu7vev3z5+6t4aKxHZ2lSHFoC7fwH4wmUe/9ux28fHbt9DORB/yfc2/fyHJ1akiByYae8eiohcRKE1407cfd/6WJZICKa+eyj76/Ry96LxLJFpp5aWiARFoSUiQVFoiUhQFFoiEhSFlogERaElIkFRaIlIUBRaIhIUhZaIBEWhJSJBUWjJJY4ttrURoEwthZZc4v5TJ7URoEwthZaIBEWhJSJBUWiJSFAUWiISFIXWDNOupRIi7Vw6w7RrqYRILS0RCYpCS0SCotASkaAotEQkKAotkWlhVn7JlhRacllaNF0D9/JLtqTQksvSommZVpqnJTLNzMAi8KK8r5aYQktk6oyNa1kcA+D52PdmPLgUWiLTpGpZWRxjcYS7Q+FAXj4eGZ7nMx1cCi2RukVx2aKKDBu1sqIIzDCoBuiLjedbBBQzG1wKLZE6mZWtqjTBkgQiq1pWG9wd4njs8bwa58ovPd4M0NXDGbWdHR407WEfVXOyRt1Aa6SQJpA2sCOHy6/DC5AmWBwRzc0RtVtYI10f55pVCq0ZdXq5y/2nTm75HE172Cfj41ZJAmkKSYI1Gliric+38bkW3m5ic3NYuw1JUra2oqjsRkazOwlV3UORgzRqXTUaEMdlCytJsDTFD7XxdoPh0RaWOZaV41jRMCd+8RzuBZZbGV5m+Ki76LM1vqXQEqmDWdnKOnoEn2uSzTcZLDbIWxHDOSMeQNItSDo53jfiZgMDPN8UUDMWWKDQEqlHFEEjpVg8xPBwk8FiQvf6iKxlFA2Iu9BYNZoRpFB2FYsC4gjziNmKqYsptGaQtlmuwWgcK02Imk3shuvIjx5i+c/m6R+J6B+F4YKTtwo4OoALKc2XY+Z+H9NYifB4gcbLCXF/gA+GkOdYHJcXEGfsKqJCawZpm+UDVs29sqgcz6KRUiy0yQ436R+J6L0CejdlWCsnauQcWeiwkrbpRU2iQUKRGHE/Ju43iFbaMBhAnpcD8m64z9YseYWWyEGKY6zVon/DHJ0bU3qvgMG/7fKf/t1jrOZNsiImiXJWrmuxfFObp9s30z+bYkWEx03mWKQxzMpjdb0ajFdLS0Qmyb2c9d5sYq0W3mqQzcUMDxmDIwXN1hCAdx35VxbiLo91/oiz8SEADh/tcMEPUfy2QRE7btXVwyjGq/Aqu4n5xt91jVNoiRwQSxOs2cAbKXnTyJtG0c5pphk5Ea9vnuaWxDibzQOwmje57lCH/iChSBp4NavSIytnzo+W9lgEtmmpzzVMk0tF9ttobWFRbvLnUUTSLWhccJovJZw/P8egSPh1dh2/yYzbWy+wEPd4fu0op88eoX+2TdJ1kr4TDcoWlY1aXNWM+lma+qDQki1pKc/eWdUyKndsKDB3LHPigZN0gAspTy+/kvvOv4Yfrb6GBzp/whNrt/DS6jzD1QbxWkSUQZQ50bDAxtcmFl7O3Zoh6h7Klu4/dZLjp+6tu4ywWbS+e4MXBQyGxP2CpFfQXDawmOe7t/Dc4o1YM8cipxhGMIxIzyUkK0Y0cKK+Y91yuoNXrSrPcyg0EC8ik2Ll2JN7tc0MgDtxZ0gaGa1mRNyHdNXon0/Jm+Vb0hxwo/0SNFad9pmMxoVhOcG0mI1u4JWoeyhXpS7iLo1/sk5Rdg0pHMsLot6QdGVA43xG+0zO/O9y5l505l40Dv0O2i8ZrTNw6KWcQ78f0jzXJ14bwGgZzwwHl1paclXqIu7SeBfOHAYAHShy7MIKFsXMvdzGmw283aA9l+JpRJ5utCWaL3ewXjklwgZD6PbwThfPsnLKw4xcMRyn0BLZb+5AUa62yQwGo1CqwijLIc9JBhmeRMRpDFUWRStdGGYQR9Af4P1BGVj5bI1jjVNozRitO6yJe7lGMDcYDssF04CvrEC/Af1muSwHsNEe8IVvLIyODIYZPqhCq/Byv/hi9nYwVWjNGK07rNflWkieF9hgAGm6cZVxPbg2un/uflGXcMayap1CS+QgueNZtjFIbxH4EB+WA/RefbiFu5eLokc/VvhMTSDdikJLpA6j8BlrLvlwUP4JF4caKLDGaMqDbIumPRwwd4XUFSi0ZFv0IRc1KaoZ7wqwdQotEQmKxrRmhLp2cq1QS2tGjLp2e5mjpXEtmQZqac2Qq30463Z+Xst5pG5qacmOqLUldVNoyY6MWmsKLqmLQusad+Lu+zh+6t6JrjdUcEmdzDX/Q0QCopaWiARFoSUiQVFoiUhQFFoiEhRNLg2YmT0B9Oqu4ypuAM7UXcRVtNz9tXUXIduj0Apbz93fXHcRWzGzh0Oose4aZPvUPRSRoCi0RCQoCq2wfanuArZBNcpEaUa8iARFLS0RCYpCS0SCotAKkJl9xMx+YWaPm9kDZvb6umvazMzeY2a/NLNnzexU3fVsZma3mdmPzewpM3vSzD5Zd02yPRrTCpCZvR142t2XzOy9wF3u/ta66xoxsxh4Bng38ALwEPBhd3+q1sLGmNnNwM3u/oiZLQA/B+6cphrl8tTSCpC7P+DuS9XdnwG31lnPZbwFeNbdf+3uA+AbwB0113QRd3/R3R+pbq8ATwPH6q1KtkOhFb6PAd+vu4hNjgHPj91/gSkOBDM7DrwBeLDmUmQbtIwnYGb2LsrQekfdtYTKzOaBbwGfcvcLuzyMxlgmw7bzJLW0AmFmnzCzR6uvW8zsdcCXgTvc/Wzd9W1yGrht7P6t1WNTxcxSysD6urt/u+56ZHs0EB8gM3sVcB/wN+7+QN31bGZmCeVA/J9ThtVDwF+7+5O1FjbGzAz4GnDO3T+1x8PpTTQZ22ppKbQCZGZfBv4S+E31UDZtOymY2fuAfwBi4Kvu/oV6K7qYmb0D+GfgcaCoHv6Mu39vF4fTm2gyFFoiB2Sib6LRpxzt9cN1A6QxLZHQjALr9HK35kqml0JLZIqcXu7OYgtrRxRaIhIUhZaIBEWhJSJBUWjJrpjZXWb26er2583sL3Z5HO22UDlx930cW2wDcGyxvT4oLxdTaMmeufvn3P1Hu/zxDPgv7v4a4G3AJ8zsNZOrLhzjg/D3nzqpK4hXoNCSbTOzz5rZM2b2U+DVY4/fY2YfrG4/Z2ZfrJYbPWxmbzSzH5jZr8zs45uPqd0WZKe0YFq2xczeBHwIuJ3y/80jlHtQXc5v3f12M/t74B7gBNACngD+cYu/4zjabUGuQqEl2/VO4Dvu3gEws+9u8dzR9x4H5qsW1IqZ9c1s0d2XN//AhHZbkBmg7qHsh371ZzF2e3T/khOldlu4PA3GX55CS7brJ8CdZtautif+wCQOWu228BXK7aP/bhLHvFZoMP7yFFqyLdVg+TeBxyh3Sn1oQoc+AXwUODm2X9j7JnRsuQZpTEu2rdpe5pItZtz9b8duHx+7fQ/lQPwl3xt77Kdsc3W/CKilJSKBUWiJSFAUWiJTYHwJj2xNY1oiU+D0cpfn7n5/3WUEQS0tEQmKQktEgqLQEpGgKLREJCgKLREJikJLZIpp0fSlFFoiU0yLpi+l0BKRoCi0RCQoCi0RCYpCS6RmWne4M1p7KFIzrTvcGbW0RKacpj1cTKElMuU07eFiCi0RCYpCS0SCotASkaAotEQkKAotEQmKQktEgqLQEpGgKLREJCgKLREJikJLpEZaLL1zWjAtUiMtlt45tbREJCgKLREJikJLRIKi0BKRoCi0RAKgjQA3KLREAqCNADcotERqojlau6N5WiI10Ryt3VFLS0SCotASkaAotEQCoSuIJYWWSCB0BbGk0BKRoCi0RCQoCi0RCYpCS6QGmli6e5pcKlIDTSzdPbW0RAKiaQ8KLZGgaNqDQktEAqPQEpGgKLREJCgKLREJikJLRIKi0BIJzKxPe1BoiQRm1qc9KLREDpiW8OyNlvGIHDAt4dkbtbREJCgKLZEDNKmu4SwPxiu0RA7Q6eUu9586uefjzPJgvEJLJFCz2toyd6+7BpHQbetNNAqYSbS0Ro6fune9uznJ49bEtvMktbRE9tmJu+/j+Kl7gckHy/j42Ky0utTSEpGgqKUlIkFRaIlIUBRaIhIUhZaIBEVrD0X2yMyeAHp113EVNwBn6i7iKlru/tqrPUmhJbJ3PXd/c91FbMXMHg6hxu08T91DEQmKQktEgqLQEtm7L9VdwDZcMzVqRryIBEUtLREJikJLZA/M7CNm9gsze9zMHjCz19dd02Zm9h4z+6WZPWtmp+quZzMzu83MfmxmT5nZk2b2yS2fr+6hyO6Z2duBp919yczeC9zl7m+tu64RM4uBZ4B3Ay8ADwEfdvenai1sjJndDNzs7o+Y2QLwc+DOK9WolpbIHrj7A+6+VN39GXBrnfVcxluAZ9391+4+AL4B3FFzTRdx9xfd/ZHq9grwNHDsSs9XaIlMzseA79ddxCbHgOfH7r/AFoFQNzM7DrwBePBKz9GMeJEJMLN3UYbWO+quJVRmNg98C/iUu1+40vPU0hLZITP7hJk9Wn3dYmavA74M3OHuZ+uub5PTwG1j92+tHpsqZpZSBtbX3f3bWz5XA/Eiu2dmrwLuA/7G3R+ou57NzCyhHIj/c8qwegj4a3d/stbCxpiZAV8Dzrn7p676fIWWyO6Z2ZeBvwR+Uz2UTdvCZDN7H/APQAx81d2/UG9FFzOzdwD/DDwOFNXDn3H37132+QotEQmJxrREJCgKLREJikJLRIKi0BKRoCi0RCQoCi2RgJnZXWb26er2583sL3Z5nJaZ/R8ze6zaaeG/TbbSydEyHpFrhLt/bg8/3gdOuvtqNTv9p2b2fXf/2YTKmxi1tEQCY2afNbNnzOynwKvHHr/HzD5Y3X7OzL5YLTV62MzeaGY/MLNfmdnHNx/TS6vV3bT6mspJnAotkYCY2ZuADwG3A+8D/v0WT/+tu99OOdv8HuCDwNuAy3b9zCw2s0eBPwA/dPcr7rRQJ4WWSFjeCXzH3TvVTgjf3eK5o+89Djzo7ivu/jLQN7PFzU9297wKuVuBt5jZVT84tQ4KLZFrV7/6sxi7Pbp/xfFsd18Gfgy8Z98q2wOFlkhYfgLcaWbtamviD0zioGb2ilHry8zalNsz/+skjj1punooEpBqH/VvAo9Rjj09NKFD3wx8rdpTPgL+l7v/7wkde6K0y4OIBEXdQxEJikJLRIKi0BKRoCi0RCQoCi0RCYpCS0SCotASkaAotEQkKP8fTqskCLFA4/IAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAS0AAAFJCAYAAADOhnuiAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAVfUlEQVR4nO3dW4xd1X3H8d/vXGbm2DP2cK8ZG5k2KW2CwARCIkwqxQWJgCKoQqSQKGlUXiKlUpCah1EiIRKJxk9pXlpVEUHwEDVpFKJGJYhSGYlgF2pCAHMJliEEPBiozYw9nss5c8759+HsCePxZW7H3nt5vh9pNHuf2bP9h+3z81rrrL22I0IAkIpS3gUAwFIQWgCSQmgBSAqhBSAphBaApBBaAJJSWcbvMEeiO7zSE9xY+jzXoksea/9s2deD69A9i7kOtLQAJIXQApAUQgtAUnIPra3bd2jr9h15lwEgEcsZiO+qkbGpvEsAkJDcW1oAsBSEFoCkEFoAkkJoAUgKoQUgKYQWgKQUIrSGBmvM1QKwKIUIrZ3D25ivBWBRChFaALBYhBaApBBaAJJCaAFISq6htXX7Dg0N1vIsAUBicl3lYWRsSm9svyXPEgAkhu4hgKQQWgCSQmgBSAqhBSAphBaApBBaAJJCaAFICqEFICmEFoCkEFoAklKY0GL1UgCLUZjQYvVSAItRmNACgMUgtAAkhdACkBRCC0BScgstVi0FsBy5rVzKqqUAloPuIYCkEFoAkkJoAUgKoQUgKYQWgKQQWgCSQmgBSAqhBSAphBaApBBaAJJCaAFICqEFICmEFoCkFCq0eLgFgIUUKrR4uAWAhRQqtABgIbktAoiCsI/dj8inDnxwLVySos21OAlCazWz5XJZrlSkUqnzpolQtFqKmSZvnDPBllySS5bKZblclsplqd1WNJtSq6Voh9Ru5V1pYRBaq9hsYLlWkyoVuVxSNJtyY0btdihakkRwnVYuda5DuST39XauQ7WqaLbkmYaiMdMJrgbXYRahtRrZcqWq0tqaPDCg5oZz1FpbVWN9RZXJtnpG6yq/M6o4OqH20QlFq8W/9N2WtbBKtT6VBvoV6wdUH1qv5pqyoiKVp9qqjs+o+tYhxfh49o8I10EitFYtVzstrPY5/ZraUFN9fVlTF1iViVDfaEXrmm2VyyW5XpeirWjnXfFZZraF1dOjGFirxoZ1Onxpj2YGrFav1HMkVDtY1rqJAZUkuTHDdcjkElo8PixHs+NYa2pqXzCoiUvX6eDlFU1f1NKFHzqkwxM1jR6qqV0d0MAbVVWPTkg24ypd1gmsqrx2jeobB3Xoo306fE1dF154WJesG9WeAxdrYm+/HOu0ZqRHlclJSeq0tlZ5NzGXKQ8jY1PaObwtjz8a8/7CR8mqX9DWwCVH9HeX7tKNl/5O528c0/S5Jc2sq8rVamdwGN2VNZlibU2N9RVNnyt9eNO7+ptNz+tv/2Snrtv0e80MNVRfV1KrVjn+U95VjO7hKhTt+GN4OULtgZb+7NyD+nz/Pg1V39fBer+e7z9fzTUlqVKRShb9ktMjeitq9pXUXBO64pwR3dD/ki7vsUbWv67fnjukZu08tasE1lyE1moUbWmmqdLRafUe7NOafWv02+Zm/WP/Vr01dY5ePXihKhNSeTqkdltqr+7uyOkQrZbUbKp8eEK199aq/61e7XrvUvWWmtpRmdR/vfsRje5frw2H2uo53JCazc61AKG1WkWzKdcbqozXtebdmqJc1cPnfVSNelWtw1VdMBaqTLYUzWbnDYbua4dUb6h6pK7aware/v35+o+pPvX31fXOO4OqHaio5/CMSpMNxUxT0SK0JEJrdYpQe7oujY7J9brOK5W0/ve9mnitXw7JrVD/WxMqj05K9XpnkuMqH/w9LaKt9sSkygfe1+DUjHoPr1Nj3TpNXlDSRYfbWnugrt63j8hHJtRqzDAInyG0VqtoKxoNSVL5vVGVxntVOdrf+Vm7rfKhccXUtNpT053Z8ei6aLWk6brCliXVItTbW1XtvV6VJ2dUPjwljR1RTE0rmjMEVobQWq1mb9fJWlw6UlZpfEK2FRHZG6XZCTbeLN2X/T+N5ozaU50PRDw9rVKprN53yop2W2rMKOr17JYqrsEsQms1i5Ci1ekqSvLUVOdmXc3OB+LWkdMuQjHTUDRnOlNLPGcWUrQZTzwBQgudSaN2dq9h9iYhrM6srOX7x///c17HsQgtdPDmyB/XYFEKtwggSy4DOJXChRZLLgM4lTMeWtwsDWAlzviY1sjYlN7YfsuZ/mMBnCUK1z0EgFMhtAAkhdACkJRChhbTHgCcTCFDi2kPAE7mjIYW0x0ArNQZDa2lrA1PFxHAiZyx0FpqK2u2i7h5+OHTWBWA1Di4SRNAQgo5EA8AJ0NoAUgKoQUgKYQWgKQseZUH2y9Kmj4NtXTT+ZIO5l3EAvoi4vK8iwBSs5ylaaYj4pquV9JFtp9Joca8awBSRPcQQFIILQBJWU5o/bDrVXQfNQJnKWbEA0gK3UMASVlSaNn+ku0XbO+xvcv2laersOWyfZPtV23vsz2cdz3z2d5k+3HbL9t+yfY38q4JSMmSuoe2r5P0SkSM2v6MpHsi4hOnrbolsl2WtFfSjZL2S9ot6Y6IeDnXwuawvUHShoh41vaApN9Iuq1INQJFtqSWVkTsiojRbPcpSRu7X9KKXCtpX0S8HhENST+RdGvONR0jIg5ExLPZ9rikVyQN5VsVkI6VjGndKemRbhXSJUOS3pqzv18FDgTbmyVdJenpnEsBkrGsh7Xa/rQ6oXV9d8tZPWz3S/q5pLsi4sgyT8NHv93hlfzyjaXPcx265LH2zxa8Fgu2tGx/3fZz2dfFtq+QdJ+kWyPiUDcK7aIRSZvm7G/MXisU21V1AuvHEfFQ3vUAKVkwtCLinyNiS0RsUadl9pCkL0fE3tNd3DLslvRh25fa7pH0BUm/zLmmY9i2pB+p84HG9/OuB0jNUruHd0s6T9K/dN57ahbpxuSIaNr+e0mPSipLuj8iXsq5rPm2SvqypD22n8te+1ZE/Cq/koB0MCM+bV2/eJuHH9Yb22/p9mmLjjGtgujKmBZWD558hBQQWgCSQmgBSAqhBSAphBaApCQVWrbvsf3NbPu7tm9Ywbnut/1e9qAOAIlIKrTmioi7I+K/V3CKByTd1KVykrd1+w4NDdbyLgNYUOFDy/a3be+1/aSky+a8/oDt27PtN2x/L7vV6BnbH7P9qO3XbH/tROeNiCckvX9m/iuKb2RsSjuHt+VdBrCgQoeW7avVuRVni6SbJX38FIe/md1q9Gt1WlG3S/qkpO+c1iLPQlu378i7BOCklrXKwxn0KUm/iIhJSbJ9qvsIZ3+2R1J/tlbVuO267cGIGDu9pZ49Rsam8i4BOKlCt7SWqJ59b8/Znt0vejgDWKSih9YTkm6zXcuWJv5s3gUByFehQytblvinkp5XZ5XU3d06t+1/k/Q/ki6zvd/2nd06d8pW4c3SSEzhu00Rca+ke0/w+lfnbG+es/2AOgPxx/1s3u/f0bUiAZwxhW5pAcB8hBaApBBaAJJCaAFICqEFICmEFoCkEFoAkkJoAUgKoQUgKYQWgKQQWmDVUiSl8Pce4vQbGZviRmkkg5YWgKQQWgCSQmgBSAqhBSAphBaApBBaOM7QYI3HiKGwCC0cZ+fwNh4jhsIitAAkhdACkBRCC0BSCC0ASSG0ACSF0AKQFEILQFIILQBJIbQAJIXQWuVYtRSpYeXSVY5VS5EaWloAkkJoAUgKoQUgKYQWgKQQWgCSwqeHQFHYkue1I6KdfY8zX09BEVpAnrKgcrks91Tlclkqlzth1Q5Fo6FoNhXNZt6VFgahBeTM1Yrc0yOvqcmVitRTldptqdmSxo9KkqLVorWVIbSAvNgq9faqNLhece56TfzpoBoDJbV6rJ6jbfUdmlHPyJh85Kj8/lgnuNqtvKvOHQPxOCGeyHOazXYL+3oVA2vVuKhfhy+taOzPSxr9qDT24bLGN/WqdV6/NLBWLpfkkvOuuhBoaeGEdg5v0+bhh/Mu46zlclmuVOSBAdU3DurQR/pU/6txXXXxft103h499O7VeuHFzZLWaqCvop5DY9LUFN1EEVpAPlySymVFrVcz/RXVz5GuvHhEt13wrLb0vq3955yn14fOVXPNoKJkqVySSnSMJLqHQG5cLkvVipq1kpr9ob/sf0dX945oY7mqD/W9o43rD6tdtWR1Qs50DyVaWkA+oq1oNuV6Q73vz2jNSK8efP6TeuzCv9CW80a08+1LdfSVc3TRgZYq4w2pXmfaQ4bQAnIQ7ZDbbbk+o+rRGdUOVjX1Zq9GJs/Xe2P9ah1Yo3VvWb2jTZUnGtknh7Hqx7MkQgvITTSbisNHVInQ4GRD1al1mllTkltr1Hu4pd6DR1V+d0wxOalozHSCC4QWkIt2SxFWu15X6ahVitBaSdFTkVqh0nRDPjqlODrRmRXfan1wS88qR2gBeYnObTrtdsgzTXl6WrY7XcBWS+2ZptRqKVptJpXOQWgBeYpQNLOu39T0HyeQRju4WfokCC0gbxFSdFpS0VZnagNBdVLM01rFeBJPQRFYp0RLaxXjSTxIES0tnBQ3TaOICC2c1M7hbRoZm8q7DOAYhBaApBBaAJJCaAFICqEFICmE1irFHC2kitBapUbGprRzeNuCxzHtAUVDaOGUmPaAoiG0ACSF0FqFljqeRRcRReLg5kwACaGlBSAphBaApBBaAJJCaAFICosAJsz2i5Km865jAedLOph3EQvoi4jL8y4Ci0NopW06Iq7Ju4hTsf1MCjXmXQMWj+4hgKQQWgCSQmil7Yd5F7AI1IiuYkY8gKTQ0gKQFEILQFIIrQTZ/pLtF2zvsb3L9pV51zSf7Ztsv2p7n+3hvOuZz/Ym24/bftn2S7a/kXdNWBzGtBJk+zpJr0TEqO3PSLonIj6Rd12zbJcl7ZV0o6T9knZLuiMiXs61sDlsb5C0ISKetT0g6TeSbitSjTgxWloJiohdETGa7T4laWOe9ZzAtZL2RcTrEdGQ9BNJt+Zc0zEi4kBEPJttj0t6RdJQvlVhMQit9N0p6ZG8i5hnSNJbc/b3q8CBYHuzpKskPZ1zKVgEbuNJmO1PqxNa1+ddS6ps90v6uaS7IuLIMk/DGEt3eDEH0dJKhO2v234u+7rY9hWS7pN0a0Qcyru+eUYkbZqzvzF7rVBsV9UJrB9HxEN514PFYSA+QbYvkbRD0lciYlfe9cxnu6LOQPxfqxNWuyV9MSJeyrWwOWxb0oOS3o+Iu1Z4Ot5E3bGolhahlSDb90n6nKQ/ZC81i7aSgu2bJf1AUlnS/RFxb74VHcv29ZJ+LWmPpHb28rci4lfLOB1vou4gtIAzpKtvos3DD+uN7bd085SpYEwLwNmH0AKQFEILQFIILQBJIbQAJIXQwrLYvsf2N7Pt79q+YZnnYbWFE9g8/HDeJRQWt/FgxSLi7hX8elPSP8xdbcH2Y6t1tQXCamG0tLBotr9te6/tJyVdNuf1B2zfnm2/Yft72e1Gz9j+mO1Hbb9m+2vzz8lqC1gqWlpYFNtXS/qCpC3q/L15Vp01qE7kzYjYYvufJD0gaaukPkkvSvrXU/wZm8VqC1gAoYXF+pSkX0TEpCTZ/uUpjp392R5J/VkLatx23fZgRIzN/4UurbaAVYDuIU6Heva9PWd7dv+4fyhZbeFYQ4O1vEsoNEILi/WEpNts17IB889246TZags/Umf56O9345yp2zm8Le8SCo3QwqJkg+U/lfS8Oiul7u7SqbdK+rKkbXPWC7u5S+fGWYgxLSxatrzMcUvMRMRX52xvnrP9gDoD8cf9bM5rT2qRd/cDEi0toJCGBmvaun1H3mUUEqEFFNDO4W0aGZvKu4xCIrQAJIXQApAUQgsoiK3bdzBHaxH49BAoiJGxqdW6NvyS0NICkBRCC0BSCC0ASSG0ACSF0AKQFEILQFIILQBJIbQAJIXQApAUQgtAUggtAEkhtAAkhdACkBRCC0BSCC0ASSG0ACSF0AIKiifynBihBRQUT+Q5MUILQFIILQBJIbQAJIXQAgqAx4ctHo8QAwqAx4ctHi0tAEkhtAAkhdACkBRCC0BSCC0ASSG0ACSF0AKQFEILQFIILQBJIbQAJIXQApAUQgtAUggtoMBYcvl4hBZQYCy5fDxCC0BSCC0ASSG0ACSF0AKQFEILyBnrwy8Na8QDOWN9+KWhpQUgKYQWgKQQWgCSQmgBSAqhBSAphBZQcNw0fSxCCyg4bpo+FqEF5IiJpUvH5FIgR0wsXTpaWgCSQmgBCWAw/gOEFpAABuM/QGgBOWEQfnkILSAHs129ncPbFv07Q4M1bR5+eNV3Ex0RedcAAItGSwtAUggtAEkhtAAkhdACkBRu4wFWyPaLkqbzrmMB50s6mHcRC+iLiMsXOojQAlZuOiKuybuIU7H9TAo1LuY4uocAkkJoAUgKoQWs3A/zLmARzpoamREPICm0tAAkhdACVsD2l2y/YHuP7V22r8y7pvls32T7Vdv7bA/nXc98tjfZftz2y7Zfsv2NUx5P9xBYPtvXSXolIkZtf0bSPRHxibzrmmW7LGmvpBsl7Ze0W9IdEfFyroXNYXuDpA0R8aztAUm/kXTbyWqkpQWsQETsiojRbPcpSRvzrOcErpW0LyJej4iGpJ9IujXnmo4REQci4tlse1zSK5KGTnY8oQV0z52SHsm7iHmGJL01Z3+/ThEIebO9WdJVkp4+2THMiAe6wPan1Qmt6/OuJVW2+yX9XNJdEXHkZMfR0gKWyPbXbT+XfV1s+wpJ90m6NSIO5V3fPCOSNs3Z35i9Vii2q+oE1o8j4qFTHstAPLB8ti+RtEPSVyJiV971zGe7os5A/F+rE1a7JX0xIl7KtbA5bFvSg5Lej4i7Fjye0AKWz/Z9kj4n6Q/ZS82i3Zhs+2ZJP5BUlnR/RNybb0XHsn29pF9L2iOpnb38rYj41QmPJ7QApIQxLQBJIbQAJIXQApAUQgtAUggtAEkhtICE2b7H9jez7e/avmGZ5+mz/b+2n89WWvhOdyvtHm7jAc4SEXH3Cn69LmlbRBzNZqc/afuRiHiqS+V1DS0tIDG2v217r+0nJV025/UHbN+ebb9h+3vZrUbP2P6Y7Udtv2b7a/PPGR1Hs91q9lXISZyEFpAQ21dL+oKkLZJulvTxUxz+ZkRsUWe2+QOSbpf0SUkn7PrZLtt+TtJ7kh6LiJOutJAnQgtIy6ck/SIiJrOVEH55imNnf7ZH0tMRMR4R/yepbntw/sER0cpCbqOka20v+ODUPBBawNmrnn1vz9me3T/peHZEjEl6XNJNp62yFSC0gLQ8Iek227VsaeLPduOkti+YbX3ZrqmzPPPvunHubuPTQyAh2TrqP5X0vDpjT7u7dOoNkh7M1pQvSfr3iPjPLp27q1jlAUBS6B4CSAqhBSAphBaApBBaAJJCaAFICqEFICmEFoCkEFoAkvL/C6gLe/eH9y8AAAAASUVORK5CYII=\n",
       "text/plain": [
        "<Figure size 360x360 with 9 Axes>"
       ]
@@ -297,14 +297,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Posterior conditional density p(θ|x) of type DirectPosterior. It samples the posterior network but rejects samples that lie outside of the prior bounds.\n"
+      "Posterior conditional density p(θ|x) of type DirectPosterior. It samples the posterior network and rejects samples that\n",
+      "            lie outside of the prior bounds.\n"
      ]
     }
    ],
@@ -315,7 +316,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -329,7 +330,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.7.11"
   }
  },
  "nbformat": 4,

--- a/tutorials/11_sampler_interface.ipynb
+++ b/tutorials/11_sampler_interface.ipynb
@@ -25,18 +25,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " Neural network successfully converged after 52 epochs."
+     ]
+    }
+   ],
    "source": [
+    "import torch\n",
+    "\n",
     "from sbi.inference import SNLE\n",
     "from sbi.inference import likelihood_estimator_based_potential, MCMCPosterior\n",
     "\n",
-    "inference = SNLE()\n",
+    "# dummy Gaussian simulator for demonstration\n",
+    "num_dim = 2\n",
+    "prior = torch.distributions.MultivariateNormal(torch.zeros(num_dim), torch.eye(num_dim))\n",
+    "theta = prior.sample((1000,))\n",
+    "x = theta + torch.randn((1000, num_dim))\n",
+    "x_o = torch.randn((1, num_dim))\n",
+    "\n",
+    "inference = SNLE(show_progress_bars=False)\n",
     "likelihood_estimator = inference.append_simulations(theta, x).train()\n",
     "\n",
     "potential_fn, parameter_transform = likelihood_estimator_based_potential(likelihood_estimator, prior, x_o)\n",
-    "posterior = MCMCPosterior(potential_fn, proposal=prior, parameter_transform=parameter_transform)"
+    "posterior = MCMCPosterior(potential_fn, proposal=prior, theta_transform=parameter_transform)"
    ]
   },
   {
@@ -50,9 +67,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " Neural network successfully converged after 33 epochs."
+     ]
+    }
+   ],
    "source": [
     "inference = SNLE()\n",
     "likelihood_estimator = inference.append_simulations(theta, x).train()"
@@ -67,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,12 +108,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Assuming that your parameters are 1D.\n",
-    "potential = potential_fn(torch.zeros(1, 1))  # -> returns f(0) = log( p(x_o|0) p(0) )"
+    "potential = potential_fn(torch.zeros(1, num_dim))  # -> returns f(0) = log( p(x_o|0) p(0) )"
    ]
   },
   {
@@ -100,11 +125,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tensor([[0., 0.]])\n"
+     ]
+    }
+   ],
    "source": [
-    "theta_tf = parameter_transform(torch.zeros(1, 1))\n",
+    "theta_tf = parameter_transform(torch.zeros(1, num_dim))\n",
     "theta_original = parameter_transform.inv(theta_tf)\n",
     "print(theta_original)  # -> tensor([[0.0]])"
    ]
@@ -118,7 +151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,9 +172,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " Neural network successfully converged after 57 epochs."
+     ]
+    }
+   ],
    "source": [
     "from sbi.inference import SNPE\n",
     "from sbi.inference import DirectPosterior\n",
@@ -151,11 +192,18 @@
     "\n",
     "posterior = DirectPosterior(posterior_estimator, prior=prior)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -169,7 +217,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.7.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
closes #662 

plus:
- tutorial notebooks contained example API in code cells that then throw an error when executed. I changed them to markdown. 
- fixes a bug with number of init params in parallel MCMC
- fixes pbar descriptions and switches for parallel MCMC and vectorized MCMC