### PR TITLE
Implementation of TSNPE

### DIFF
--- a/docs/docs/faq/question_06.md
+++ b/docs/docs/faq/question_06.md
@@ -9,13 +9,11 @@ inference = inference.append_simulations(theta, x)
 inference.train(max_num_epochs=300)  # Pick `max_num_epochs` such that it does not exceed the runtime.
 
 with open("path/to/my/inference.pkl", "wb") as handle:
-    dill.dump(inference, handle)
+    pickle.dump(inference, handle)
 
 # To resume training:
 with open("path/to/my/inference.pkl", "rb") as handle:
-    inference_from_disk = dill.load(handle)
+    inference_from_disk = pickle.load(handle)
 inference_from_disk.train(resume_training=True, max_num_epochs=600)  # Run epochs 301 until 600 (or stop early).
 posterior = inference_from_disk.build_posterior()
 ```
-
-Note that the inference object can not be saved with `pickle`. To save it, you will have to install and use [dill](https://pypi.org/project/dill/). Another solution is described [here](https://www.mackelab.org/sbi/faq/question_04/).

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -36,7 +36,8 @@ In the case of simulators, a key quantity required for statistical inference, th
 likelihood of observed data given parameters, $\mathcal{L}(\theta) = p(x_o|\theta)$, is
 typically intractable, rendering conventional statistical approaches inapplicable.
 
-`sbi` implements three powerful machine-learning methods that address this problem:
+`sbi` implements powerful machine-learning methods that address this problem. Roughly, 
+these algorithms can be categorized as:
 
 - Sequential Neural Posterior Estimation (SNPE),
 - Sequential Neural Likelihood Estimation (SNLE), and
@@ -77,10 +78,10 @@ See [Cranmer, Brehmer, Louppe (2020)](https://doi.org/10.1073/pnas.1912789117) f
 review on simulation-based inference.
 
 The following papers offer additional details on the inference methods included in
-`sbi`:
+`sbi`. You can find a tutorial on how to run each of these methods [here](https://www.mackelab.org/sbi/tutorial/16_implemented_algorithms/).
 
 
-### SNPE
+### Posterior estimation (SNPE)
 
 - **Fast ε-free Inference of Simulation Models with Bayesian Conditional Density Estimation**<br> by Papamakarios & Murray (NeurIPS 2016) <br>[[PDF]](https://papers.nips.cc/paper/6084-fast-free-inference-of-simulation-models-with-bayesian-conditional-density-estimation.pdf) [[BibTeX]](https://papers.nips.cc/paper/6084-fast-free-inference-of-simulation-models-with-bayesian-conditional-density-estimation/bibtex)
 
@@ -88,12 +89,29 @@ The following papers offer additional details on the inference methods included 
 
 - **Automatic posterior transformation for likelihood-free inference**<br>by Greenberg, Nonnenmacher & Macke (ICML 2019) <br>[[PDF]](http://proceedings.mlr.press/v97/greenberg19a/greenberg19a.pdf) [[BibTeX]](data:text/plain;charset=utf-8,%0A%0A%0A%0A%0A%0A%40InProceedings%7Bpmlr-v97-greenberg19a%2C%0A%20%20title%20%3D%20%09%20%7BAutomatic%20Posterior%20Transformation%20for%20Likelihood-Free%20Inference%7D%2C%0A%20%20author%20%3D%20%09%20%7BGreenberg%2C%20David%20and%20Nonnenmacher%2C%20Marcel%20and%20Macke%2C%20Jakob%7D%2C%0A%20%20booktitle%20%3D%20%09%20%7BProceedings%20of%20the%2036th%20International%20Conference%20on%20Machine%20Learning%7D%2C%0A%20%20pages%20%3D%20%09%20%7B2404--2414%7D%2C%0A%20%20year%20%3D%20%09%20%7B2019%7D%2C%0A%20%20editor%20%3D%20%09%20%7BChaudhuri%2C%20Kamalika%20and%20Salakhutdinov%2C%20Ruslan%7D%2C%0A%20%20volume%20%3D%20%09%20%7B97%7D%2C%0A%20%20series%20%3D%20%09%20%7BProceedings%20of%20Machine%20Learning%20Research%7D%2C%0A%20%20address%20%3D%20%09%20%7BLong%20Beach%2C%20California%2C%20USA%7D%2C%0A%20%20month%20%3D%20%09%20%7B09--15%20Jun%7D%2C%0A%20%20publisher%20%3D%20%09%20%7BPMLR%7D%2C%0A%20%20pdf%20%3D%20%09%20%7Bhttp%3A%2F%2Fproceedings.mlr.press%2Fv97%2Fgreenberg19a%2Fgreenberg19a.pdf%7D%2C%0A%20%20url%20%3D%20%09%20%7Bhttp%3A%2F%2Fproceedings.mlr.press%2Fv97%2Fgreenberg19a.html%7D%2C%0A%20%20abstract%20%3D%20%09%20%7BHow%20can%20one%20perform%20Bayesian%20inference%20on%20stochastic%20simulators%20with%20intractable%20likelihoods%3F%20A%20recent%20approach%20is%20to%20learn%20the%20posterior%20from%20adaptively%20proposed%20simulations%20using%20neural%20network-based%20conditional%20density%20estimators.%20However%2C%20existing%20methods%20are%20limited%20to%20a%20narrow%20range%20of%20proposal%20distributions%20or%20require%20importance%20weighting%20that%20can%20limit%20performance%20in%20practice.%20Here%20we%20present%20automatic%20posterior%20transformation%20(APT)%2C%20a%20new%20sequential%20neural%20posterior%20estimation%20method%20for%20simulation-based%20inference.%20APT%20can%20modify%20the%20posterior%20estimate%20using%20arbitrary%2C%20dynamically%20updated%20proposals%2C%20and%20is%20compatible%20with%20powerful%20flow-based%20density%20estimators.%20It%20is%20more%20flexible%2C%20scalable%20and%20efficient%20than%20previous%20simulation-based%20inference%20techniques.%20APT%20can%20operate%20directly%20on%20high-dimensional%20time%20series%20and%20image%20data%2C%20opening%20up%20new%20applications%20for%20likelihood-free%20inference.%7D%0A%7D%0A)
 
-### SNLE
+- **Truncated proposals for scalable and hassle-free simulation-based inference** <br> by Deistler, Goncalves & Macke (NeurIPS 2022) <br>[[Paper]](https://arxiv.org/abs/2210.04815)
+
+
+### Likelihood-estimation (SNLE)
 
 - **Sequential neural likelihood: Fast likelihood-free inference with autoregressive flows**<br>by Papamakarios, Sterratt & Murray (AISTATS 2019) <br>[[PDF]](http://proceedings.mlr.press/v89/papamakarios19a/papamakarios19a.pdf) [[BibTeX]](https://gpapamak.github.io/bibtex/snl.bib)
 
-### SNRE
+- **Variational methods for simulation-based inference** <br> by Glöckler, Deistler, Macke (ICLR 2022) <br>[[Paper]](https://arxiv.org/abs/2203.04176)
+
+- **Flexible and efficient simulation-based inference for models of decision-making** <br> by Boelts, Lueckmann, Gao, Macke (Elife 2022) <br>[[Paper]](https://elifesciences.org/articles/77220)
+
+
+### Likelihood-ratio-estimation (SNRE)
 
 - **Likelihood-free MCMC with Amortized Approximate Likelihood Ratios**<br>by Hermans, Begy & Louppe (ICML 2020) <br>[[PDF]](http://proceedings.mlr.press/v119/hermans20a/hermans20a.pdf)
 
-- **On Contrastive Learning for Likelihood-free Inference**<br>Durkan, Murray & Papamakarios (ICML 2020) <br>[[PDF]](http://proceedings.mlr.press/v119/durkan20a/durkan20a.pdf).
+- **On Contrastive Learning for Likelihood-free Inference**<br>Durkan, Murray & Papamakarios (ICML 2020) <br>[[PDF]](http://proceedings.mlr.press/v119/durkan20a/durkan20a.pdf)
+
+
+### Utilities
+
+- **Restriction estimator**<br>by Deistler, Macke & Goncalves (PNAS 2022) <br>[[Paper]](https://www.pnas.org/doi/10.1073/pnas.2207632119)
+
+- **Simulation-based calibration**<br>by Talts, Betancourt, Simpson, Vehtari, Gelman (arxiv 2018) <br>[[Paper]](https://arxiv.org/abs/1804.06788))
+
+- **Expected coverage (sample-based)**<br>as computed in Deistler, Goncalves, Macke [[Paper]](https://arxiv.org/abs/2210.04815) and in Rozet, Louppe [[Paper]](https://matheo.uliege.be/handle/2268.2/12993)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
         - Amortized inference: tutorial/01_gaussian_amortized.md
         - Flexible interface: tutorial/02_flexible_interface.md
         - Sampler interface: tutorial/11_sampler_interface.md
+        - Implemented algorithms: tutorial/16_implemented_methods.md
       - Advanced:
         - Multi-round inference: tutorial/03_multiround_inference.md
         - Custom density estimators: tutorial/04_density_estimators.md

--- a/sbi/analysis/sbc.py
+++ b/sbi/analysis/sbc.py
@@ -37,7 +37,7 @@ def run_sbc(
         xs: observed data for sbc, simulated from thetas.
         posterior: a posterior obtained from sbi.
         num_posterior_samples: number of approximate posterior samples used for ranking.
-        reduce_fns: Function that is used to reduce the parameter space into 1D.
+        reduce_fns: Function used to reduce the parameter space into 1D.
             Simulation-based calibration can be recovered by setting this to the string
             `marginals`. Sample-based expected coverage can be recovered by setting it
             to `posterior.log_prob` (as a Callable).

--- a/sbi/inference/posteriors/direct_posterior.py
+++ b/sbi/inference/posteriors/direct_posterior.py
@@ -73,7 +73,6 @@ class DirectPosterior(NeuralPosterior):
 
         self.prior = prior
         self.posterior_estimator = posterior_estimator
-        self._accept_reject_fn = lambda theta: within_support(self.prior, theta)
 
         self.max_sampling_batch_size = max_sampling_batch_size
         self._leakage_density_correction_factor = None
@@ -117,7 +116,7 @@ class DirectPosterior(NeuralPosterior):
 
         samples = accept_reject_sample(
             proposal=self.posterior_estimator,
-            accept_reject_fn=self._accept_reject_fn,
+            accept_reject_fn=lambda theta: within_support(self.prior, theta),
             num_samples=num_samples,
             show_progress_bars=show_progress_bars,
             max_sampling_batch_size=max_sampling_batch_size,
@@ -224,7 +223,7 @@ class DirectPosterior(NeuralPosterior):
 
             return accept_reject_sample(
                 proposal=self.posterior_estimator,
-                accept_reject_fn=self._accept_reject_fn,
+                accept_reject_fn=lambda theta: within_support(self.prior, theta),
                 num_samples=num_rejection_samples,
                 show_progress_bars=show_progress_bars,
                 sample_for_correction_factor=True,

--- a/sbi/inference/posteriors/direct_posterior.py
+++ b/sbi/inference/posteriors/direct_posterior.py
@@ -122,6 +122,7 @@ class DirectPosterior(NeuralPosterior):
             show_progress_bars=show_progress_bars,
             max_sampling_batch_size=max_sampling_batch_size,
             proposal_sampling_kwargs={"context": x},
+            alternative_method="build_posterior(..., sample_with='mcmc')",
         )[0]
         return samples
 

--- a/sbi/samplers/__init__.py
+++ b/sbi/samplers/__init__.py
@@ -1,2 +1,0 @@
-from sbi.samplers.mcmc.slice import Slice
-from sbi.samplers.mcmc.slice_numpy import SliceSampler, SliceSamplerVectorized

--- a/sbi/samplers/importance/sir.py
+++ b/sbi/samplers/importance/sir.py
@@ -23,7 +23,7 @@ def sampling_importance_resampling(
         potential_fn: Potential function $log(p(\theta))$ from which to draw samples.
         proposal: Proposal distribution for SIR.
         num_samples: Number of samples to draw.
-        num_candidate_samples: Number of proposed samples form which only one is
+        num_candidate_samples: Number of proposed samples from which only one is
             selected based on its importance weight.
         max_sampling_batch_size: The batchsize of samples being drawn from the
             proposal at every iteration.

--- a/sbi/utils/__init__.py
+++ b/sbi/utils/__init__.py
@@ -5,7 +5,11 @@ from sbi.utils.get_nn_models import classifier_nn, likelihood_nn, posterior_nn
 from sbi.utils.io import get_data_root, get_log_root, get_project_root
 from sbi.utils.kde import KDEWrapper, get_kde
 from sbi.utils.potentialutils import pyro_potential_wrapper, transformed_potential
-from sbi.utils.restriction_estimator import RestrictedPrior, RestrictionEstimator
+from sbi.utils.restriction_estimator import (
+    RestrictedPrior,
+    RestrictionEstimator,
+    threshold_distribution,
+)
 from sbi.utils.sbiutils import (
     batched_mixture_mv,
     batched_mixture_vmv,

--- a/sbi/utils/__init__.py
+++ b/sbi/utils/__init__.py
@@ -8,7 +8,7 @@ from sbi.utils.potentialutils import pyro_potential_wrapper, transformed_potenti
 from sbi.utils.restriction_estimator import (
     RestrictedPrior,
     RestrictionEstimator,
-    threshold_distribution,
+    get_density_thresholder,
 )
 from sbi.utils.sbiutils import (
     batched_mixture_mv,

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -30,7 +30,7 @@ from sbi.simulators.linear_gaussian import (
     samples_true_posterior_linear_gaussian_uniform_prior,
     true_posterior_linear_gaussian_mvn_prior,
 )
-from sbi.utils import RestrictedPrior, threshold_distribution
+from sbi.utils import RestrictedPrior, get_density_thresholder
 from tests.sbiutils_test import conditional_of_mvn
 from tests.test_utils import (
     check_c2st,
@@ -315,7 +315,7 @@ def test_c2st_multi_round_snpe_on_linearGaussian(method_str: str):
         posterior1 = DirectPosterior(
             prior=prior, posterior_estimator=posterior_estimator
         ).set_default_x(x_o)
-        accept_reject_fn = threshold_distribution(posterior1, quantile=1e-4)
+        accept_reject_fn = get_density_thresholder(posterior1, quantile=1e-4)
         proposal = RestrictedPrior(
             prior, accept_reject_fn, posterior=posterior1, sample_with=sample_method
         )

--- a/tests/save_and_load_test.py
+++ b/tests/save_and_load_test.py
@@ -1,0 +1,43 @@
+import pickle
+
+import pytest
+import torch
+
+from sbi import utils as utils
+from sbi.inference import SNLE, SNPE, SNRE
+
+
+@pytest.mark.parametrize(
+    "inference_method, sampling_method",
+    (
+        (SNPE, "rejection"),
+        (SNLE, "mcmc"),
+        (SNRE, "mcmc"),
+        pytest.param(SNRE, "vi", marks=pytest.mark.xfail),  # bug: see #684
+        (SNRE, "rejection"),
+    ),
+)
+def test_picklability(inference_method, sampling_method: str, tmp_path):
+
+    num_dim = 2
+    prior = utils.BoxUniform(low=-2 * torch.ones(num_dim), high=2 * torch.ones(num_dim))
+    x_o = torch.zeros(1, num_dim)
+
+    theta = prior.sample((500,))
+    x = theta + 1.0 + torch.randn_like(theta) * 0.1
+
+    inference = inference_method(prior=prior)
+    _ = inference.append_simulations(theta, x).train(max_num_epochs=1)
+    posterior = inference.build_posterior(sample_with=sampling_method).set_default_x(
+        x_o
+    )
+
+    with open(f"{tmp_path}/saved_posterior.pickle", "wb") as handle:
+        pickle.dump(posterior, handle)
+    with open(f"{tmp_path}/saved_posterior.pickle", "rb") as handle:
+        _ = pickle.load(handle)
+
+    with open(f"{tmp_path}/saved_inference.pickle", "wb") as handle:
+        pickle.dump(inference, handle)
+    with open(f"{tmp_path}/saved_inference.pickle", "rb") as handle:
+        _ = pickle.load(handle)

--- a/tests/sbc_test.py
+++ b/tests/sbc_test.py
@@ -14,9 +14,10 @@ from sbi.simulators import linear_gaussian
 from sbi.utils import BoxUniform, MultipleIndependent
 
 
+@pytest.mark.parametrize("reduce_fn_str", ("marginals", "posterior_log_prob"))
 @pytest.mark.parametrize("prior", ("boxuniform", "independent"))
 @pytest.mark.parametrize("method", (SNPE, SNLE))
-def test_running_sbc(method, prior, model="mdn"):
+def test_running_sbc(method, prior, reduce_fn_str, model="mdn"):
     """Tests running inference and then SBC and obtaining nltp."""
 
     num_dim = 2
@@ -49,7 +50,15 @@ def test_running_sbc(method, prior, model="mdn"):
     thetas = prior.sample((num_sbc_runs,))
     xs = simulator(thetas)
 
-    run_sbc(thetas, xs, posterior, num_workers=1, num_posterior_samples=10)
+    reduce_fn = "marginals" if reduce_fn_str == "marginals" else posterior.log_prob
+    run_sbc(
+        thetas,
+        xs,
+        posterior,
+        num_workers=1,
+        num_posterior_samples=10,
+        reduce_fns=reduce_fn,
+    )
 
     # Check nltp
     get_nltp(thetas, xs, posterior)

--- a/tutorials/11_sampler_interface.ipynb
+++ b/tutorials/11_sampler_interface.ipynb
@@ -9,8 +9,11 @@
     "Note: this tutorial requires that the user is already familiar with the [flexible interface](https://www.mackelab.org/sbi/tutorial/02_flexible_interface/).\n",
     "\n",
     "`sbi` implements three methods: SNPE, SNLE, and SNRE. When using SNPE, the trained neural network directly approximates the posterior. Thus, sampling from the posterior can be done by sampling from the trained neural network. The neural networks trained in SNLE and SNRE approximate the likelihood(-ratio). Thus, in order to draw samples from the posterior, one has to perform additional sampling steps, e.g. Markov-chain Monte-Carlo (MCMC). In `sbi`, the implemented samplers are:\n",
+    "\n",
     "- Markov-chain Monte-Carlo (MCMC)\n",
+    "\n",
     "- Rejection sampling  \n",
+    "\n",
     "- Variational inference (VI)\n",
     "\n",
     "When using the flexible interface, the sampler as well as its attributes can be set with `sample_with=\"mcmc\"`, `mcmc_method=\"slice_np\"`, and `mcmc_parameters={}`. However, for full flexibility in customizing the sampler, we recommend using the **sampler interface**. This interface is described here. Further details can be found [here](https://github.com/mackelab/sbi/pull/573)."
