### PR TITLE
upgrade to codecov v3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
         pytest -m "not slow and not gpu" tests/ --cov=sbi --cov-report=xml
       
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         file: ./coverage.xml
         flags: unittests


### PR DESCRIPTION
codecov v1 is deprecated, see codecov: https://github.com/codecov/codecov-action#%EF%B8%8F--deprecation-of-v1