### PR TITLE
Patched a potential segfault when appending simulations

### DIFF
--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -34,7 +34,18 @@ def warn_if_zscoring_changes_data(x: Tensor, duplicate_tolerance: float = 0.1) -
     num_unique = torch.unique(x, dim=0).numel()
 
     # z-score.
-    zx = (x - x.mean(0)) / x.std(0)
+    xstd = x.std(0)
+    if (xstd==0).any():
+        warnings.warn(
+            """Variance along batches is 0. Therefore, Z-score could not be computed and will be skipped.
+            Check that data is different along all dimensions.""",
+            UserWarning,
+        )
+        
+        #Skip computation.
+        return
+
+    zx = (x - x.mean(0)) / xstd 
 
     # Count again and warn on too many new duplicates.
     num_unique_z = torch.unique(zx, dim=0).numel()

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -33,34 +33,34 @@ def warn_if_zscoring_changes_data(x: Tensor, duplicate_tolerance: float = 0.1) -
     # Count unique xs.
     num_unique = torch.unique(x, dim=0).numel()
 
-    # z-score.
-    xstd = x.std(0)
-    if (xstd==0).any():
+    # Check we do have different data in the batch
+    if num_unique == 1:
         warnings.warn(
             """Variance along batches is 0. Therefore, Z-score could not be computed and will be skipped.
             Check that data is different along all dimensions.""",
             UserWarning,
         )
-        
-        #Skip computation.
+
+        # Skip computation.
         return
+    else:
+        # z-score.
+        zx = (x - x.mean(0)) / x.std(0)
 
-    zx = (x - x.mean(0)) / xstd 
+        # Count again and warn on too many new duplicates.
+        num_unique_z = torch.unique(zx, dim=0).numel()
 
-    # Count again and warn on too many new duplicates.
-    num_unique_z = torch.unique(zx, dim=0).numel()
-
-    if num_unique_z < num_unique * (1 - duplicate_tolerance):
-        warnings.warn(
-            """Z-scoring these simulation outputs resulted in {num_unique_z} unique
-            datapoints. Before z-scoring, it had been {num_unique}. This can occur due
-            to numerical inaccuracies when the data covers a large range of values.
-            Consider either setting `z_score_x=False` (but beware that this can be
-            problematic for training the NN) or exclude outliers from your dataset.
-            Note: if you have already set `z_score_x=False`, this warning will still be
-            displayed, but you can ignore it.""",
-            UserWarning,
-        )
+        if num_unique_z < num_unique * (1 - duplicate_tolerance):
+            warnings.warn(
+                """Z-scoring these simulation outputs resulted in {num_unique_z} unique
+                datapoints. Before z-scoring, it had been {num_unique}. This can occur due
+                to numerical inaccuracies when the data covers a large range of values.
+                Consider either setting `z_score_x=False` (but beware that this can be
+                problematic for training the NN) or exclude outliers from your dataset.
+                Note: if you have already set `z_score_x=False`, this warning will still be
+                displayed, but you can ignore it.""",
+                UserWarning,
+            )
 
 
 def x_shape_from_simulation(batch_x: Tensor) -> torch.Size:


### PR DESCRIPTION
I had some problems when calling the ``append_simulations` method. In a Jupyter Notebook, it would kill the kernel every time without further notice. In a script, one can see this is due to a segmentation fault. 

After some debugging, I spotted the problem when checking the Z-score of the data. In my case, the result of the simulation was two `vstacked` time series (external input and simulated time series; the tensor shape was `(batch_size, 2, n_data)`). For testing purposes, I was training the SBI only with a single realization of the external input, thus leading to 0 variance among all batches. 

Despite this not being a very common use case, the fact that it kills the Python kernel makes the problem difficult to track for the user: there is no error message and the debugger does not work properly (it will just crash, not going inside the SBI code). Even `print` statements inside the function `append_simulations` would not print out in a notebook, being visible only when used on a script. 

For this reason, I added a small extra check in the code. If this edge case arises, the computation of the Z-score is skipped, and now the user is adequately warned about the problem so it can be fixed when needed. From what I have seen code would run afterwards without problems.