### PR TITLE
expose enable_transform for all methods.

### DIFF
--- a/sbi/inference/posteriors/direct_posterior.py
+++ b/sbi/inference/posteriors/direct_posterior.py
@@ -290,7 +290,7 @@ class DirectPosterior(NeuralPosterior):
                 `map`-attribute, and printed every `save_best_every`-th iteration.
                 Computing the best log-probability creates a significant overhead
                 (thus, the default is `10`.)
-            show_progress_bars: Whether to show a progressbar for sampling from the
+            show_progress_bars: Whether to show a progressbar during sampling from the
                 posterior.
             force_update: Whether to re-calculate the MAP when x is unchanged and
                 have a cached value.

--- a/sbi/inference/posteriors/importance_posterior.py
+++ b/sbi/inference/posteriors/importance_posterior.py
@@ -304,8 +304,8 @@ class ImportanceSamplingPosterior(NeuralPosterior):
                 `map`-attribute, and printed every `save_best_every`-th iteration.
                 Computing the best log-probability creates a significant overhead
                 (thus, the default is `10`.)
-            show_progress_bars: Whether or not to show a progressbar for sampling from
-                the posterior.
+            show_progress_bars: Whether to show a progressbar during sampling from the
+                posterior.
             force_update: Whether to re-calculate the MAP when x is unchanged and
                 have a cached value.
             log_prob_kwargs: Will be empty for SNLE and SNRE. Will contain

--- a/sbi/inference/posteriors/mcmc_posterior.py
+++ b/sbi/inference/posteriors/mcmc_posterior.py
@@ -625,7 +625,7 @@ class MCMCPosterior(NeuralPosterior):
                 `map`-attribute, and printed every `save_best_every`-th iteration.
                 Computing the best log-probability creates a significant overhead
                 (thus, the default is `10`.)
-            show_progress_bars: Whether or not to show a progressbar for sampling from
+            show_progress_bars: Whether to show a progressbar during sampling from
                 the posterior.
             force_update: Whether to re-calculate the MAP when x is unchanged and
                 have a cached value.

--- a/sbi/inference/posteriors/rejection_posterior.py
+++ b/sbi/inference/posteriors/rejection_posterior.py
@@ -207,7 +207,7 @@ class RejectionPosterior(NeuralPosterior):
                 `map`-attribute, and printed every `save_best_every`-th iteration.
                 Computing the best log-probability creates a significant overhead
                 (thus, the default is `10`.)
-            show_progress_bars: Whether or not to show a progressbar for sampling from
+            show_progress_bars: Whether to show a progressbar during sampling from
                 the posterior.
             force_update: Whether to re-calculate the MAP when x is unchanged and
                 have a cached value.

--- a/sbi/inference/posteriors/vi_posterior.py
+++ b/sbi/inference/posteriors/vi_posterior.py
@@ -538,7 +538,7 @@ class VIPosterior(NeuralPosterior):
                 `map`-attribute, and printed every `save_best_every`-th iteration.
                 Computing the best log-probability creates a significant overhead
                 (thus, the default is `10`.)
-            show_progress_bars: Whether or not to show a progressbar for sampling from
+            show_progress_bars: Whether to show a progressbar during sampling from
                 the posterior.
             force_update: Whether to re-calculate the MAP when x is unchanged and
                 have a cached value.

