### PR TITLE
bugfix: BoxUniform device handling.

### DIFF
--- a/tests/inference_on_device_test.py
+++ b/tests/inference_on_device_test.py
@@ -522,3 +522,14 @@ def test_vi_on_gpu(num_dim: int, q: Distribution, vi_method: str, sampling_metho
 
     assert str(samples.device) == device, "The devices after training does not match"
     assert str(logprobs.device) == device, "The devices after training does not match"
+
+
+@pytest.mark.gpu
+@pytest.mark.parametrize("arg_device", ["cpu", "cuda"])
+@pytest.mark.parametrize("device", [None, "cpu", "cuda"])
+def test_BoxUniform_device_handling(arg_device, device):
+    """Test mismatch between device passed via low / high and device kwarg."""
+    prior = BoxUniform(
+        low=zeros(1).to(arg_device), high=ones(1).to(arg_device), device=device
+    )
+    SNPE_C(prior=prior, device=device)


### PR DESCRIPTION
potential fix for #853. 

a) We raise an error if the device passed via low/high does not match the device kward. E.g., if low/high have been moved to GPU already, but `device` is still on default "cpu". 
b) Alternatively, we could automatically use the device passed via low/high as the new device to be less verbose and to follow the user's obvious intention to have the prior on that device. 

For now, I implemented b). what do you think @michaeldeistler? 