@@ -213,7 +216,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -227,7 +230,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.11"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/tutorials/13_diagnostics_simulation_based_calibration.ipynb
+++ b/tutorials/13_diagnostics_simulation_based_calibration.ipynb
@@ -862,7 +862,7 @@
    "hash": "2193897e41726b46f35b9de052100742a934a9183b8a000ae8eb69e12e860d83"
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -876,10 +876,10 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.11"
+   "version": "3.9.5"
   },
   "name": "13_diagnosis_sbc.ipynb"
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/tutorials/15_mcmc_diagnostics_with_arviz.ipynb
+++ b/tutorials/15_mcmc_diagnostics_with_arviz.ipynb
@@ -443,7 +443,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.13 ('sbi')",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -457,9 +457,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.9.5"
   },
-  "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
     "hash": "9ef9b53a5ce850816b9705a866e49207a37a04a71269aa157d9f9ab944ea42bf"
@@ -467,5 +466,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/tutorials/16_implemented_methods.ipynb
+++ b/tutorials/16_implemented_methods.ipynb
@@ -1,0 +1,387 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "85a348a5-f139-4cb0-8f82-6ebeabd2c882",
+   "metadata": {},
+   "source": [
+    "# API of implemented methods\n",
+    "\n",
+    "This notebook spells out the API for all algorithms implemented in the `sbi` toolbox:\n",
+    "\n",
+    "- Posterior estimation (SNPE)\n",
+    "\n",
+    "- Likelihood estimation (SNLE)\n",
+    "\n",
+    "- Likelihood-ratio estimation (SNRE)\n",
+    "\n",
+    "- Utilities  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e2d1852-898e-49ed-85ef-888f0abd7e4e",
+   "metadata": {},
+   "source": [
+    "## Posterior estimation (SNPE)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e7559f4-d97b-4bca-8e22-6529c9c92d9c",
+   "metadata": {},
+   "source": [
+    "**Fast ε-free Inference of Simulation Models with Bayesian Conditional Density Estimation**<br> by Papamakarios & Murray (NeurIPS 2016) <br>[[PDF]](https://papers.nips.cc/paper/6084-fast-free-inference-of-simulation-models-with-bayesian-conditional-density-estimation.pdf) [[BibTeX]](https://papers.nips.cc/paper/6084-fast-free-inference-of-simulation-models-with-bayesian-conditional-density-estimation/bibtex)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "080081fb-1558-4756-8a8f-ff065dd1b400",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sbi.inference import SNPE_A\n",
+    "\n",
+    "inference = SNPE_A(prior)\n",
+    "proposal = prior\n",
+    "for _ in range(rounds):\n",
+    "    theta = proposal.sample((num_sims,))\n",
+    "    x = simulator(theta)\n",
+    "    _ = inference.append_simulations(theta, x, proposal=proposal).train()\n",
+    "    posterior = inference.build_posterior().set_default_x(x_o)\n",
+    "    proposal = posterior"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f04c1c6-35b3-4a91-90c5-9fd0377eb8e2",
+   "metadata": {},
+   "source": [
+    "**Automatic posterior transformation for likelihood-free inference**<br>by Greenberg, Nonnenmacher & Macke (ICML 2019) <br>[[PDF]](http://proceedings.mlr.press/v97/greenberg19a/greenberg19a.pdf)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "743eb04f-2cd5-4986-a33b-f2207b9cd5a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sbi.inference import SNPE\n",
+    "\n",
+    "inference = SNPE(prior)\n",
+    "proposal = prior\n",
+    "for _ in range(rounds):\n",
+    "    theta = proposal.sample((num_sims,))\n",
+    "    x = simulator(theta)\n",
+    "    _ = inference.append_simulations(theta, x, proposal=proposal).train()\n",
+    "    posterior = inference.build_posterior().set_default_x(x_o)\n",
+    "    proposal = posterior"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4de2b24-94ce-4cbf-a675-b0c19b5200ca",
+   "metadata": {},
+   "source": [
+    "**Truncated proposals for scalable and hassle-free simulation-based inference** <br> by Deistler, Goncalves & Macke (NeurIPS 2022) <br>[[Paper]](https://arxiv.org/abs/2210.04815)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ae54b1a9-c3a6-4ee9-b687-bf8c046023c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sbi.inference import SNPE\n",
+    "from sbi.utils import get_density_thresholder, RestrictedPrior\n",
+    "\n",
+    "inference = SNPE(prior)\n",
+    "proposal = prior\n",
+    "for _ in range(rounds):\n",
+    "    theta = proposal.sample((num_sims,))\n",
+    "    x = simulator(theta)\n",
+    "    _ = inference.append_simulations(theta, x).train(force_first_round_loss=True)\n",
+    "    posterior = inference.build_posterior().set_default_x(x_o)\n",
+    "\n",
+    "    accept_reject_fn = get_density_thresholder(posterior, quantile=1e-4)\n",
+    "    proposal = RestrictedPrior(prior, accept_reject_fn, sample_with=\"rejection\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d13f84e2-d35a-4f54-8cbf-0e4be1a38fb3",
+   "metadata": {},
+   "source": [
+    "## Likelihood estimation (SNLE)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89a5783d-1b46-47f8-800b-3cda038ea447",
+   "metadata": {},
+   "source": [
+    "**Sequential neural likelihood: Fast likelihood-free inference with autoregressive flows**<br>by Papamakarios, Sterratt & Murray (AISTATS 2019) <br>[[PDF]](http://proceedings.mlr.press/v89/papamakarios19a/papamakarios19a.pdf) [[BibTeX]](https://gpapamak.github.io/bibtex/snl.bib)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4430dbe-ac60-4978-9695-d0a5b317ee57",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sbi.inference import SNLE\n",
+    "\n",
+    "inference = SNLE(prior)\n",
+    "proposal = prior\n",
+    "for _ in range(rounds):\n",
+    "    theta = proposal.sample((num_sims,))\n",
+    "    x = simulator(theta)\n",
+    "    _ = inference.append_simulations(theta, x).train()\n",
+    "    posterior = inference.build_posterior().set_default_x(x_o)\n",
+    "    proposal = posterior"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16d22866-e095-4f4e-bcef-40bc196a8703",
+   "metadata": {},
+   "source": [
+    "**Variational methods for simulation-based inference** <br> by Glöckler, Deistler, Macke (ICLR 2022) <br>[[Paper]](https://arxiv.org/abs/2203.04176)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d284d6c5-e6f6-4b1d-9c15-d6fa1736a10e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sbi.inference import SNLE\n",
+    "\n",
+    "inference = SNLE(prior)\n",
+    "proposal = prior\n",
+    "for _ in range(rounds):\n",
+    "    theta = proposal.sample((num_sims,))\n",
+    "    x = simulator(theta)\n",
+    "    _ = inference.append_simulations(theta, x).train()\n",
+    "    posterior = inference.build_posterior(sample_with=\"vi\", vi_method=\"fKL\").set_default_x(x_o)\n",
+    "    proposal = posterior"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1ca3f25-c7d2-4688-b5c0-f50864d650ba",
+   "metadata": {},
+   "source": [
+    "**Flexible and efficient simulation-based inference for models of decision-making** <br> by Boelts, Lueckmann, Gao, Macke (Elife 2022) <br>[[Paper]](https://elifesciences.org/articles/77220)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e6d6d8f-8718-44cd-bdf7-a4af2887fc14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sbi.inference import MNLE\n",
+    "\n",
+    "inference = MNLE(prior)\n",
+    "theta = prior.sample((num_sims,))\n",
+    "x = simulator(theta)\n",
+    "_ = inference.append_simulations(theta, x).train()\n",
+    "posterior = inference.build_posterior().set_default_x(x_o)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d81ff49e-f363-43c0-ba16-3ee6a697be5e",
+   "metadata": {},
+   "source": [
+    "## Likelihood-ratio estimation (SNRE)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0823041a-b3f7-4cd3-8a48-497450f622ea",
+   "metadata": {},
+   "source": [
+    "**Likelihood-free MCMC with Amortized Approximate Likelihood Ratios**<br>by Hermans, Begy & Louppe (ICML 2020) <br>[[PDF]](http://proceedings.mlr.press/v119/hermans20a/hermans20a.pdf)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b58c3609-7bd7-40ce-a154-f72a190da2ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sbi.inference import SNRE_A\n",
+    "\n",
+    "inference = SNRE_A(prior)\n",
+    "theta = prior.sample((num_sims,))\n",
+    "x = simulator(theta)\n",
+    "_ = inference.append_simulations(theta, x).train()\n",
+    "posterior = inference.build_posterior().set_default_x(x_o)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42b12584-63cd-47d4-93d2-430d407e1e0b",
+   "metadata": {},
+   "source": [
+    "**On Contrastive Learning for Likelihood-free Inference**<br>Durkan, Murray & Papamakarios (ICML 2020) <br>[[PDF]](http://proceedings.mlr.press/v119/durkan20a/durkan20a.pdf)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e36ab4e7-713f-4ff2-b467-8b481a149861",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sbi.inference import SNRE\n",
+    "\n",
+    "inference = SNRE(prior)\n",
+    "proposal = prior\n",
+    "for _ in range(rounds):\n",
+    "    theta = proposal.sample((num_sims,))\n",
+    "    x = simulator(theta)\n",
+    "    _ = inference.append_simulations(theta, x).train()\n",
+    "    posterior = inference.build_posterior().set_default_x(x_o)\n",
+    "    proposal = posterior"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6271d3b2-1d64-45b8-93b7-b640ab7dafc5",
+   "metadata": {},
+   "source": [
+    "## Utilities"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07414c0c-f8b5-45bd-9597-0eaf19d50a13",
+   "metadata": {},
+   "source": [
+    "**Simulation-based calibration**<br>by Talts, Betancourt, Simpson, Vehtari, Gelman (arxiv 2018) <br>[[Paper]](https://arxiv.org/abs/1804.06788))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7066ef9b-0e3d-44d3-a80e-5e06de7845ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sbi.analysis import run_sbc, sbc_rank_plot\n",
+    "\n",
+    "thetas = prior.sample((1_000,))\n",
+    "xs = simulator(thetas)\n",
+    "\n",
+    "ranks, dap_samples = run_sbc(\n",
+    "    thetas, xs, posterior, num_posterior_samples=1_000\n",
+    ")\n",
+    "\n",
+    "_ = sbc_rank_plot(\n",
+    "    ranks=ranks,\n",
+    "    num_posterior_samples=num_posterior_samples,\n",
+    "    plot_type=\"hist\",\n",
+    "    num_bins=None,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f1c75d9-4139-45ba-ad60-49d8ce8ec2ec",
+   "metadata": {},
+   "source": [
+    "**Restriction estimator**<br>by Deistler, Macke & Goncalves (PNAS 2022) <br>[[Paper]](https://www.pnas.org/doi/10.1073/pnas.2207632119)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bdb39216-d0f0-41f6-a065-579d309ee1eb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sbi.inference import SNPE\n",
+    "from sbi.utils import RestrictionEstimator\n",
+    "\n",
+    "restriction_estimator = RestrictionEstimator(prior=prior)\n",
+    "proposal = prior\n",
+    "\n",
+    "for _ in range(num_rounds):\n",
+    "    theta = proposal.sample((num_sims,))\n",
+    "    x = simulator(theta)\n",
+    "    restriction_estimator.append_simulations(theta, x)\n",
+    "    classifier = restriction_estimator.train()\n",
+    "    proposal = restriction_estimator.restrict_prior()\n",
+    "\n",
+    "all_theta, all_x, _ = restriction_estimator.get_simulations()\n",
+    "\n",
+    "inference = SNPE(prior)\n",
+    "density_estimator = inference.append_simulations(all_theta, all_x).train()\n",
+    "posterior = inference.build_posterior()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "48853668-7b6f-4cfd-9d93-7d62f0e77de8",
+   "metadata": {},
+   "source": [
+    "**Expected coverage (sample-based)**<br>as computed in Deistler, Goncalves, Macke (Neurips 2022) [[Paper]](https://arxiv.org/abs/2210.04815) and in Rozet, Louppe (2021) [[Paper]](https://matheo.uliege.be/handle/2268.2/12993)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60e3d581-8a7f-4133-8756-9750f0174c88",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sbi.analysis import run_sbc, sbc_rank_plot\n",
+    "\n",
+    "thetas = prior.sample((1_000,))\n",
+    "xs = simulator(thetas)\n",
+    "\n",
+    "ranks, dap_samples = run_sbc(\n",
+    "    thetas, xs, posterior, num_posterior_samples=1_000, reduce_fns=posterior.log_prob\n",
+    ")\n",
+    "\n",
+    "_ = sbc_rank_plot(\n",
+    "    ranks=ranks,\n",
+    "    num_posterior_samples=num_posterior_samples,\n",
+    "    plot_type=\"hist\",\n",
+    "    num_bins=None,\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
### Contributions of this PR
- [x] Implement truncation for SNPE
- [x] Coverage diagnostic
- [x] Tutorial on all implemented methods in the toolbox
- [x] Documetion
- [x] Minor fixup to one of the FAQ
- [x] Tests for picklability

### Changes to the code-base
Renamed `rejection_sample_posterior_within_prior` to `accept_reject_sample` since it is more general than to sample the posterior within the prior.

### API
```python
from sbi.inference import SNPE
from sbi.utils import get_density_thresholder, RestrictedPrior

inference = SNPE()
_ = inference.append_simulations(theta, x).train()
posterior = inference.build_posterior()

accept_reject_fn = get_density_thresholder(posterior, quantile=1e-4)
proposal = RestrictedPrior(prior, accept_reject_fn, sample_with="rejection")
```

```python
from sbi.analysis import run_sbc
ranks, dap_samples = run_sbc(theta, x, reduce_fns=posterior.log_prob)
```