--- a/sbi/inference/potentials/likelihood_based_potential.py
+++ b/sbi/inference/potentials/likelihood_based_potential.py
@@ -30,7 +30,7 @@ def likelihood_estimator_based_potential(
         likelihood_estimator: The neural network modelling the likelihood.
         prior: The prior distribution.
         x_o: The observed data at which to evaluate the likelihood.
-        enable_transform: Whether or not to transform parameters to unconstrained space.
+        enable_transform: Whether to transform parameters to unconstrained space.
 
     Returns:
         The potential function $p(x_o|\theta)p(\theta)$ and a transformation that maps

--- a/sbi/inference/potentials/likelihood_based_potential.py
+++ b/sbi/inference/potentials/likelihood_based_potential.py
@@ -19,6 +19,7 @@ def likelihood_estimator_based_potential(
     likelihood_estimator: nn.Module,
     prior: Distribution,
     x_o: Optional[Tensor],
+    enable_transform: bool = True,
 ) -> Tuple[Callable, TorchTransform]:
     r"""Returns potential $\log(p(x_o|\theta)p(\theta))$ for likelihood-based methods.
 
@@ -29,6 +30,7 @@ def likelihood_estimator_based_potential(
         likelihood_estimator: The neural network modelling the likelihood.
         prior: The prior distribution.
         x_o: The observed data at which to evaluate the likelihood.
+        enable_transform: Whether or not to transform parameters to unconstrained space.
 
     Returns:
         The potential function $p(x_o|\theta)p(\theta)$ and a transformation that maps
@@ -40,7 +42,9 @@ def likelihood_estimator_based_potential(
     potential_fn = LikelihoodBasedPotential(
         likelihood_estimator, prior, x_o, device=device
     )
-    theta_transform = mcmc_transform(prior, device=device)
+    theta_transform = mcmc_transform(
+        prior, device=device, enable_transform=enable_transform
+    )
 
     return potential_fn, theta_transform
 

--- a/sbi/inference/potentials/posterior_based_potential.py
+++ b/sbi/inference/potentials/posterior_based_potential.py
@@ -4,7 +4,6 @@
 from typing import Callable, Optional, Tuple
 
 import torch
-import torch.distributions.transforms as torch_tf
 from pyknos.nflows import flows
 from torch import Tensor, nn
 from torch.distributions import Distribution
@@ -20,7 +19,7 @@ def posterior_estimator_based_potential(
     posterior_estimator: nn.Module,
     prior: Distribution,
     x_o: Optional[Tensor],
-    theta_transform: Optional[TorchTransform] = None,
+    enable_transform: bool = True,
 ) -> Tuple[Callable, TorchTransform]:
     r"""Returns the potential for posterior-based methods.
 
@@ -34,11 +33,7 @@ def posterior_estimator_based_potential(
         posterior_estimator: The neural network modelling the posterior.
         prior: The prior distribution.
         x_o: The observed data at which to evaluate the posterior.
-        theta_transform: Transform to map the parameters to an
-            unconstrained space. If None (default), a suitable transform is
-            built from the prior support. In order to not use a transform at all,
-            pass an identity transform, e.g., `theta_transform=torch.distrbutions.
-            transforms`.
+        enable_transform: Whether or not to transform parameters to unconstrained space.
 
     Returns:
         The potential function and a transformation that maps
@@ -51,8 +46,9 @@ def posterior_estimator_based_potential(
         posterior_estimator, prior, x_o, device=device
     )
 
-    if theta_transform is None:
-        theta_transform = mcmc_transform(prior, device=device)
+    theta_transform = mcmc_transform(
+        prior, device=device, enable_transform=enable_transform
+    )
 
     return potential_fn, theta_transform
 

--- a/sbi/inference/potentials/posterior_based_potential.py
+++ b/sbi/inference/potentials/posterior_based_potential.py
@@ -33,7 +33,7 @@ def posterior_estimator_based_potential(
         posterior_estimator: The neural network modelling the posterior.
         prior: The prior distribution.
         x_o: The observed data at which to evaluate the posterior.
-        enable_transform: Whether or not to transform parameters to unconstrained space.
+        enable_transform: Whether to transform parameters to unconstrained space.
 
     Returns:
         The potential function and a transformation that maps

--- a/sbi/inference/potentials/ratio_based_potential.py
+++ b/sbi/inference/potentials/ratio_based_potential.py
@@ -29,7 +29,7 @@ def ratio_estimator_based_potential(
         ratio_estimator: The neural network modelling likelihood-to-evidence ratio.
         prior: The prior distribution.
         x_o: The observed data at which to evaluate the likelihood-to-evidence ratio.
-        enable_transform: Whether or not to transform parameters to unconstrained space.
+        enable_transform: Whether to transform parameters to unconstrained space.
 
     Returns:
         The potential function and a transformation that maps

--- a/sbi/inference/potentials/ratio_based_potential.py
+++ b/sbi/inference/potentials/ratio_based_potential.py
@@ -18,6 +18,7 @@ def ratio_estimator_based_potential(
     ratio_estimator: nn.Module,
     prior: Distribution,
     x_o: Optional[Tensor],
+    enable_transform: bool = True,
 ) -> Tuple[Callable, TorchTransform]:
     r"""Returns the potential for ratio-based methods.
 
@@ -28,6 +29,7 @@ def ratio_estimator_based_potential(
         ratio_estimator: The neural network modelling likelihood-to-evidence ratio.
         prior: The prior distribution.
         x_o: The observed data at which to evaluate the likelihood-to-evidence ratio.
+        enable_transform: Whether or not to transform parameters to unconstrained space.
 
     Returns:
         The potential function and a transformation that maps
@@ -37,7 +39,9 @@ def ratio_estimator_based_potential(
     device = str(next(ratio_estimator.parameters()).device)
 
     potential_fn = RatioBasedPotential(ratio_estimator, prior, x_o, device=device)
-    theta_transform = mcmc_transform(prior, device=device)
+    theta_transform = mcmc_transform(
+        prior, device=device, enable_transform=enable_transform
+    )
 
     return potential_fn, theta_transform
 

--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -341,7 +341,9 @@ class LikelihoodEstimator(NeuralInference, ABC):
             device = next(density_estimator.parameters()).device.type
 
         potential_fn, theta_transform = likelihood_estimator_based_potential(
-            likelihood_estimator=likelihood_estimator, prior=prior, x_o=None
+            likelihood_estimator=likelihood_estimator,
+            prior=prior,
+            x_o=None,
         )
 
         if sample_with == "mcmc":

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -465,7 +465,9 @@ class PosteriorEstimator(NeuralInference, ABC):
             device = next(density_estimator.parameters()).device.type
 
         potential_fn, theta_transform = posterior_estimator_based_potential(
-            posterior_estimator=posterior_estimator, prior=prior, x_o=None
+            posterior_estimator=posterior_estimator,
+            prior=prior,
+            x_o=None,
         )
 
         if sample_with == "rejection":

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -374,7 +374,9 @@ class RatioEstimator(NeuralInference, ABC):
             device = next(density_estimator.parameters()).device.type
 
         potential_fn, theta_transform = ratio_estimator_based_potential(
-            ratio_estimator=ratio_estimator, prior=prior, x_o=None
+            ratio_estimator=ratio_estimator,
+            prior=prior,
+            x_o=None,
         )
 
         if sample_with == "mcmc":

--- a/sbi/samplers/importance/sir.py
+++ b/sbi/samplers/importance/sir.py
@@ -27,7 +27,7 @@ def sampling_importance_resampling(
             selected based on its importance weight.
         max_sampling_batch_size: The batchsize of samples being drawn from the
             proposal at every iteration.
-        show_progress_bars: Whether or not to show a progress bar.
+        show_progress_bars: Whether to show a progress bar.
         device: Device on which to sample.
 
     Returns:

--- a/sbi/utils/posterior_ensemble.py
+++ b/sbi/utils/posterior_ensemble.py
@@ -314,7 +314,7 @@ class NeuralPosteriorEnsemble(NeuralPosterior):
                 `map`-attribute, and printed every `save_best_every`-th iteration.
                 Computing the best log-probability creates a significant overhead
                 (thus, the default is `10`.)
-            show_progress_bars: Whether or not to show a progressbar for sampling from
+            show_progress_bars: Whether to show a progressbar during sampling from
                 the posterior.
             individually: If true, returns log weights and MAPs individually.
 

--- a/sbi/utils/potentialutils.py
+++ b/sbi/utils/potentialutils.py
@@ -25,7 +25,7 @@ def transformed_potential(
         potential_fn: Potential function.
         theta_transform: Transformation applied before evaluating the `potential_fn`
         device: The device to which to move the parameters before evaluation.
-        track_gradients: Whether or not to track the gradients of the `potential_fn`
+        track_gradients: Whether to track the gradients of the `potential_fn`
             evaluation.
     """
 

--- a/sbi/utils/restriction_estimator.py
+++ b/sbi/utils/restriction_estimator.py
@@ -566,7 +566,7 @@ class RestrictedPrior:
 
         Args:
             sample_shape: Shape of the returned samples.
-            show_progress_bars: Whether or not to show a progressbar during sampling.
+            show_progress_bars: Whether to show a progressbar during sampling.
             max_sampling_batch_size: Batch size for drawing samples from the posterior.
                 Takes effect only in the second iteration of the loop below, i.e., in
                 case of leakage or `num_samples>max_sampling_batch_size`. Larger batch
@@ -757,7 +757,7 @@ class RestrictedPrior:
             reweigh_factor: Post-hoc correction factor. Should be in [0, 1]. A large
                 reweigh factor will increase the probability of predicting a `invalid`
                 simulation.
-            print_fp_rate: Whether or not to compute and print the false-positive rate
+            print_fp_rate: Whether to compute and print the false-positive rate
                 at the obtained threshold.
             safety_margin: When `allowed_false_negatives=0.0`, we might want to apply
                 an additional `safety_margin` to the threshold. If `None`, there will

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -575,7 +575,7 @@ def mcmc_transform(
             to infer the `mean` and `stddev` of the prior used for z-scoring. Unused if
             the prior has bounded support or when the prior has `mean` and `stddev`
             attributes.
-        enable_transform: Whether or not to use a transformation during MCMC.
+        enable_transform: Whether or not to transform parameters to unconstrained space.
 
     Returns: A transformation that transforms whose `forward()` maps from unconstrained
         (or z-scored) to constrained (or non-z-scored) space.

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -575,7 +575,7 @@ def mcmc_transform(
             to infer the `mean` and `stddev` of the prior used for z-scoring. Unused if
             the prior has bounded support or when the prior has `mean` and `stddev`
             attributes.
-        enable_transform: Whether or not to transform parameters to unconstrained space.
+        enable_transform: Whether to transform parameters to unconstrained space.
 
     Returns: A transformation that transforms whose `forward()` maps from unconstrained
         (or z-scored) to constrained (or non-z-scored) space.
@@ -775,7 +775,7 @@ def gradient_ascent(
             `map`-attribute, and printed every `save_best_every`-th iteration.
             Computing the best log-probability creates a significant overhead (thus,
             the default is `10`.)
-        show_progress_bars: Whether or not to show a progressbar for the optimization.
+        show_progress_bars: Whether to show a progressbar for the optimization.
         interruption_note: The message printed when the user interrupts the
             optimization.
 


### PR DESCRIPTION
the current API does not allow to **not** perform sampling in unconstrained space. 
In scenarios where one has already transformed parameters to unconstrained space, one workaround is to manually build potential functions and pass them to the posterior object. 

But it would be nice to enable this for `build_posterior` as well, as it offers more flexibility to switch between sampling methods etc. 

This PR exposes the `enable_transform` argument from `mcmc_transform` at the top level to allow this for all methods. 
Note: To keep things parallel for all three methods, this PR reverts #714, which enabled custom transforms for `NPE`. 