### PR TITLE
pass on sir kwargs to init method.

### DIFF
--- a/sbi/inference/posteriors/mcmc_posterior.py
+++ b/sbi/inference/posteriors/mcmc_posterior.py
@@ -237,7 +237,11 @@ class MCMCPosterior(NeuralPosterior):
         self.potential_ = self._prepare_potential(method)  # type: ignore
 
         initial_params = self._get_initial_params(
-            init_strategy, num_chains, num_workers, show_progress_bars  # type: ignore
+            init_strategy,
+            num_chains,
+            num_workers,
+            show_progress_bars,  # type: ignore
+            **dict(num_candidate_samples=init_strategy_num_candidates),
         )
         num_samples = torch.Size(sample_shape).numel()
 

--- a/sbi/samplers/importance/sir.py
+++ b/sbi/samplers/importance/sir.py
@@ -11,7 +11,7 @@ def sampling_importance_resampling(
     potential_fn: Callable,
     proposal: Any,
     num_samples: int = 1,
-    oversampling_factor: int = 32,
+    num_candidate_samples: int = 32,
     max_sampling_batch_size: int = 10_000,
     show_progress_bars: bool = False,
     device: str = "cpu",
@@ -23,7 +23,7 @@ def sampling_importance_resampling(
         potential_fn: Potential function $log(p(\theta))$ from which to draw samples.
         proposal: Proposal distribution for SIR.
         num_samples: Number of samples to draw.
-        oversampling_factor: Number of proposed samples form which only one is
+        num_candidate_samples: Number of proposed samples form which only one is
             selected based on its importance weight.
         max_sampling_batch_size: The batchsize of samples being drawn from the
             proposal at every iteration.
@@ -36,7 +36,9 @@ def sampling_importance_resampling(
 
     selected_samples = []
 
-    max_sampling_batch_size = max(1, int(max_sampling_batch_size / oversampling_factor))
+    max_sampling_batch_size = max(
+        1, int(max_sampling_batch_size / num_candidate_samples)
+    )
     sampling_batch_size = min(num_samples, max_sampling_batch_size)
 
     num_remaining = num_samples
@@ -52,13 +54,13 @@ def sampling_importance_resampling(
             thetas, log_weights = importance_sample(
                 potential_fn=potential_fn,
                 proposal=proposal,
-                num_samples=batch_size * oversampling_factor,
+                num_samples=batch_size * num_candidate_samples,
             )
-            log_weights = log_weights.reshape(batch_size, oversampling_factor)
+            log_weights = log_weights.reshape(batch_size, num_candidate_samples)
             weights = log_weights.softmax(-1).cumsum(-1)
             uniform_decision = torch.rand(batch_size, 1, device=device)
             mask = torch.cumsum(weights >= uniform_decision, -1) == 1
-            samples = thetas.reshape(batch_size, oversampling_factor, -1)[mask]
+            samples = thetas.reshape(batch_size, num_candidate_samples, -1)[mask]
             selected_samples.append(samples)
 
         num_remaining -= batch_size

--- a/sbi/samplers/mcmc/init_strategy.py
+++ b/sbi/samplers/mcmc/init_strategy.py
@@ -38,7 +38,7 @@ def sir_init(
     proposal: Any,
     potential_fn: Callable,
     transform: torch_tf.Transform,
-    num_candidate_samples: int = 1000,
+    num_candidate_samples: int = 10_000,
     **kwargs: Any,
 ) -> Tensor:
     r"""Return a sample obtained by sequential importance reweighting.
@@ -68,7 +68,7 @@ def resample_given_potential_fn(
     proposal: Any,
     potential_fn: Callable,
     transform: torch_tf.Transform,
-    num_candidate_samples: int = 1000,
+    num_candidate_samples: int = 10_000,
     num_batches: int = 1,
     **kwargs: Any,
 ) -> Tensor:


### PR DESCRIPTION
quick fix to actually use `init_strategy_num_candidates` in `sir`. 

However, I am not sure, how `init_strategy_num_candidates` relates to `sir_num_batches` and `sir_batch_size`. Previously, we used `init_strategy_num_candidates=sir_num_batches * sir_batch_size`, but this was replaced by the `oversampling factor right? @michaeldeistler can you clarify? 
https://github.com/mackelab/sbi/blob/ce389f8ce633985b8ea7cf96b1ea0001daac3dd5/sbi/samplers/importance/sir.py#L39-L40