### PR TITLE
Add citation metadata in machine-parsable formats

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,41 @@
+cff-version: 1.2.0
+message: "Please cite https://doi.org/10.21105/joss.02505 also"
+title: "sbi: Simulation-based inference toolkit"
+authors:
+- family-names: Tejero-Cantero
+  given-names: Alvaro
+  orcid: "http://orcid.org/0000-0002-8768-4227"
+- family-names: Boelts
+  given-names: Jan
+  orcid: "http://orcid.org/0000-0003-4979-7092"
+- family-names: Deistler
+  given-names: Michael
+  orcid: "http://orcid.org/0000-0002-3573-0404"
+- family-names: Lueckmann
+  given-names: Jan-Matthis
+  orcid: "http://orcid.org/0000-0003-4320-4663"
+- family-names: Durkan
+  given-names: Conor
+  orcid: "http://orcid.org/0000-0001-9333-7777"
+- family-names: Gonçalves
+  given-names: Pedro
+  orcid: "http://orcid.org/0000-0002-6987-4836"
+- family-names: Greenberg
+  given-names: David
+  orcid: "http://orcid.org/0000-0002-8515-0459"
+- family-names: Macke
+  given-names: Jakob
+  orcid: "https://orcid.org/0000-0001-5154-8912"
+
+version: 0.21.0
+date-released: "2022-12-22"
+identifiers:
+ - type: "ascl-id"
+   value: "2306.002"
+ - type: "doi"
+   value: 10.21105/joss.02505
+ - type: "bibcode"
+   value: "2023ascl.soft06002T"
+abstract: "Simulation-based inference is the process of finding parameters of a simulator from observations. The PyTorch package sbi performs simulation-based inference by taking a Bayesian approach to return a full posterior distribution over the parameters, conditional on the observations. This posterior can be amortized (<i>i.e.</i> useful for any observation) or focused (<i>i.e.</i>tailored to a particular observation), with different computational trade-offs. The code offers a simple interface for one-line posterior inference."
+license: AGPL-3.0
+repository-code: https://github.com/mackelab/sbi

--- a/codemeta.json
+++ b/codemeta.json
@@ -1,0 +1,73 @@
+{
+    "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
+    "@type": "SoftwareSourceCode",
+    "name": "sbi: Simulation-based inference toolkit",
+    "description": "Simulation-based inference is the process of finding parameters of a simulator from observations. The PyTorch package sbi performs simulation-based inference by taking a Bayesian approach to return a full posterior distribution over the parameters, conditional on the observations. This posterior can be amortized (<i>i.e.</i> useful for any observation) or focused (<i>i.e.</i>tailored to a particular observation), with different computational trade-offs. The code offers a simple interface for one-line posterior inference.",
+    "identifier": "ascl:2306.002",
+    "author": [
+        {
+            "@type": "Person",
+            "givenName": "Alvaro",
+            "familyName": "Tejero-Cantero",
+            "@id": "http://orcid.org/0000-0002-8768-4227"
+        },
+        {
+            "@type": "Person",
+            "givenName": "Jan",
+            "familyName": "Boelts",
+            "@id": "http://orcid.org/0000-0003-4979-7092"
+        },
+        {
+            "@type": "Person",
+            "givenName": "Michael",
+            "familyName": "Deistler",
+            "@id": "http://orcid.org/0000-0002-3573-0404"
+        },
+        {
+            "@type": "Person",
+            "givenName": "Jan-Matthis",
+            "familyName": "Lueckmann",
+            "@id": "http://orcid.org/0000-0003-4320-4663"
+        },
+        {
+            "@type": "Person",
+            "givenName": "Conor",
+            "familyName": "Durkan",
+            "@id": "http://orcid.org/0000-0001-9333-7777"
+        },
+        {
+            "@type": "Person",
+            "givenName": "Pedro",
+            "familyName": "Gonçalves",
+            "@id": "http://orcid.org/0000-0002-6987-4836"
+        },
+        {
+            "@type": "Person",
+            "givenName": "David",
+            "familyName": "Greenberg",
+            "@id": "http://orcid.org/0000-0002-8515-0459"
+        },
+        {
+            "@type": "Person",
+            "givenName": "Jakob",
+            "familyName": "Macke",
+            "https://orcid.org/0000-0001-5154-8912"
+        }
+    ],
+    "citation": "https://doi.org/10.21105/joss.02505",
+    "relatedLink": [
+        "https://www.mackelab.org/sbi/"
+    ],
+    "codeRepository": [
+        "https://github.com/mackelab/sbi/"
+    ],
+    "referencePublication": [
+        {
+            "@type": "ScholarlyArticle",
+            "url": "https://joss.theoj.org/papers/10.21105/joss.02505",
+            "@id": "https://doi.org/10.21105/joss.02505"
+        }
+    ],
+    "version": "0.21.0",
+    "license": "https://spdx.org/licenses/AGPL-3.0-only.html"
+}


### PR DESCRIPTION
This adds two popular citation metadata formats, based on the templates offered by the [Astrophysics Source Code Library](http://ascl.net/), see recent entry added for sbi at https://ascl.net/2306.002 (https://ascl.net/2306.002/CITATION.cff, https://ascl.net/2306.002/codemeta.json).

* https://citation-file-format.github.io/ (used e.g. by the Zotero plugin when bookmarking).
* https://codemeta.github.io/ (with a long list of _crosswalks_ that help other projects map metadata to their own packaging files, e.g. debian packages, wikidata, etc).

These citation files pertain to the software, but they encourage to cite the paper. There are best practices about citing the software directly that result in nuances in these files (e.g. use of 'preferred citation') that I have not investigated.

The paper citations are encouraged to occur not via the ASCL or the JOSS URLs but as advised by ASCL engineer Alice Allen through the DOI resolver URL.

Finally, note that this PR does not deal with CI updates to this metadata (notably concerning version numbers and release dates). See
* https://github.com/caltechlibrary/codemeta2cff to get a GH action to autoupdate the CFF file from the codemeta.json file.
* https://codemeta.github.io/tools/ for more pointers (e.g. automatic generation)
