### PR TITLE
fix handling of multiple gpus.

### DIFF
--- a/sbi/inference/posteriors/direct_posterior.py
+++ b/sbi/inference/posteriors/direct_posterior.py
@@ -51,8 +51,8 @@ class DirectPosterior(NeuralPosterior):
             x_shape: Shape of a single simulator output. If passed, it is used to check
                 the shape of the observed data and give a descriptive error.
             enable_transform: Whether to transform parameters to unconstrained space
-                during MAP optimization. When False, an identity transform will be returned
-                for `theta_transform`.
+                during MAP optimization. When False, an identity transform will be
+                returned for `theta_transform`.
         """
         # Because `DirectPosterior` does not take the `potential_fn` as input, it
         # builds it itself. The `potential_fn` and `theta_transform` are used only for

--- a/sbi/utils/torchutils.py
+++ b/sbi/utils/torchutils.py
@@ -26,19 +26,26 @@ def process_device(device: str) -> str:
     else:
         warnings.warn(
             "GPU was selected as a device for training the neural network. "
-            "Note that we expect **no** significant speed ups in training for the "
+            "Note that we expect no significant speed ups in training for the "
             "default architectures we provide. Using the GPU will be effective "
             "only for large neural networks with operations that are fast on the "
             "GPU, e.g., for a CNN or RNN `embedding_net`."
         )
-        current_gpu_index = torch.cuda.current_device()
         if device == "cuda":
+            assert torch.cuda.is_available(), "CUDA is not available."
+            current_gpu_index = torch.cuda.current_device()
             return f"cuda:{current_gpu_index}"
         else:
-            assert device == f"cuda:{current_gpu_index}", (
-                f"Unrecognized device {device}, "
-                "should be one of [`cpu`, `cuda`, f`cuda:{index}`]"
-            )
+            # Check if the device is a valid cuda device.
+            try:
+                torch.randn(1, device=device)
+            except RuntimeError:
+                raise RuntimeError(
+                    f"""Could not instantiate torch.randn(1, device={device}). Please
+                    use 'cuda', or cuda:<index> with <index> <
+                    {torch.cuda.device_count()}."""
+                )
+            torch.cuda.set_device(device)
             return device
 
 


### PR DESCRIPTION
Previously, a call with `cuda:index` with `index != torch.cuda.current_device()` (default 0) would result in an assertion error. 
However, there are scenarios in which one wants to use a specific cuda index > 0. This is now possible. 