### PR TITLE
update the device for is_valid_x

### DIFF
--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -143,6 +143,13 @@ class PosteriorEstimator(NeuralInference, ABC):
             else:
                 exclude_invalid_x = False
 
+        if data_device is None:
+            data_device = self._device
+
+        theta, x = validate_theta_and_x(
+            theta, x, data_device=data_device, training_device=self._device
+        )
+
         is_valid_x, num_nans, num_infs = handle_invalid_x(
             x, exclude_invalid_x=exclude_invalid_x
         )
@@ -165,12 +172,6 @@ class PosteriorEstimator(NeuralInference, ABC):
                 num_nans, num_infs, exclude_invalid_x, "Single-round NPE"
             )
 
-        if data_device is None:
-            data_device = self._device
-
-        theta, x = validate_theta_and_x(
-            theta, x, data_device=data_device, training_device=self._device
-        )
         self._check_proposal(proposal)
 
         self._data_round_index.append(current_round)


### PR DESCRIPTION
This PR should address issues in the tests mentioned in #788. The `is_valid_x` index will be (maybe) copied to the correct device for `x` and `theta` before indexing. Thereby a runtime error is avoided.