### PR TITLE
improve error handling for custom priors.

### DIFF
--- a/sbi/utils/user_input_checks_utils.py
+++ b/sbi/utils/user_input_checks_utils.py
@@ -266,11 +266,13 @@ class MultipleIndependent(Distribution):
         """Check type and shape of a single input distribution."""
 
         assert not isinstance(
-            dist, MultipleIndependent
+            dist, (MultipleIndependent, Sequence)
         ), "Nesting of combined distributions is not possible."
         assert isinstance(
             dist, Distribution
-        ), "Distribution must be a PyTorch distribution."
+        ), """priors passed to MultipleIndependent must be PyTorch distributions. Make
+            sure to process custom priors individually using process_prior before
+            passing them in a list to process_prior."""
         # Make sure batch shape is smaller or equal to 1.
         assert dist.batch_shape in (
             torch.Size([1]),

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -161,6 +161,17 @@ def test_reinterpreted_batch_dim_prior():
         UserNumpyUniform(zeros(3), ones(3), return_numpy=False),
         UserNumpyUniform(zeros(3), ones(3), return_numpy=True),
         BoxUniform(zeros(3, dtype=torch.float64), ones(3, dtype=torch.float64)),
+        [
+            Uniform(zeros(1), ones(1)),
+            Uniform(zeros(1), ones(1)),
+        ],  # multiple independent prior
+        pytest.param(
+            [
+                UserNumpyUniform(zeros(3), ones(3), return_numpy=True),
+                Uniform(zeros(1), ones(1)),
+            ],  # combination multiple independent and custom prior
+            marks=pytest.mark.xfail,
+        ),
     ),
 )
 def test_process_prior(prior):


### PR DESCRIPTION
see #774 

improves error messages. does not apply `process_prior` recursively on a passed list of custom priors to avoid circular imports. 