### PR TITLE
pre-commit hook for isort and black.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+    -   repo: https://github.com/asottile/seed-isort-config
+        rev: v2.2.0
+        hooks:
+        - id: seed-isort-config
+    -   repo: https://github.com/pre-commit/mirrors-isort
+        rev: v5.10.1
+        hooks:
+        - id: isort
+    -   repo: https://github.com/ambv/black
+        rev: 23.1.0
+        hooks:
+        - id: black
+          language_version: python3.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,5 +18,5 @@ force_grid_wrap=0
 use_parentheses=True
 skip_glob=.ipynb_checkpoints
 known_first_party=sbi,tests
-known_third_party=matplotlib,numpy,pandas,pytest,pyknos,scipy,setuptools,six,sklearn,torch,tqdm,typeguard,yaml
+known_third_party=arviz,joblib,matplotlib,numpy,pyknos,pyro,pytest,scipy,setuptools,six,sklearn,tensorboard,torch,torchtestcase,tqdm,typing_extensions
 multi_line_output=3

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ EXTRAS = {
         "mkdocstrings[python]>=0.18",
         "nbconvert",
         "pep517",
+        "pre-commit",
         "pytest",
         "pyyaml",
         "pyright",


### PR DESCRIPTION
not sure this will work directly locally. One has to re-install `sbi` to install `pre-commit` and then run `pre-commit install` locally to activate the hook. 

@michaeldeistler does this work fow you? 