### PR TITLE
Fix SMCABC summary to  save epsilon history correctly.

### DIFF
--- a/sbi/inference/abc/smcabc.py
+++ b/sbi/inference/abc/smcabc.py
@@ -246,8 +246,8 @@ class SMCABC(ABCBASE):
             # collect results
             all_particles.append(particles)
             all_log_weights.append(log_weights)
-            all_distances.append(distances)
-            all_epsilons.append(epsilon)
+            all_distances.append(distances.clone())
+            all_epsilons.append(epsilon.clone())
             all_x.append(x)
 
         # Maybe run LRA and adjust weights.

--- a/sbi/inference/abc/smcabc.py
+++ b/sbi/inference/abc/smcabc.py
@@ -246,7 +246,7 @@ class SMCABC(ABCBASE):
             # collect results
             all_particles.append(particles)
             all_log_weights.append(log_weights)
-            all_distances.append(distances.clone())
+            all_distances.append(distances)
             all_epsilons.append(epsilon.clone())
             all_x.append(x)
 


### PR DESCRIPTION
When passing the option `return_summary=True` to the SMCABC interface, the returned dictionary contains a list of tensors for the `epsilon` values. However, since `epsilon` is modified in place [here](https://github.com/mackelab/sbi/blob/6c4fa7a6fd254d48d0c18640c832f2d80ab2257a/sbi/inference/abc/smcabc.py#L215C19-L215C19), the list just contains views of the last value of `epsilon` rather than the intended history of `epsilon` values. 

A small fix I suggest is to simply clone the tensors before appending them to the history list.