### PR TITLE
Fix spurious seeding by switching to keyword args.

### DIFF
--- a/sbi/inference/base.py
+++ b/sbi/inference/base.py
@@ -459,6 +459,7 @@ def simulate_for_sbi(
     num_simulations: int,
     num_workers: int = 1,
     simulation_batch_size: int = 1,
+    seed: Optional[int] = None,
     show_progress_bar: bool = True,
 ) -> Tuple[Tensor, Tensor]:
     r"""Returns ($\theta, x$) pairs obtained from sampling the proposal and simulating.
@@ -481,6 +482,7 @@ def simulate_for_sbi(
             maps to data x at once. If None, we simulate all parameter sets at the
             same time. If >= 1, the simulator has to process data of shape
             (simulation_batch_size, parameter_dimension).
+        seed: Seed for reproducibility.
         show_progress_bar: Whether to show a progress bar for simulating. This will not
             affect whether there will be a progressbar while drawing samples from the
             proposal.
@@ -491,7 +493,12 @@ def simulate_for_sbi(
     theta = proposal.sample((num_simulations,))
 
     x = simulate_in_batches(
-        simulator, theta, simulation_batch_size, num_workers, show_progress_bar
+        simulator=simulator,
+        theta=theta,
+        sim_batch_size=simulation_batch_size,
+        num_workers=num_workers,
+        seed=seed,
+        show_progress_bars=show_progress_bar,
     )
 
     return theta, x

--- a/tests/linearGaussian_snpe_test.py
+++ b/tests/linearGaussian_snpe_test.py
@@ -59,8 +59,8 @@ def test_c2st_snpe_on_linearGaussian(
     """Test whether SNPE infers well a simple example with available ground truth."""
 
     x_o = zeros(num_trials, num_dim)
-    num_samples = 1000
-    num_simulations = 2600
+    num_samples = 5000
+    num_simulations = 5000
 
     # likelihood_mean will be likelihood_shift+theta
     likelihood_shift = -1.0 * ones(num_dim)


### PR DESCRIPTION
`simulate_for_sbi` calls `simulate_in_batches` with wrong positional arguments: 5afd40b added seed as an extra argument for `simulate_in_batches` which was not reflected at the call site. Thus, `show_progress_bar` (defaulting to True) is erroneously used as the value for seed. This PR proposes to fix the resulting spurious seeding by switching from positional to keyword arguments.