### PR TITLE
add size invariant iid embedding nets, tests.

### DIFF
--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -161,8 +161,6 @@ class NeuralInference(ABC):
         Args:
             starting_round: The earliest round to return samples from (we start counting
                 from zero).
-            exclude_invalid_x: Whether to exclude simulation outputs `x=NaN` or `x=±∞`
-                during training.
             warn_on_invalid: Whether to give out a warning if invalid simulations were
                 found.
 

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -10,7 +10,6 @@ import torch
 from torch import Tensor, nn, ones, optim
 from torch.distributions import Distribution
 from torch.nn.utils.clip_grad import clip_grad_norm_
-from torch.utils import data
 from torch.utils.tensorboard.writer import SummaryWriter
 
 from sbi import utils as utils
@@ -306,6 +305,7 @@ class PosteriorEstimator(NeuralInference, ABC):
             # Get theta,x to initialize NN
             theta, x, _ = self.get_simulations(starting_round=start_idx)
             # Use only training data for building the neural net (z-scoring transforms)
+
             self._neural_net = self._build_neural_net(
                 theta[self.train_indices].to("cpu"),
                 x[self.train_indices].to("cpu"),

--- a/sbi/utils/sbiutils.py
+++ b/sbi/utils/sbiutils.py
@@ -243,6 +243,8 @@ def handle_invalid_x(
     # Squeeze to cover all dimensions in case of multidimensional x.
     x = x.reshape(batch_size, -1)
 
+    # TODO: add option to allow for NaNs in certain dimensions, e.g., to encode varying
+    # numbers of trials.
     x_is_nan = torch.isnan(x).any(dim=1)
     x_is_inf = torch.isinf(x).any(dim=1)
     num_nans = int(x_is_nan.sum().item())

--- a/tests/inference_with_NaN_simulator_test.py
+++ b/tests/inference_with_NaN_simulator_test.py
@@ -22,14 +22,13 @@ from sbi.simulators.linear_gaussian import (
 )
 from sbi.utils import RestrictionEstimator
 from sbi.utils.sbiutils import handle_invalid_x
-from tests.test_utils import check_c2st
+
+from .test_utils import check_c2st
 
 
 @pytest.mark.parametrize(
     "x_shape",
     (
-        torch.Size((1, 1)),
-        torch.Size((1, 10)),
         torch.Size((10, 1)),
         torch.Size((10, 10)),
     ),
@@ -38,6 +37,7 @@ def test_handle_invalid_x(x_shape):
     x = torch.rand(x_shape)
     x[x < 0.1] = float("nan")
     x[x > 0.9] = float("inf")
+    x[-1, :] = 1.0  # make sure there is one row of valid entries.
 
     x_is_valid, *_ = handle_invalid_x(x, exclude_invalid_x=True)
 


### PR DESCRIPTION
goal: have an embedding net for `NPE` that can handle varying number of iid trials, i.e., learn how the posterior changes as we change the number of trials. 

problem: our training procedure assume that `x` is a tensor with fixed dimensions, e.g., the trial dimension must be the same for all training data points. 

solution: given a training data set with a varying number of trials where the maximum number of trials is `max_num_trials`, pad all `x`s with smaller number of trials with `NaN`s such that `x.shape = (num_thetas, max_num_trials, dim_x)`. Adapt the `PermutationInvariantEmbeddingNet` such that it detects the `NaNs` and applies the `TrialEmbedding` only to the valid entries (using a loop over the batch). 

functional tests: seems to work fine for a Gaussian example

Questions: 
- any ideas how to change our training procedure to be more flexible, e.g., allows `x` to be a list? treat `x` a `torch.DataSet` from the very start in `append_simulations`? 